### PR TITLE
Pi 4 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ fbneo.ini
 xcuserdata
 project.xcworkspace
 projectfiles/xcode/build
+nvram

--- a/makefile.pi
+++ b/makefile.pi
@@ -28,6 +28,11 @@ INCLUDE_AVI_RECORDING=
 BUILD_A68K=
 UNICODE=
 RASPBIAN_VER=$(shell cat /etc/os-release | grep VERSION_ID | cut -d '=' -f2)
+PI_VER=$(shell cat /proc/device-tree/model | cut -d ' ' -f 3)
+
+ifeq ($(shell test $(PI_VER) -ge 4; echo $$?),0)
+  BUILD_DRM=1
+endif
 
 #
 #	Specify paths/files

--- a/makefile.pi
+++ b/makefile.pi
@@ -38,13 +38,13 @@ srcdir	= src/
 
 include makefile.burn_rules
 # Platform-specific
-alldir	+= 	burner burner/pi burner/sdl dep/libs/libpng dep/libs/lib7z \
+alldir += burner burner/pi burner/sdl dep/libs/libpng dep/libs/lib7z \
 		dep/libs/zlib intf intf/video intf/video/scalers intf/video/pi \
 		intf/audio intf/audio/sdl intf/input intf/input/pi intf/cd \
 		intf/cd/sdl intf/perfcount intf/perfcount/pi dep/generated \
 		dep/pi/gles
 
-depobj	+= 	neocdlist.o \
+depobj += neocdlist.o \
 		\
 		conc.o cong.o dat.o gamc.o gami.o image.o ioapi.o misc.o \
 		sshot.o state.o statec.o unzip.o zipfn.o \
@@ -66,7 +66,13 @@ depobj	+= 	neocdlist.o \
 		inp_pi.o aud_sdl.o support_paths.o \
 		ips_manager.o scrn.o cd_isowav.o cdsound.o config.o \
 		main_pi.o run_pi.o stringset.o bzip.o drv.o media.o inpdipsw.o \
-		phl_gles.o matrix.o vid_pi.o dynhuff.o replay.o
+		matrix.o vid_pi.o dynhuff.o replay.o
+
+ifdef BUILD_DRM
+  depobj += pigl_drm.o
+else
+  depobj += pigl_dmx.o
+endif
 
 ifdef INCLUDE_7Z_SUPPORT
 	depobj	+= un7z.o 7zArcIn.o 7zBuf.o 7zBuf2.o 7zCrc.o 7zCrcOpt.o \
@@ -77,24 +83,35 @@ endif
 
 autobj += $(depobj)
 
-ifdef	BUILD_X86_ASM
+ifdef BUILD_X86_ASM
 autobj += eagle_fm.o 2xsaimmx.o hq2x32.o hq3x32.o hq4x32.o superscale.o
 endif
 # End platform-specific
 
-incdir	= $(foreach dir,$(alldir),-I$(srcdir)$(dir)) -I$(objdir)dep/generated \
+incdir = $(foreach dir,$(alldir),-I$(srcdir)$(dir)) -I$(objdir)dep/generated \
 		  -I/local/include -I$(srcdir)dep/pi/include -I$(srcdir)intf/input/sdl \
 		  -I/usr/include/SDL \
-		  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux \
+		  -I/opt/vc/include/interface/vcos/pthreads \
 		  -I/opt/vc/include
 
-lib	= -lstdc++ -lSDL -lbcm_host -lpthread -L/usr/X11R6/lib -L/opt/vc/lib
-
-ifeq ($(shell test $(RASPBIAN_VER) -ge 9; echo $$?),0)
-  # Stretch and higher
-  lib += -lbrcmEGL -lbrcmGLESv2
+ifdef BUILD_DRM
+  incdir += -I/usr/include/libdrm
 else
