### PR TITLE
pgm: big-endianize attempt 2

### DIFF
--- a/src/burn/drv/pgm/pgm_run.cpp
+++ b/src/burn/drv/pgm/pgm_run.cpp
@@ -408,7 +408,7 @@ static UINT16 __fastcall PgmZ80ReadWord(UINT32 sekAddress)
 	pgmSynchroniseZ80(0);
 
 	sekAddress &= 0xffff;
-	return BURN_ENDIAN_SWAP_INT16((RamZ80[sekAddress] << 8) + RamZ80[sekAddress + 1]);
+	return BURN_ENDIAN_SWAP_INT16((RamZ80[sekAddress] << 8) | RamZ80[sekAddress + 1]);
 }
 
 static void __fastcall PgmZ80WriteByte(UINT32 sekAddress, UINT8 byteValue)

--- a/src/burn/drv/pgm/pgm_run.cpp
+++ b/src/burn/drv/pgm/pgm_run.cpp
@@ -408,7 +408,7 @@ static UINT16 __fastcall PgmZ80ReadWord(UINT32 sekAddress)
 	pgmSynchroniseZ80(0);
 
 	sekAddress &= 0xffff;
-	return (RamZ80[sekAddress] << 8) | RamZ80[sekAddress + 1];
+	return BURN_ENDIAN_SWAP_INT16((RamZ80[sekAddress] << 8) + RamZ80[sekAddress + 1]);
 }
 
 static void __fastcall PgmZ80WriteByte(UINT32 sekAddress, UINT8 byteValue)
@@ -425,8 +425,8 @@ static void __fastcall PgmZ80WriteWord(UINT32 sekAddress, UINT16 wordValue)
 	pgmSynchroniseZ80(0);
 
 	sekAddress &= 0xffff;
-	RamZ80[sekAddress    ] = wordValue >> 8;
-	RamZ80[sekAddress + 1] = wordValue & 0xFF;
+	RamZ80[sekAddress    ] = BURN_ENDIAN_SWAP_INT16(wordValue) >> 8;
+	RamZ80[sekAddress + 1] = BURN_ENDIAN_SWAP_INT16(wordValue) & 0xFF;
 }
 
 inline static UINT32 CalcCol(UINT16 nColour)


### PR DESCRIPTION
@dinkc64 re big-endianizing those handlers : finally i wonder if it's not required, 2 reasons : 
- it fixes the following error on ddp2
![ddp2-200801-051400](https://user-images.githubusercontent.com/10391265/89096798-99356a00-d3d9-11ea-94d8-3f2c92d4957d.png)
- there is something similar done in m68k : 
https://github.com/finalburnneo/FBNeo/blob/b51b55f2bdef3f21dbffd501984f857841a151ea/src/cpu/m68000_intf.cpp#L333
https://github.com/finalburnneo/FBNeo/blob/b51b55f2bdef3f21dbffd501984f857841a151ea/src/cpu/m68000_intf.cpp#L375-L378