### PR TITLE
gaplus : Starfield fix and add service mode in DISPW

### DIFF
--- a/src/burn/drv/pre90s/d_gaplus.cpp
+++ b/src/burn/drv/pre90s/d_gaplus.cpp
@@ -335,7 +335,7 @@ static void starfield_init()
 			if (bit1 ^ bit2) generator |= 1;
 
 			if (((~generator >> 16) & 1) && (generator & 0xff) == 0xff) {
-				int color;
+				INT32 color;
 
 				color = (~(generator >> 8)) % 7 + 1;
 				/* A guess based on comparison with PCB video output */
@@ -659,8 +659,8 @@ static void starfield_render()
 		/* Some stars in the second tier will flash erratically while changing their movements. */
 		if (stars[i].set == 1 && starfield_control[2] != 0x85 && i % 2 == 0)
 		{
-			int bit = (starfield_framecount & 4) ? 1 : 2;
-			if (starfield_framecount & bit) { continue; }
+			INT32 bit = ((starfield_framecount + i) & 8) ? 2 : 4;
+			if ((starfield_framecount + i) & bit) { continue; }
 		}
 
 		if (x >= 0 && x < nScreenWidth && y >= 0 && y < nScreenHeight)

--- a/src/burn/drv/pre90s/d_gaplus.cpp
+++ b/src/burn/drv/pre90s/d_gaplus.cpp
@@ -7,6 +7,8 @@
 #include "namcoio.h"
 #include "samples.h"
 
+#define STARFIELD_CLIPPING_X 16
+
 static UINT8 *AllMem;
 static UINT8 *MemEnd;
 static UINT8 *AllRam;
@@ -326,7 +328,7 @@ static void starfield_init()
 
 	for (INT32 y = 0; y < nScreenHeight; y++)
 	{
-		for (INT32 x = nScreenWidth - 1; x >= 0; x--)
+		for (INT32 x = nScreenWidth - (STARFIELD_CLIPPING_X * 2) - 1; x >= 0; x--)
 		{
 			generator <<= 1;
 			INT32 bit1 = (~generator >> 17) & 1;
@@ -347,7 +349,7 @@ static void starfield_init()
 				}
 
 				if (color && total_stars < 120) {
-					stars[total_stars].x = x;
+					stars[total_stars].x = x + STARFIELD_CLIPPING_X;
 					stars[total_stars].y = y;
 					stars[total_stars].col = color;
 					stars[total_stars].set = set++;
@@ -712,8 +714,8 @@ static void vblank_update()
 			case 0xaf: stars[i].y -= 3.0f; break;
 		}
 
-		if (stars[i].x < 16) stars[i].x = (float)(nScreenWidth-32) + stars[i].x;
-		if (stars[i].x >= (float)(nScreenWidth-16)) stars[i].x -= (float)(nScreenWidth-32);
+		if (stars[i].x < STARFIELD_CLIPPING_X) stars[i].x = (float)(nScreenWidth-STARFIELD_CLIPPING_X*2) + stars[i].x;
+		if (stars[i].x >= (float)(nScreenWidth-STARFIELD_CLIPPING_X)) stars[i].x -= (float)(nScreenWidth-STARFIELD_CLIPPING_X*2);
 		if (stars[i].y < 0) stars[i].y = (float)(nScreenHeight) + stars[i].y;
 		if (stars[i].y >= (float)(nScreenHeight)) stars[i].y -= (float)(nScreenHeight);
 	}


### PR DESCRIPTION
- Fixed displaying of starfield
  - Fixed scrolling speed and direction ([MAME Testers-00434](https://mametesters.org/view.php?id=434))
  - Added top and bottom clipping ([MAME Testers-07663](https://mametesters.org/view.php?id=7663))
  - Modified to use sprite color instead of text color with refer to the PCB
  - Added blinking when the movement of the star changes
- Add service mode in DIPSW setting