### PR TITLE
win32ui: Add a maximize and restore button to the form [select game]

### DIFF
--- a/src/burner/win32/sel.cpp
+++ b/src/burner/win32/sel.cpp
@@ -1569,6 +1569,9 @@ static INT_PTR CALLBACK DialogProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lP
 
 		hSelDlg = hDlg;
 
+		// add WS_MAXIMIZEBOX button;
+		SetWindowLongPtr(hSelDlg, GWL_STYLE, GetWindowLongPtr(hSelDlg, GWL_STYLE) | WS_MAXIMIZEBOX);
+
 		SendDlgItemMessage(hDlg, IDC_SCREENSHOT_H, STM_SETIMAGE, IMAGE_BITMAP, (LPARAM)NULL);
 		SendDlgItemMessage(hDlg, IDC_SCREENSHOT_V, STM_SETIMAGE, IMAGE_BITMAP, (LPARAM)NULL);
 


### PR DESCRIPTION
The gamelist window has a low initial height and limited visible content
1. Enlarge the window by dragging the edge of the window (fbneo's default scheme)
2. Add a button to maximize and restore the window (another way)
![11](https://user-images.githubusercontent.com/67533945/98454991-fe9db180-21a5-11eb-83a1-72b3128a1fe8.PNG)