### PR TITLE
Fix integer constant is too large for 'long' on old GCC

### DIFF
--- a/src/cpu/tms34010_intf.cpp
+++ b/src/cpu/tms34010_intf.cpp
@@ -99,7 +99,7 @@ cpu_core_config TMS34010Config =
 	TMS34010Run,
 	TMS34010RunEnd,
 	TMS34010Reset,
-	0x100000000,
+	0x100000000ULL,
 	0
 };
 // end cheat-engine hook-up


### PR DESCRIPTION
../../cpu/tms34010_intf.cpp:102: error: integer constant is too large for 'long' type
make: *** [../../cpu/tms34010_intf.o] Error 1
make: Leaving directory `/home/crystal/tmpwork/FBNeo/src/burner/libretro'