### PR TITLE
megadrive: attempt at fixing misaligned address access

### DIFF
--- a/src/burn/drv/megadrive/megadrive.cpp
+++ b/src/burn/drv/megadrive/megadrive.cpp
@@ -402,12 +402,7 @@ static INT32 MemIndex()
 
 	MegadriveCurPal		= (UINT32 *) Next; Next += 0x000040 * sizeof(UINT32) * 4;
 
-	HighColFull	= Next; Next += (8 + 320 + 8) * 240 + 1;
-
-#ifdef __LIBRETRO__
-	// Ugly hack to avoid misaligned address access
-	Next += 3;
-#endif
+	HighColFull	= Next; Next += (8 + 320 + 8) * 240 + 1 + 3; // +3 alignment
 
 	LineBuf     = (UINT16 *) Next; Next += 320 * 320 * sizeof(UINT16); // palete-processed line-buffer (dink / for sonic mode)
 

--- a/src/burn/drv/megadrive/megadrive.cpp
+++ b/src/burn/drv/megadrive/megadrive.cpp
@@ -43,12 +43,6 @@
 #define MAX_CARTRIDGE_SIZE      0xc00000
 #define MAX_SRAM_SIZE           0x010000
 
-#if defined (__GNUC__) && defined (__LIBRETRO__)
-#define OPTIMIZE_ATTR __attribute__((optimize("O2")))
-#else
-#define OPTIMIZE_ATTR
-#endif
-
 // PicoDrive Sek interface
 static UINT64 SekCycleCnt, SekCycleAim, SekCycleCntDELTA, line_base_cycles;
 
@@ -409,6 +403,11 @@ static INT32 MemIndex()
 	MegadriveCurPal		= (UINT32 *) Next; Next += 0x000040 * sizeof(UINT32) * 4;
 
 	HighColFull	= Next; Next += (8 + 320 + 8) * 240 + 1;
+
+#ifdef __LIBRETRO__
+	// Ugly hack to avoid misaligned address access
+	Next += 3;
+#endif
 
 	LineBuf     = (UINT16 *) Next; Next += 320 * 320 * sizeof(UINT16); // palete-processed line-buffer (dink / for sonic mode)
 
@@ -4210,7 +4209,7 @@ static void DrawSpritesFromCache(INT32 *hc, INT32 sh)
 // Index + 0  :    hhhhvvvv ab--hhvv yyyyyyyy yyyyyyyy // a: offscreen h, b: offs. v, h: horiz. size
 // Index + 4  :    xxxxxxxx xxxxxxxx pccvhnnn nnnnnnnn // x: x coord + 8
 
-static void OPTIMIZE_ATTR PrepareSprites(INT32 full)
+static void PrepareSprites(INT32 full)
 {
 	INT32 u=0,link=0,sblocks=0;
 	INT32 table=0;
@@ -4575,7 +4574,7 @@ INT32 MegadriveDraw()
 #define CYCLES_M68K_VINT_LAG  68
 #define CYCLES_M68K_ASD      148
 
-INT32 OPTIMIZE_ATTR MegadriveFrame()
+INT32 MegadriveFrame()
 {
 	if (MegadriveReset) {
 		MegadriveResetDo();


### PR DESCRIPTION
Attempt at fixing : 
```
../../burn/drv/megadrive/megadrive.cpp:4282:10: runtime error: store to misaligned address 0x7f568b7ad3f1 for type 'INT32', which requires 4 byte alignment
0x7f568b7ad3f1: note: pointer points here
 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00
              ^ 
../../burn/drv/megadrive/megadrive.cpp:4283:10: runtime error: store to misaligned address 0x7f568b7ad3f5 for type 'INT32', which requires 4 byte alignment
0x7f568b7ad3f5: note: pointer points here
 80 ff 40 11 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:4290:7: runtime error: store to misaligned address 0x7f568b7ad3f9 for type 'INT32', which requires 4 byte alignment
0x7f568b7ad3f9: note: pointer points here
 00 00 88  ff 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00
              ^ 
../../burn/drv/megadrive/megadrive.cpp:4512:14: runtime error: store to misaligned address 0x7f568b77b15d for type 'UINT16', which requires 2 byte alignment
0x7f568b77b15d: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:4493:14: runtime error: store to misaligned address 0x7f568b77b15d for type 'UINT16', which requires 2 byte alignment
0x7f568b77b15d: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:4535:22: runtime error: load of misaligned address 0x7f568b77b15d for type 'UINT16', which requires 2 byte alignment
0x7f568b77b15d: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:3679:10: runtime error: store to misaligned address 0x7f568b7ad205 for type 'INT32', which requires 4 byte alignment
0x7f568b7ad205: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:4447:17: runtime error: load of misaligned address 0x7f568b7ad205 for type 'INT32', which requires 4 byte alignment
0x7f568b7ad205: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:4455:18: runtime error: load of misaligned address 0x7f568b7ad15d for type 'INT32', which requires 4 byte alignment
0x7f568b7ad15d: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:3659:14: runtime error: store to misaligned address 0x7f568b7ad15d for type 'INT32', which requires 4 byte alignment
0x7f568b7ad15d: note: pointer points here
 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00
             ^ 
../../burn/drv/megadrive/megadrive.cpp:3936:14: runtime error: load of misaligned address 0x7f568b7ad15d for type 'INT32', which requires 4 byte alignment
0x7f568b7ad15d: note: pointer points here
 00 00 00 00 01 80 78  00 02 80 80 00 03 80 88  00 04 80 90 00 05 80 98  00 06 80 a0 00 07 80 a8  00
             ^
```
This fix is ugly, but it's still probably better than the previous one that was only attempting to hide the issue by sub-optimizing (which i think doesn't work for some people).

Any better suggestion ? Maybe replacing line 411 by `HighColFull	= Next; Next += (8 + 320 + 8) * 240 + 4;` would be better ?