-  lib += -lEGL -lGLESv2
+  incdir += -I/opt/vc/include/interface/vmcs_host/linux
+endif
+
+lib	= -lstdc++ -lSDL -lpthread -L/opt/vc/lib
+
+ifdef BUILD_DRM
+  lib += -lEGL -lGL -ldrm -lgbm
+else
+  lib += -lbcm_host -L/usr/X11R6/lib
+  ifeq ($(shell test $(RASPBIAN_VER) -ge 9; echo $$?),0)
+    # Stretch and higher
+    lib += -lbrcmEGL -lbrcmGLESv2
+  else
+    lib += -lEGL -lGLESv2
+  endif
 endif
 
 autdep	= $(depobj:.o=.d)

--- a/src/burner/pi/main_pi.cpp
+++ b/src/burner/pi/main_pi.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
 	BurnLibInit();
 
 	int driverId = -1;
-	for (int i = 0; i < nBurnDrvCount; i++) {
+	for (int i = 0; i < (int) nBurnDrvCount; i++) {
 		nBurnDrvActive = i;
 		if (strcmp(BurnDrvGetTextA(0), romname) == 0) {
 			driverId = i;
@@ -201,7 +201,11 @@ int main(int argc, char *argv[])
 
 	bCheatsAllowed = false;
 
-	DrvInit(driverId, 0);
+	if (DrvInit(driverId, 0) != 0) {
+		fprintf(stderr, "Driver init failed\n");
+		return 0;
+	}
+
 	parseSwitches(argc, argv);
 	RunMessageLoop();
 

--- a/src/burner/pi/run_pi.cpp
+++ b/src/burner/pi/run_pi.cpp
@@ -193,12 +193,12 @@ int RunMessageLoop()
 
 	RunInit();
 
-	GameInpCheckMouse();															// Hide the cursor
+	GameInpCheckMouse();
 	while (!nExitEmulator) {
 		SDL_Event event;
 		if ( SDL_PollEvent(&event) ) {
 		switch (event.type) {
-			case SDL_QUIT: /* Windows was closed */
+			case SDL_QUIT:
 				nExitEmulator = 1;
 				break;
 			}
@@ -219,6 +219,8 @@ int SaveNVRAM()
 
 	fprintf(stderr, "Writing NVRAM to \"%s\"\n", temp);
 	BurnStateSave(temp, 0);
+
+    return 0;
 }
 
 int ReadNVRAM()
@@ -228,4 +230,6 @@ int ReadNVRAM()
 
 	fprintf(stderr, "Reading NVRAM from \"%s\"\n", temp);
     BurnStateLoad(temp, 0, NULL);
+
+    return 0;
 }

--- a/src/dep/pi/gles/pigl.h
+++ b/src/dep/pi/gles/pigl.h
@@ -1,5 +1,5 @@
 /**
-** Copyright (C) 2015 Akop Karapetyan
+** Copyright (C) 2015-2019 Akop Karapetyan
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@
 ** limitations under the License.
 **/
 
-#ifndef PHL_GLES_H
-#define PHL_GLES_H
+#ifndef PIGL_H
+#define PIGL_H
 
-extern uint32_t phl_gles_screen_width;
-extern uint32_t phl_gles_screen_height;
+extern uint32_t pigl_screen_width;
+extern uint32_t pigl_screen_height;
 
-int phl_gles_init();
-void phl_gles_shutdown();
+int pigl_init();
+void pigl_shutdown();
 
-void phl_gles_swap_buffers();
+void pigl_swap();
 
-#endif // PHL_GLES_H
+#endif // PIGL_H

--- a/src/dep/pi/gles/pigl_dmx.c
+++ b/src/dep/pi/gles/pigl_dmx.c
@@ -1,5 +1,5 @@
 /**
-** Copyright (C) 2015 Akop Karapetyan
+** Copyright (C) 2015-2019 Akop Karapetyan
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #include <GLES2/gl2.h>
 #include <stdio.h>
 
-#include "phl_gles.h"
+#include "pigl.h"
 
 static EGL_DISPMANX_WINDOW_T nativeWindow;
 static EGLDisplay display = EGL_NO_DISPLAY;
@@ -29,10 +29,10 @@ static EGLContext context = EGL_NO_CONTEXT;
 
 static int bcm_host_initted = 0;
 
-uint32_t phl_gles_screen_width = 0;
-uint32_t phl_gles_screen_height = 0;
+uint32_t pigl_screen_width = 0;
+uint32_t pigl_screen_height = 0;
 
-int phl_gles_init()
+int pigl_init()
 {
 	if (!bcm_host_initted) {
 		bcm_host_init();
@@ -43,7 +43,7 @@ int phl_gles_init()
 	display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 	if (display == EGL_NO_DISPLAY) {
 		fprintf(stderr, "eglGetDisplay() failed: EGL_NO_DISPLAY\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
@@ -51,7 +51,7 @@ int phl_gles_init()
 	EGLBoolean result = eglInitialize(display, NULL, NULL);
 	if (result == EGL_FALSE) {
 		fprintf(stderr, "eglInitialize() failed: EGL_FALSE\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
@@ -69,14 +69,14 @@ int phl_gles_init()
 	result = eglChooseConfig(display, attributeList, &config, 1, &numConfig);
 	if (result == EGL_FALSE) {
 		fprintf(stderr, "eglChooseConfig() failed: EGL_FALSE\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
 	result = eglBindAPI(EGL_OPENGL_ES_API);
 	if (result == EGL_FALSE) {
 		fprintf(stderr, "eglBindAPI() failed: EGL_FALSE\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
@@ -88,31 +88,32 @@ int phl_gles_init()
 	context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttributes);
 	if (context == EGL_NO_CONTEXT) {
 		fprintf(stderr, "eglCreateContext() failed: EGL_NO_CONTEXT\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
 	// create an EGL window surface
-	int32_t success = graphics_get_display_size(0, &phl_gles_screen_width, &phl_gles_screen_height);
+	int32_t success = graphics_get_display_size(0, &pigl_screen_width, &pigl_screen_height);
 	if (result < 0) {
 		fprintf(stderr, "graphics_get_display_size() failed: < 0\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
-	fprintf(stderr, "Width/height: %d/%d\n", phl_gles_screen_width, phl_gles_screen_height);
+	fprintf(stderr, "Hardware resolution: %dx%d\n",
+		pigl_screen_width, pigl_screen_height);
 
 	VC_RECT_T dstRect;
 	dstRect.x = 0;
 	dstRect.y = 0;
-	dstRect.width = phl_gles_screen_width;
-	dstRect.height = phl_gles_screen_height;
+	dstRect.width = pigl_screen_width;
+	dstRect.height = pigl_screen_height;
 
 	VC_RECT_T srcRect;
 	srcRect.x = 0;
 	srcRect.y = 0;
-	srcRect.width = phl_gles_screen_width << 16;
-	srcRect.height = phl_gles_screen_height << 16;
+	srcRect.width = pigl_screen_width << 16;
+	srcRect.height = pigl_screen_height << 16;
 
 	DISPMANX_DISPLAY_HANDLE_T dispManDisplay = vc_dispmanx_display_open(0);
 	DISPMANX_UPDATE_HANDLE_T dispmanUpdate = vc_dispmanx_update_start(0);
@@ -121,8 +122,8 @@ int phl_gles_init()
 		DISPMANX_PROTECTION_NONE, NULL, NULL, DISPMANX_NO_ROTATE);
 
 	nativeWindow.element = dispmanElement;
-	nativeWindow.width = phl_gles_screen_width;
-	nativeWindow.height = phl_gles_screen_height;
+	nativeWindow.width = pigl_screen_width;
+	nativeWindow.height = pigl_screen_height;
 	vc_dispmanx_update_submit_sync(dispmanUpdate);
 
 	fprintf(stderr, "Initializing window surface...\n");
@@ -130,7 +131,7 @@ int phl_gles_init()
 	surface = eglCreateWindowSurface(display, config, &nativeWindow, NULL);
 	if (surface == EGL_NO_SURFACE) {
 		fprintf(stderr, "eglCreateWindowSurface() failed: EGL_NO_SURFACE\n");
-		phl_gles_shutdown();
+		pigl_shutdown();
 		return 0;
 	}
 
@@ -146,7 +147,7 @@ int phl_gles_init()
 	return 1;
 }
 
-void phl_gles_shutdown()
+void pigl_shutdown()
 {
 	// Release OpenGL resources
 	if (display != EGL_NO_DISPLAY) {
@@ -169,7 +170,7 @@ void phl_gles_shutdown()
 	}
 }
 
-void phl_gles_swap_buffers()
+void pigl_swap()
 {
 	if (display) {
 		eglSwapBuffers(display, surface);

--- a/src/dep/pi/gles/pigl_drm.c
+++ b/src/dep/pi/gles/pigl_drm.c
@@ -1,0 +1,271 @@
+/**
+** Copyright (C) 2019 Akop Karapetyan
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+** http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+**/
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <gbm.h>
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+#include "pigl.h"
+
+uint32_t pigl_screen_width = 0;
+uint32_t pigl_screen_height = 0;
+
+static int device = -1;
+static uint32_t connector_id;
+static struct gbm_device *gbm_device = NULL;
+static struct gbm_surface *gbm_surface = NULL;
+static EGLContext context = EGL_NO_CONTEXT;
+static EGLDisplay display = EGL_NO_DISPLAY;
+static EGLSurface egl_surface = EGL_NO_SURFACE;
+
+static drmModeModeInfo mode_info;
+static drmModeCrtc *crtc = NULL;
+
+static struct gbm_bo *previous_bo = NULL;
+static uint32_t previous_fb;
+
+static drmModeConnector *find_connector(drmModeRes *resources)
+{
+    int i;
+    for (i = 0; i < resources->count_connectors; i++) {
+        drmModeConnector *connector = drmModeGetConnector(device, resources->connectors[i]);
+        if (connector->connection == DRM_MODE_CONNECTED)
+            return connector;
+        drmModeFreeConnector(connector);
+    }
+
+    return NULL;
+}
+
+static drmModeEncoder *find_encoder (drmModeRes *resources, drmModeConnector *connector)
+{
+    if (connector->encoder_id)
+        return drmModeGetEncoder (device, connector->encoder_id);
+    return NULL;
+}
+
+static int find_display_configuration()
+{
+    drmModeRes *resources = drmModeGetResources(device);
+    if (!resources) {
+        fprintf(stderr, "drmModeGetResources returned NULL\n");
+        return 0;
+    }
+
+    drmModeConnector *connector = find_connector(resources);
+    if (!connector) {
+        fprintf(stderr, "find_connector returned NULL\n");
+        drmModeFreeResources(resources);
+        return 0;
+    }
+
+    // save the connector_id
+    connector_id = connector->connector_id;
+    // save the first mode
+    mode_info = connector->modes[0];
+
+    pigl_screen_width = mode_info.hdisplay;
+    pigl_screen_height = mode_info.vdisplay;
+
+    fprintf(stderr, "Hardware resolution: %dx%d\n",
+        pigl_screen_width, pigl_screen_height);
+
+    // find an encoder
+    drmModeEncoder *encoder = find_encoder(resources, connector);
+    if (!encoder) {
+        fprintf(stderr, "find_encoder returned NULL\n");
+        drmModeFreeConnector(connector);
+        drmModeFreeResources(resources);
+        return 0;
+    }
+
+    // find a CRTC
+    if (encoder->crtc_id)
+        crtc = drmModeGetCrtc(device, encoder->crtc_id);
+
+    drmModeFreeEncoder(encoder);
+    drmModeFreeConnector(connector);
+    drmModeFreeResources(resources);
+
+    return 1;
+}
+
+static int match_config_to_visual(EGLDisplay egl_display,
+    EGLint visual_id, EGLConfig* configs, int count)
+{
+    EGLint id;
+    for (int i = 0; i < count; ++i)
+        if (eglGetConfigAttrib(egl_display, configs[i], EGL_NATIVE_VISUAL_ID, &id)
+            && id == visual_id) return i;
+
+    return -1;
+}
+
+int pigl_init()
+{
+    printf("Initializing DRM video\n");
+
+    device = open("/dev/dri/card1", O_RDWR);
+    if (device == -1) {
+        fprintf(stderr, "Error opening device\n");
+        return 0;
+    }
+
+    if (!find_display_configuration())
+        return 0;
+
+    gbm_device = gbm_create_device(device);
+    gbm_surface = gbm_surface_create(gbm_device,
+        pigl_screen_width, pigl_screen_height,
+        GBM_BO_FORMAT_XRGB8888, GBM_BO_USE_SCANOUT|GBM_BO_USE_RENDERING);
+
+    display = eglGetDisplay(gbm_device);
+    if (display == EGL_NO_DISPLAY) {
+        fprintf(stderr, "eglGetDisplay() failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+
+    if (eglInitialize(display, NULL, NULL) == EGL_FALSE) {
+        fprintf(stderr, "eglInitialize() failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+
+    // create an OpenGL context
+    if (eglBindAPI(EGL_OPENGL_ES_API) == EGL_FALSE) {
+        fprintf(stderr, "eglBindAPI() failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+
+    // get an appropriate EGL frame buffer configuration
+    EGLint count = 0;
+    if (eglGetConfigs(display, NULL, 0, &count) == EGL_FALSE) {
+        fprintf(stderr, "eglGetConfigs() failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+
+    EGLConfig *configs = malloc(count * sizeof *configs);
+    EGLint attributes[] = {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 0,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_NONE };
+    EGLint num_config;
+    if (eglChooseConfig(display, attributes, configs, count, &num_config) == EGL_FALSE) {
+        free(configs);
+        fprintf(stderr, "eglChooseConfig() failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+
+    int config_index = match_config_to_visual(display, GBM_FORMAT_XRGB8888,
+        configs, num_config);
+    if (config_index == -1) {
+        free(configs);
+        fprintf(stderr, "No suitable config match\n");
+        return 0;
+    }
+
+    // create an EGL rendering context
+    EGLConfig *config = configs[config_index];
+    static const EGLint contextAttributes[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE
+    };
+    context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttributes);
+    if (context == EGL_NO_CONTEXT) {
+        free(configs);
+        fprintf(stderr, "eglCreateContext() failed: EGL_NO_CONTEXT\n");
+        return 0;
+    }
+
+    egl_surface = eglCreateWindowSurface(display, config, gbm_surface, NULL);
+    free(configs);
+    if (egl_surface == EGL_NO_SURFACE) {
+        fprintf(stderr, "eglCreateWindowSurface() failed: EGL_NO_SURFACE\n");
+        return 0;
+    }
+
+    if (eglMakeCurrent(display, egl_surface, egl_surface, context) == EGL_FALSE) {
+        fprintf(stderr, "eglMakeCurrent() failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+
+    return 1;
+}
+
+void pigl_shutdown()
+{
+    // set the previous crtc
+    if (crtc != NULL) {
+        drmModeSetCrtc(device, crtc->crtc_id, crtc->buffer_id,
+            crtc->x, crtc->y, &connector_id, 1, &crtc->mode);
+        drmModeFreeCrtc(crtc);
+    }
+
+    if (previous_bo) {
+        drmModeRmFB(device, previous_fb);
+        gbm_surface_release_buffer(gbm_surface, previous_bo);
+    }
+    if (egl_surface != EGL_NO_SURFACE) {
+        eglDestroySurface(display, egl_surface);
+        egl_surface = EGL_NO_SURFACE;
+    }
+    if (gbm_surface) {
+        gbm_surface_destroy(gbm_surface);
+        gbm_surface = NULL;
+    }
+    if (context != EGL_NO_CONTEXT) {
+        eglDestroyContext(display, context);
+        context = EGL_NO_CONTEXT;
+    }
+    if (display != EGL_NO_DISPLAY) {
+        eglTerminate(display);
+        display = EGL_NO_DISPLAY;
+    }
+    if (gbm_device) {
+        gbm_device_destroy(gbm_device);
+        gbm_device = NULL;
+    }
+    if (device != -1) {
+        close(device);
+        device = -1;
+    }
+}
+
+void pigl_swap()
+{
+    eglSwapBuffers(display, egl_surface);
+    struct gbm_bo *bo = gbm_surface_lock_front_buffer(gbm_surface);
+    uint32_t handle = gbm_bo_get_handle(bo).u32;
+    uint32_t pitch = gbm_bo_get_stride(bo);
+    uint32_t fb;
+    drmModeAddFB(device, mode_info.hdisplay, mode_info.vdisplay, 24, 32, pitch, handle, &fb);
+    drmModeSetCrtc(device, crtc->crtc_id, fb, 0, 0, &connector_id, 1, &mode_info);
+
+    if (previous_bo) {
+        drmModeRmFB(device, previous_fb);
+        gbm_surface_release_buffer(gbm_surface, previous_bo);
+    }
+
+    previous_bo = bo;
+    previous_fb = fb;
+}

--- a/src/intf/video/pi/vid_pi.cpp
+++ b/src/intf/video/pi/vid_pi.cpp
@@ -4,8 +4,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <bcm_host.h>
-#include <interface/vchiq_arm/vchiq_if.h>
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 #include <SDL.h>
@@ -14,7 +12,7 @@
 
 extern "C" {
 #include "matrix.h"
-#include "phl_gles.h"
+#include "pigl.h"
 }
 
 typedef	struct ShaderInfo {
@@ -105,12 +103,12 @@ static const GLfloat vertices[] = {
 
 static int piInitVideo()
 {
-	if (!phl_gles_init()) {
+	if (!pigl_init()) {
 		return 0;
 	}
 
-	screen_width = phl_gles_screen_width;
-	screen_height = phl_gles_screen_height - vborder_thickness;
+	screen_width = pigl_screen_width;
+	screen_height = pigl_screen_height - vborder_thickness;
 
 	fprintf(stderr, "Initializing shaders...\n");
 
@@ -161,7 +159,7 @@ static void piDestroyVideo()
 		glDeleteProgram(shader.program);
 	}
 
-	phl_gles_shutdown();
+	pigl_shutdown();
 }
 
 static void piUpdateEmuDisplay()
@@ -172,7 +170,7 @@ static void piUpdateEmuDisplay()
 	}
 
 	glClear(GL_COLOR_BUFFER_BIT);
-	glViewport(0, phl_gles_screen_height - screen_height, screen_width, screen_height);
+	glViewport(0, pigl_screen_height - screen_height, screen_width, screen_height);
 
 	ShaderInfo *sh = &shader;
 
@@ -200,7 +198,7 @@ static void piUpdateEmuDisplay()
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
-	phl_gles_swap_buffers();
+	pigl_swap();
 }
 
 static GLuint createShader(GLenum type, const char *shaderSrc)
@@ -402,7 +400,7 @@ static int FbInit()
 	if (!piInitVideo()) {
 		return 1;
 	}
-	
+
 	int virtualWidth;
 	int virtualHeight;
 	int xAspect;


### PR DESCRIPTION
This PR adds initial support for rendering via DRM, so the emulator should now be playable on the Pi 4. It's likely unoptimized and could use additional tweaking; I'll be chipping away at it as time allows.
It also properly handles driver init errors by propagating them up the initialization chain (#173).
