### PR TITLE
Some pst90s Big Endian fixes

### DIFF
--- a/src/burn/drv/pst90s/d_3x3puzzl.cpp
+++ b/src/burn/drv/pst90s/d_3x3puzzl.cpp
@@ -500,7 +500,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
+		*pnMin = 0x029698;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_bestleag.cpp
+++ b/src/burn/drv/pst90s/d_bestleag.cpp
@@ -525,7 +525,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
+		*pnMin = 0x029698;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_bigstrkb.cpp
+++ b/src/burn/drv/pst90s/d_bigstrkb.cpp
@@ -498,7 +498,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
+		*pnMin = 0x029698;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_blackt96.cpp
+++ b/src/burn/drv/pst90s/d_blackt96.cpp
@@ -633,7 +633,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
+		*pnMin = 0x029698;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_crospang.cpp
+++ b/src/burn/drv/pst90s/d_crospang.cpp
@@ -733,7 +733,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
+		*pnMin = 0x029698;
 	}
 
 	if (nAction & ACB_VOLATILE) {

--- a/src/burn/drv/pst90s/d_cultures.cpp
+++ b/src/burn/drv/pst90s/d_cultures.cpp
@@ -485,7 +485,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
+		*pnMin = 0x029698;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_cultures.cpp
+++ b/src/burn/drv/pst90s/d_cultures.cpp
@@ -245,7 +245,7 @@ static tilemap_callback( bg1 )
 {
 	UINT16 *map = (UINT16*)DrvGfxROM1;
 
-	UINT16 code = map[0x100000 + nBgBank1 * 0x40000 + offs];
+	UINT16 code = BURN_ENDIAN_SWAP_INT16(map[0x100000 + nBgBank1 * 0x40000 + offs]);
 
 	code = (code << 8) | (code >> 8); //?
 
@@ -256,7 +256,7 @@ static tilemap_callback( bg2 )
 {
 	UINT16 *map = (UINT16*)DrvGfxROM2;
 
-	UINT16 code = map[0x100000 + nBgBank2 * 0x40000 + offs];
+	UINT16 code = BURN_ENDIAN_SWAP_INT16(map[0x100000 + nBgBank2 * 0x40000 + offs]);
 
 	code = (code << 8) | (code >> 8);//?
 
@@ -485,7 +485,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = 0x029698;
+		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029698);
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_dooyong.cpp
+++ b/src/burn/drv/pst90s/d_dooyong.cpp
@@ -740,7 +740,7 @@ STDDIPINFO(Popbingo)
 
 static inline void palette_write_4bgr(INT32 offset)
 {
-	UINT16 p = *((UINT16*)(DrvPalRAM + offset));
+	UINT16 p = BURN_ENDIAN_SWAP_INT16(*((UINT16*)(DrvPalRAM + offset)));
 
 	INT32 r = p & 0x0f;
 	INT32 g = (p >> 4) & 0x0f;
@@ -751,7 +751,7 @@ static inline void palette_write_4bgr(INT32 offset)
 
 static inline void palette_write_5rgb(INT32 offset)
 {
-	UINT16 p = *((UINT16*)(DrvPalRAM + offset));
+	UINT16 p = BURN_ENDIAN_SWAP_INT16(*((UINT16*)(DrvPalRAM + offset)));
 
 	INT32 b = (p >> 0) & 0x1f;
 	INT32 g = (p >> 5) & 0x1f;
@@ -1099,7 +1099,7 @@ static void __fastcall superx_main_write_word(UINT32 address, UINT16 data)
 	if ((address & 0x0f0000) == 0x0c0000) address = (address & 0xffff) | 0x80000; // fix address for rshark
 
 	if ((address & 0x0ff000) == 0x088000) {
-		*((UINT16*)(DrvPalRAM + (address & 0xffe))) = data;
+		*((UINT16*)(DrvPalRAM + (address & 0xffe))) = BURN_ENDIAN_SWAP_INT16(data);
 		palette_write_5rgb(address & 0xffe);
 		return;
 	}
@@ -2523,18 +2523,18 @@ static void draw_sprites_rshark(INT32 priority)
 
 	for (INT32 offs = 0; offs < 0x1000 / 2; offs += 8)
 	{
-		if (ram[offs] & 0x0001)
+		if (BURN_ENDIAN_SWAP_INT16(ram[offs]) & 0x0001)
 		{
-			INT32 color  = ram[offs+7] & 0x000f;
+			INT32 color  = BURN_ENDIAN_SWAP_INT16(ram[offs+7]) & 0x000f;
 
 			INT32 pri (((color == 0x00) || (color == 0x0f)) ? 0 : 1);
 			if (priority != pri) continue;
 
-			INT32 code   = ram[offs+3];
-			INT32 width  = ram[offs+1] & 0x000f;
-			INT32 height = (ram[offs+1] & 0x00f0) >> 4;
-			INT32 sx     = ram[offs+4] & 0x01ff;
-			INT32 sy     = (INT16)ram[offs+6] & 0x01ff;
+			INT32 code   = BURN_ENDIAN_SWAP_INT16(ram[offs+3]);
+			INT32 width  = BURN_ENDIAN_SWAP_INT16(ram[offs+1]) & 0x000f;
+			INT32 height = (BURN_ENDIAN_SWAP_INT16(ram[offs+1]) & 0x00f0) >> 4;
+			INT32 sx     = BURN_ENDIAN_SWAP_INT16(ram[offs+4]) & 0x01ff;
+			INT32 sy     = (INT16)BURN_ENDIAN_SWAP_INT16(ram[offs+6]) & 0x01ff;
 			if (sy & 0x0100) sy |= ~(int)0x01ff;
 
 			for (INT32 y = 0; y <= height; y++)
@@ -2982,7 +2982,7 @@ static INT32 Z80YM2203Scan(INT32 nAction,INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = 0x029707;
+		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029707);
 	}
 
 	if (nAction & ACB_VOLATILE) {		
@@ -3017,7 +3017,7 @@ static INT32 Z80YM2151Scan(INT32 nAction,INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = 0x029707;
+		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029707);
 	}
 
 	if (nAction & ACB_VOLATILE) {		
@@ -3053,7 +3053,7 @@ static INT32 Drv68KScan(INT32 nAction,INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = 0x029707;
+		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029707);
 	}
 
 	if (nAction & ACB_VOLATILE) {		

--- a/src/burn/drv/pst90s/d_dooyong.cpp
+++ b/src/burn/drv/pst90s/d_dooyong.cpp
@@ -3017,7 +3017,7 @@ static INT32 Z80YM2151Scan(INT32 nAction,INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029707);
+		*pnMin = 0x029707;
 	}
 
 	if (nAction & ACB_VOLATILE) {		
@@ -3053,7 +3053,7 @@ static INT32 Drv68KScan(INT32 nAction,INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029707);
+		*pnMin = 0x029707;
 	}
 
 	if (nAction & ACB_VOLATILE) {		

--- a/src/burn/drv/pst90s/d_dooyong.cpp
+++ b/src/burn/drv/pst90s/d_dooyong.cpp
@@ -2982,7 +2982,7 @@ static INT32 Z80YM2203Scan(INT32 nAction,INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029707);
+		*pnMin = 0x029707;
 	}
 
 	if (nAction & ACB_VOLATILE) {		

--- a/src/burn/drv/pst90s/d_dreamwld.cpp
+++ b/src/burn/drv/pst90s/d_dreamwld.cpp
@@ -906,7 +906,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029740);
+		*pnMin = 0x029740;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_dreamwld.cpp
+++ b/src/burn/drv/pst90s/d_dreamwld.cpp
@@ -317,7 +317,7 @@ inline static void palette_write(INT32 offset)
 {
 	offset &= 0x1ffe;
 
-	UINT16 data = *((UINT16 *)(DrvPalRAM + offset));
+	UINT16 data = BURN_ENDIAN_SWAP_INT16(*((UINT16 *)(DrvPalRAM + offset)));
 	UINT8 r, g, b;
 	offset >>= 1;
 
@@ -437,18 +437,18 @@ static tilemap_callback( background )
 {
 	UINT16 *ram = (UINT16*)DrvBg1RAM;
 	UINT32 *lnscroll = (UINT32  *)DrvBgScrollRAM;
-	INT32 bank = (lnscroll[0x104] >> 9) & 0x2000;
+	INT32 bank = (BURN_ENDIAN_SWAP_INT32(lnscroll[0x104]) >> 9) & 0x2000;
 
-	TILE_SET_INFO(0, (ram[offs] & 0x1fff) + bank, (ram[offs] >> 13) + 0x80, 0);
+	TILE_SET_INFO(0, (BURN_ENDIAN_SWAP_INT16(ram[offs]) & 0x1fff) + bank, (BURN_ENDIAN_SWAP_INT16(ram[offs]) >> 13) + 0x80, 0);
 }
 
 static tilemap_callback( foreground )
 {
 	UINT16 *ram = (UINT16*)DrvBg2RAM;
 	UINT32 *lnscroll = (UINT32  *)DrvBgScrollRAM;
-	INT32 bank = (lnscroll[0x105] >> 9) & 0x2000;
+	INT32 bank = (BURN_ENDIAN_SWAP_INT32(lnscroll[0x105]) >> 9) & 0x2000;
 
-	TILE_SET_INFO(0, (ram[offs] & 0x1fff) + bank, (ram[offs] >> 13) + 0xc0, 0);
+	TILE_SET_INFO(0, (BURN_ENDIAN_SWAP_INT16(ram[offs]) & 0x1fff) + bank, (BURN_ENDIAN_SWAP_INT16(ram[offs]) >> 13) + 0xc0, 0);
 }
 
 static INT32 DrvDoReset()
@@ -713,10 +713,10 @@ static void draw_layer(INT32 layer)
 	UINT32 *scroll = (UINT32 *)DrvBgScrollRAM;
 	UINT16 *lnscroll = (UINT16 *)DrvBgScrollRAM;
 
-	INT32 ctrl = scroll[0x104 + layer] >> 16;
+	INT32 ctrl = BURN_ENDIAN_SWAP_INT32(scroll[0x104 + layer]) >> 16;
 
-	INT32 scrolly = scroll[0x100 + (layer * 2)] >> 16;
-	INT32 scrollx = (scroll[0x101 + (layer * 2)] >> 16) + (layer ? 5 : 3);
+	INT32 scrolly = BURN_ENDIAN_SWAP_INT32(scroll[0x100 + (layer * 2)]) >> 16;
+	INT32 scrollx = (BURN_ENDIAN_SWAP_INT32(scroll[0x101 + (layer * 2)]) >> 16) + (layer ? 5 : 3);
 
 	GenericTilemapSetScrollY(layer, scrolly + 32);
 
@@ -730,7 +730,7 @@ static void draw_layer(INT32 layer)
 
 		for (INT32 y = 0; y < 256; y += 16)
 		{
-			GenericTilemapSetScrollRow(layer, ((y + scrolly + 32) & 0xff) / 16, scrollx + (scroll[y / 16] >> 16));
+			GenericTilemapSetScrollRow(layer, ((y + scrolly + 32) & 0xff) / 16, scrollx + (BURN_ENDIAN_SWAP_INT32(scroll[y / 16]) >> 16));
 		}
 	}
 	else if ((ctrl & 0x0300) == 0x100)	// line scroll
@@ -741,7 +741,7 @@ static void draw_layer(INT32 layer)
 
 		for (INT32 y = 0; y < 256; y++)
 		{
-			GenericTilemapSetScrollRow(layer, (y + scrolly + 32) & 0x3ff, (scrollx + (lnscroll[(y + 32) & 0xff])));
+			GenericTilemapSetScrollRow(layer, (y + scrolly + 32) & 0x3ff, (scrollx + (BURN_ENDIAN_SWAP_INT16(lnscroll[(y + 32) & 0xff]))));
 		}
 	}
 	else if ((ctrl & 0x0300) == 0)		// normal scroll
@@ -765,15 +765,15 @@ static void draw_sprites()
 		INT32 xpos, ypos, tileno, code, colour, xflip, yflip;
 		INT32 xsize, ysize, xinc, yinc, xct, yct;
 
-		xpos   = (source[1]&0x01ff);
-		ypos   = (source[0]&0x01ff);
-		xsize  = (source[1]&0x0e00) >> 9;
-		ysize  = (source[0]&0x0e00) >> 9;
-		tileno = (source[3]&0xffff);
-		if (source[2]&1) tileno += 0x10000; // fix sprites in cute fighter -dink
-		colour = (source[2]&0x3f00) >> 8;
-		xflip  = (source[2]&0x4000);
-		yflip  = (source[2]&0x8000);
+		xpos   = (BURN_ENDIAN_SWAP_INT16(source[1])&0x01ff);
+		ypos   = (BURN_ENDIAN_SWAP_INT16(source[0])&0x01ff);
+		xsize  = (BURN_ENDIAN_SWAP_INT16(source[1])&0x0e00) >> 9;
+		ysize  = (BURN_ENDIAN_SWAP_INT16(source[0])&0x0e00) >> 9;
+		tileno = (BURN_ENDIAN_SWAP_INT16(source[3])&0xffff);
+		if (BURN_ENDIAN_SWAP_INT16(source[2])&1) tileno += 0x10000; // fix sprites in cute fighter -dink
+		colour = (BURN_ENDIAN_SWAP_INT16(source[2])&0x3f00) >> 8;
+		xflip  = (BURN_ENDIAN_SWAP_INT16(source[2])&0x4000);
+		yflip  = (BURN_ENDIAN_SWAP_INT16(source[2])&0x8000);
 
 		xinc = 16;
 		yinc = 16;
@@ -796,7 +796,7 @@ static void draw_sprites()
 		{
 			for (xct=0;xct<xsize+1;xct++)
 			{
-				code = redirect[tileno];
+				code = BURN_ENDIAN_SWAP_INT16(redirect[tileno]);
 
 				if (yflip) {
 					if (xflip) {
@@ -906,7 +906,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 	
 	if (pnMin != NULL) {
-		*pnMin = 0x029740;
+		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029740);
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_drgnmst.cpp
+++ b/src/burn/drv/pst90s/d_drgnmst.cpp
@@ -726,7 +726,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029697);
+		*pnMin = 0x029697;
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {

--- a/src/burn/drv/pst90s/d_drgnmst.cpp
+++ b/src/burn/drv/pst90s/d_drgnmst.cpp
@@ -152,7 +152,7 @@ STDDIPINFO(Drv)
 
 static inline void palette_write(INT32 offset)
 {
-	UINT16 data = *((UINT16*)(DrvPalRAM + offset));	
+	UINT16 data = BURN_ENDIAN_SWAP_INT16(*((UINT16*)(DrvPalRAM + offset)));	
 
 	INT32 i = (data >> 12) + 5;
 	INT32 r = (data >> 8) & 0x0f;
@@ -198,13 +198,13 @@ static void __fastcall drgnmst_write_byte(UINT32 address, UINT8 data)
 static void __fastcall drgnmst_write_word(UINT32 address, UINT16 data)
 {
 	if ((address & 0xffc000) == 0x900000) {
-		*((UINT16 *)(DrvPalRAM + (address & 0x3ffe))) = data;
+		*((UINT16 *)(DrvPalRAM + (address & 0x3ffe))) = BURN_ENDIAN_SWAP_INT16(data);
 		palette_write(address & 0x3ffe);
 		return;
 	}
 
 	if (address >= 0x800100 && address <= 0x80011f) {
-		*((UINT16*)(DrvVidRegs + (address & 0x1e))) = data;
+		*((UINT16*)(DrvVidRegs + (address & 0x1e))) = BURN_ENDIAN_SWAP_INT16(data);
 		return;
 	}
 
@@ -349,21 +349,21 @@ static tilemap_callback( bg )
 {
 	UINT16 *ram = (UINT16*)(DrvBgRAM + offs * 4);
 	
-	TILE_SET_INFO(0, (ram[0] & 0x1fff) + 0x0800, ram[1], TILE_FLIPYX(ram[1] >> 5));
+	TILE_SET_INFO(0, (BURN_ENDIAN_SWAP_INT16(ram[0]) & 0x1fff) + 0x0800, BURN_ENDIAN_SWAP_INT16(ram[1]), TILE_FLIPYX(BURN_ENDIAN_SWAP_INT16(ram[1]) >> 5));
 }
 
 static tilemap_callback( mg )
 {
 	UINT16 *ram = (UINT16*)(DrvMidRAM + offs * 4);
 	
-	TILE_SET_INFO(1, (ram[0] & 0x7fff) - 0x2000, ram[1], TILE_FLIPYX(ram[1] >> 5));
+	TILE_SET_INFO(1, (BURN_ENDIAN_SWAP_INT16(ram[0]) & 0x7fff) - 0x2000, BURN_ENDIAN_SWAP_INT16(ram[1]), TILE_FLIPYX(BURN_ENDIAN_SWAP_INT16(ram[1]) >> 5));
 }
 
 static tilemap_callback( fg )
 {
 	UINT16 *ram = (UINT16*)(DrvFgRAM + offs * 4);
 	
-	TILE_SET_INFO(2, (ram[0] & 0xfff) | ((offs & 0x20) << 10), ram[1], TILE_FLIPYX(ram[1] >> 5));
+	TILE_SET_INFO(2, (BURN_ENDIAN_SWAP_INT16(ram[0]) & 0xfff) | ((offs & 0x20) << 10), BURN_ENDIAN_SWAP_INT16(ram[1]), TILE_FLIPYX(BURN_ENDIAN_SWAP_INT16(ram[1]) >> 5));
 }
 
 static tilemap_scan( fg )
@@ -575,17 +575,17 @@ static void draw_sprites()
 	for (INT32 i = 0; i < 0x800/2; i+=4)
 	{
 		INT32 incx, incy;
-		INT32 xpos   = source[i+0] - 64;
-		INT32 ypos   = source[i+1] - 16;
-		INT32 number = source[i+2];
-		INT32 attr   = source[i+3];
+		INT32 xpos   = BURN_ENDIAN_SWAP_INT16(source[i+0]) - 64;
+		INT32 ypos   = BURN_ENDIAN_SWAP_INT16(source[i+1]) - 16;
+		INT32 number = BURN_ENDIAN_SWAP_INT16(source[i+2]);
+		INT32 attr   = BURN_ENDIAN_SWAP_INT16(source[i+3]);
 		INT32 flipx  = attr & 0x0020;
 		INT32 flipy  = attr & 0x0040;
 		INT32 wide  = (attr & 0x0f00) >> 8;
 		INT32 high  = (attr & 0xf000) >> 12;
 		INT32 color = (attr & 0x001f);
 
-		if ((source[i+3] & 0xff00) == 0xff00) break;
+		if ((BURN_ENDIAN_SWAP_INT16(source[i+3]) & 0xff00) == 0xff00) break;
 
 		if (!flipx) { incx = 16; } else { incx = -16; xpos += 16*wide; }
 		if (!flipy) { incy = 16; } else { incy = -16; ypos += 16*high; }
@@ -617,18 +617,18 @@ static INT32 DrvDraw()
 
 	UINT16 *vreg = (UINT16*)DrvVidRegs;
 
-	GenericTilemapSetScrollX(2, vreg[0x0c/2] - 18);
-	GenericTilemapSetScrollY(2, vreg[0x0e/2]);
+	GenericTilemapSetScrollX(2, BURN_ENDIAN_SWAP_INT16(vreg[0x0c/2]) - 18);
+	GenericTilemapSetScrollY(2, BURN_ENDIAN_SWAP_INT16(vreg[0x0e/2]));
 //	GenericTilemapSetScrollX(1, vreg[0x10/2] - 16);
-	GenericTilemapSetScrollY(1, vreg[0x12/2] + 16);
-	GenericTilemapSetScrollX(0, vreg[0x14/2] - 18);
-	GenericTilemapSetScrollY(0, vreg[0x16/2]);
+	GenericTilemapSetScrollY(1, BURN_ENDIAN_SWAP_INT16(vreg[0x12/2]) + 16);
+	GenericTilemapSetScrollX(0, BURN_ENDIAN_SWAP_INT16(vreg[0x14/2]) - 18);
+	GenericTilemapSetScrollY(0, BURN_ENDIAN_SWAP_INT16(vreg[0x16/2]));
 
 	{
-		UINT16 *rs = (UINT16*)(DrvRowScroll + ((vreg[0x08/2] & 0x30) << 8));
+		UINT16 *rs = (UINT16*)(DrvRowScroll + ((BURN_ENDIAN_SWAP_INT16(vreg[0x08/2]) & 0x30) << 8));
 
 		for (INT32 y = 0; y < 1024; y++) {
-			GenericTilemapSetScrollRow(1, y, (vreg[0x10/2] - 16) + rs[y]);
+			GenericTilemapSetScrollRow(1, y, (BURN_ENDIAN_SWAP_INT16(vreg[0x10/2]) - 16) + BURN_ENDIAN_SWAP_INT16(rs[y]));
 		}
 	}
 	
@@ -726,7 +726,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 	struct BurnArea ba;
 
 	if (pnMin) {
-		*pnMin = 0x029697;
+		*pnMin = BURN_ENDIAN_SWAP_INT32(0x029697);
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {


### PR DESCRIPTION
Before continuing I ask you for an opinion about:
`static INT32 DrvScan(INT32 nAction, INT32 *pnMin)` and `*pnMin = 0x029707;`
In the past it never big endian swapped.... but i think it must be swapped.... and that is weird.
What is that value for?