### PR TITLE
Updated SF 2 Mix

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -3896,7 +3896,7 @@ static struct BurnDIPInfo Sf2mixDIPList[]=
 
 	// Dip B
 	CPS1_DIFFICULTY_1(0x1c)
-	{0   , 0xfe, 0   , 2   , "Classic Mode"           },
+	{0   , 0xfe, 0   , 2   , "Complete Mode"           },
 	{0x1c, 0x01, 0x08, 0x00, "Off"                    },
 	{0x1c, 0x01, 0x08, 0x08, "On"                     },
 	
@@ -24110,31 +24110,31 @@ struct BurnDriver BurnDrvCpsWofjdr = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-// Street Fighter II Mix (Ver 0.97)
+// Street Fighter II Mix
 // Hacked by ZERO800 - BRAZIL
 // For more infomation, please visit: https://sf2mix.github.io/
 static struct BurnRomInfo sf2mixRomDesc[] = {
-	{ "smxe_23b.8f",   0x080000, 0xdba189f5, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "smx_22b.7f",    0x080000, 0x78517c23, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "smx_21a.6f",    0x080000, 0x91a5f422, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "s92e_23a.8f",   0x080000, 0x9218219F, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "s92_22a.7f",    0x080000, 0x5E3C3D10, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "s92_21a.6f",    0x080000, 0x0ABF92B1, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	{ "smx-1m.3a",     0x080000, 0xa1d1a20f, BRF_GRA | CPS1_TILES },
-	{ "smx-3m.5a",     0x080000, 0x0708bb01, BRF_GRA | CPS1_TILES },
-	{ "smx-2m.4a",     0x080000, 0x42e159b9, BRF_GRA | CPS1_TILES },
-	{ "smx-4m.6a",     0x080000, 0xcac353a3, BRF_GRA | CPS1_TILES },
-	{ "smx-5m.7a",     0x080000, 0xcd128779, BRF_GRA | CPS1_TILES },
-	{ "smx-7m.9a",     0x080000, 0x66dc2114, BRF_GRA | CPS1_TILES },
-	{ "smx-6m.8a",     0x080000, 0xbcf5a5d4, BRF_GRA | CPS1_TILES },
-	{ "smx-8m.10a",    0x080000, 0xb51db630, BRF_GRA | CPS1_TILES },
-	{ "smx-10m.3c",    0x080000, 0xc2a6eaa1, BRF_GRA | CPS1_TILES },
-	{ "smx-12m.5c",    0x080000, 0x7033d28b, BRF_GRA | CPS1_TILES },
-	{ "smx-11m.4c",    0x080000, 0x0c300970, BRF_GRA | CPS1_TILES },
-	{ "smx-13m.6c",    0x080000, 0x853ddf81, BRF_GRA | CPS1_TILES },
+	{ "s92-1m.3a",     0x080000, 0xA1D1A20F, BRF_GRA | CPS1_TILES },
+	{ "s92-3m.5a",     0x080000, 0x0708BB01, BRF_GRA | CPS1_TILES },
+	{ "s92-2m.4a",     0x080000, 0x42E159B9, BRF_GRA | CPS1_TILES },
+	{ "s92-4m.6a",     0x080000, 0xCAC353A3, BRF_GRA | CPS1_TILES },
+	{ "s92-5m.7a",     0x080000, 0x44788FC3, BRF_GRA | CPS1_TILES },
+	{ "s92-7m.9a",     0x080000, 0xDB3E33F9, BRF_GRA | CPS1_TILES },
+	{ "s92-6m.8a",     0x080000, 0x7F757D22, BRF_GRA | CPS1_TILES },
+	{ "s92-8m.10a",    0x080000, 0x7E2C6383, BRF_GRA | CPS1_TILES },
+	{ "s92-10m.3c",    0x080000, 0xD4E75239, BRF_GRA | CPS1_TILES },
+	{ "s92-12m.5c",    0x080000, 0xC66DC52C, BRF_GRA | CPS1_TILES },
+	{ "s92-11m.4c",    0x080000, 0x416149F2, BRF_GRA | CPS1_TILES },
+	{ "s92-13m.6c",    0x080000, 0x7316D4BC, BRF_GRA | CPS1_TILES },
 
-	{ "smx_09.11a",    0x010000, 0xa379fdc5, BRF_PRG | CPS1_Z80_PROGRAM },
+	{ "s92_09.11a",    0x010000, 0xA379FDC5, BRF_PRG | CPS1_Z80_PROGRAM },
 
-	{ "smx_18.11c",    0x020000, 0x6aa5d7fa, BRF_SND | CPS1_OKIM6295_SAMPLES },
-	{ "smx_19.12c",    0x020000, 0xf92f5a4f, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "s92_18.11c",    0x020000, 0x6AA5D7FA, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "s92_19.12c",    0x020000, 0xF92F5A4F, BRF_SND | CPS1_OKIM6295_SAMPLES },
 	
 	A_BOARD_PLDS
 	


### PR DESCRIPTION
Changed the Classic Mode dipswitch into Complete as the creator of the hack made the fake 3D and bonus stages appearing as actual stages optional.

The creator of the hack didn't choose the smx naming scheme so I changed that back to the way he intended it to be also updated the crc's as well.