### PR TITLE
Mamemingw changes

### DIFF
--- a/makefile
+++ b/makefile
@@ -24,6 +24,9 @@ UNICODE = 1
 # Include x86 Assembly routines
 BUILD_X86_ASM = 1
 
+# Include GCC optmisations for your CPU e.g use -march=native. WARNING: This might mean that the generated binaries will not run on other peoples (older) machines!
+#BUILD_NATIVE = 1
+
 # Build for x64 targets (MinGW64 and MSVC only, this will undefine BUILD_A68K and BUILD_X86_ASM)
 #BUILD_X64_EXE = 1
 

--- a/makefile.mamemingw
+++ b/makefile.mamemingw
@@ -95,8 +95,11 @@ ifdef UNICODE
 # lib	= -lunicows
 endif
 
-lib	+=	-luser32 -lgdi32 -lcomdlg32 -lcomctl32 -lshell32 -lwinmm -lshlwapi -ladvapi32 -lsetupapi -lole32 -luuid -lwininet
+lib	+=	-luser32 -lgdi32 -lcomdlg32 -lcomctl32 -lshell32 -lwinmm -lshlwapi -ladvapi32 -lsetupapi -lole32 -luuid -lwininet 
 
+ifdef INCLUDE_AVI_RECORDING
+lib +=	-lvfw32
+endif
 
 depobj	+=	resource.o \
 
@@ -632,8 +635,10 @@ else
 	@echo Making normal build...
 endif
 	@echo
-	@mingw-mkdir -p $(foreach dir, $(alldir),$(objdir)$(dir))
-	@mingw-mkdir -p $(srcdir)dep/generated
+	-@cmd /q /e:on /c for %i in ($(foreach dir,$(alldir),$(subst /,\,$(objdir)$(dir))),) do mkdir %i \>nul 2\>nul
+	-@cmd /q /e:on /c mkdir $(subst /,\,$(srcdir))dep\generated
+
+
 
 cleandep:
 	@echo Removing depend files from $(objdir)...

--- a/makefile.mamemingw
+++ b/makefile.mamemingw
@@ -270,6 +270,12 @@ ifdef BUILD_X86_ASM
 	CXXFLAGS += -mmmx
 endif
 
+ifdef BUILD_NATIVE
+	CFLAGS	 += -march=native -mtune=native
+	CXXFLAGS += -march=native -mtune=native 
+endif
+
+
 # For zlib
 DEF := $(DEF) -DNO_VIZ -D_LARGEFILE64_SOURCE=0 -D_FILE_OFFSET_BITS=32
 

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -379,6 +379,11 @@ ifdef BUILD_X86_ASM
 	CXXFLAGS += -mmmx
 endif
 
+ifdef BUILD_NATIVE
+	CFLAGS	 += -march=native -mtune=native
+	CXXFLAGS += -march=native -mtune=native
+endif
+
 # For zlib
 DEF := $(DEF) -DNO_VIZ -D_LARGEFILE64_SOURCE=0 -D_FILE_OFFSET_BITS=32
 

--- a/makefile.sdl
+++ b/makefile.sdl
@@ -256,6 +256,11 @@ else
 	LDFLAGS	 += -s
 endif
 
+ifdef BUILD_NATIVE
+	CFLAGS	 += -march=native -mtune=native
+	CXXFLAGS += -march=native -mtune=native
+endif
+
 # For zlib
 DEF := $(DEF) -DNO_VIZ -D_LARGEFILE64_SOURCE=0 -D_FILE_OFFSET_BITS=32
 

--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -277,6 +277,11 @@ else
 	LDFLAGS	 += -s
 endif
 
+ifdef BUILD_NATIVE
+	CFLAGS	 += -march=native -mtune=native
+	CXXFLAGS += -march=native -mtune=native
+endif
+
 # For zlib
 DEF := $(DEF) -DNO_VIZ -D_LARGEFILE64_SOURCE=0 -D_FILE_OFFSET_BITS=32
 

--- a/src/burner/win32/inps.cpp
+++ b/src/burner/win32/inps.cpp
@@ -467,7 +467,7 @@ static INT_PTR CALLBACK DialogProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lP
 		if ((HWND)lParam == GetDlgItem(hDlg, IDC_INPS_CONTROL) ||
 			(HWND)lParam == GetDlgItem(hDlg, IDC_INPS_CONTROL_S2))
 		{
-			return (BOOL)hWhiteBGBrush;
+			return (INT_PTR)hWhiteBGBrush;
 		}
 	}
 	return 0;


### PR DESCRIPTION
Are these changes ok? 

Basically I have changed the mamemingw makefile so it doesn't require mingw mkdir, which means FBNeo can now be built with http://www.winlibs.com/ out of the box, which is nice if you want an easy way of using GCC10 for example. I have checked with @JacKc029735 and he very kindly confirmed that this doesn't break his build environment. 

Building with GCC10 threw up a warning in inps.cpp. The change I made seemed like the most sensible fix, and as far as I can tell doesn't break any other build when running it and trying that dialog. I have no done any win32 programming for ages though so it's possible I have made a terrible mistake...

Finally, I added a BUILD_NATIVE flag to all the GCC makefiles, and if this is defined it will build using -march=native -mtune=native. This would be a terrible thing to enable for releases, but is handy if you are building your own binaries as it will try and make GCC enable all the cpu specific optimisations for the machine you are building on, as I know a lot more people are doing that nowadays. 