### PR TITLE
Redumped gulunpa ROM 1

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -6927,7 +6927,7 @@ static struct BurnRomInfo gulunpaRomDesc[] = {
 	{ "26",		0x20000, 0xf30ffa29, BRF_PRG | BRF_ESS | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "30",		0x20000, 0x5d35f737, BRF_PRG | BRF_ESS | CPS1_68K_PROGRAM_BYTESWAP },
 
-	{ "1",		0x80000, 0x3cf0546b, BRF_GRA | CPS1_TILES },
+	{ "1",		0x80000, 0xb55e648f, BRF_GRA | CPS1_TILES },
 	{ "2",		0x80000, 0xad033bce, BRF_GRA | CPS1_TILES },
 	{ "3",		0x80000, 0x36c3951a, BRF_GRA | CPS1_TILES },
 	{ "4",		0x80000, 0xff0cb826, BRF_GRA | CPS1_TILES },


### PR DESCRIPTION
The game is still marked as non working in MAME even with the new dump of the bad gfx rom, although this could simply be an oversight i'll leave it as not working here for the moment.