### PR TITLE
SDL2: Improvements

### DIFF
--- a/README-SDL.md
+++ b/README-SDL.md
@@ -97,6 +97,7 @@ The above will give you a nicely scalend game screen and the menu for launching 
 'F11' - show FPS counter
 'F6' - Screenshot
 'ALT-ENTER' - Switch window/fullscreen
+'+'/'-' - Volume controls
 
 ## SDL2 in menu controls
 

--- a/src/burner/sdl/run.cpp
+++ b/src/burner/sdl/run.cpp
@@ -475,7 +475,22 @@ int RunMessageLoop()
 						bscreenshot = 1;
 					}
 					break;
-	
+				case SDLK_KP_MINUS: // volumme -
+					nAudVolume -= 500;
+					if (nAudVolume < 0) {
+						nAudVolume = 0;
+					}
+					if (AudSoundSetVolume() == 0) {
+					}
+					break;
+				case SDLK_KP_PLUS: // volume -+
+					nAudVolume += 500;
+					if (nAudVolume > 10000) {
+						nAudVolume = 10000;
+					}
+					if (AudSoundSetVolume() == 0) {
+					}
+					break;
 				default:
 					break;
 				}

--- a/src/burner/sdl/run.cpp
+++ b/src/burner/sdl/run.cpp
@@ -376,6 +376,10 @@ void pause_game()
 					case SDL_WINDOWEVENT_FOCUS_GAINED:
 						finished=1;
 						break;
+					case SDL_WINDOWEVENT_CLOSE:
+						finished=1;
+						RunExit();
+						break;
 					default:
 						break;
 				}

--- a/src/burner/sdl/sdl2_gui.cpp
+++ b/src/burner/sdl/sdl2_gui.cpp
@@ -171,6 +171,7 @@ static bool CheckIfSystem(INT32 gameTocheck)
 				case HARDWARE_SEGA_OUTRUN:
 				case HARDWARE_SEGA_SYSTEM1:
 				case HARDWARE_SEGA_MISC:
+				case HARDWARE_SEGA_SYSTEM24:
 					bRet = true;
 					break;
 			}
@@ -286,7 +287,7 @@ static void DoFilterGames()
 		for(UINT32 i = 0; i < nBurnDrvCount; i++)
 		{
 			nBurnDrvActive = i;
-			if (gameAv[i] && CheckIfSystem(i))
+			if (gameAv[i] && CheckIfSystem(i) && !(BurnDrvGetGenreFlags() & GBF_BIOS)	)
 			{
 				if(bShowClones)
 				{
@@ -306,7 +307,7 @@ static void DoFilterGames()
 		for(UINT32 i = 0; i < nBurnDrvCount; i++)
 		{
 			nBurnDrvActive = i;
-			if (gameAv[i] && CheckIfSystem(i))
+			if (gameAv[i] && CheckIfSystem(i) && !(BurnDrvGetGenreFlags() & GBF_BIOS)	)
 			{
 				if(bShowClones)
 				{
@@ -330,7 +331,7 @@ static void DoFilterGames()
 		for(UINT32 i = 0; i < nBurnDrvCount; i++)
 		{
 			nBurnDrvActive = i;
-			if (CheckIfSystem(i))
+			if (CheckIfSystem(i) && !(BurnDrvGetGenreFlags() & GBF_BIOS)	)
 			{
 				if(bShowClones)
 				{
@@ -883,7 +884,7 @@ void gui_render()
 	incolor(fbn_color, /* unused */ 0);
 	inprint(sdlRenderer, "FBNeo * F1 - Rescan / F2 - Filter Missing / F3 - System Filter / F4 - Filter Clones / F12 - Quit *", 10, 5);
 	if (strlen(systemName) != 0) {
-		snprintf(newLine, MAX_PATH, "Active Filter: %s - Showing : %d of %d", systemName, filterGamesCount, (nBurnDrvCount - REDUCE_TOTAL_SETS_BIOS));
+		snprintf(newLine, MAX_PATH, "Filter System: %s / Missing: %s / Clones: %s / Showing : %d of %d", systemName, (bShowAvailableOnly?"No":"Yes"), (bShowClones?"Yes":"No"), filterGamesCount, (nBurnDrvCount + 1 - REDUCE_TOTAL_SETS_BIOS));
 		inprint(sdlRenderer, newLine, 10, 15);
 	}
 	incolor(normal_color, /* unused */ 0);

--- a/src/burner/sdl/sdl2_gui.cpp
+++ b/src/burner/sdl/sdl2_gui.cpp
@@ -5,6 +5,9 @@
 
 extern char videofiltering[3];
 
+// reduce the total number of sets by this number - (isgsm, neogeo, nmk004, pgm, skns, ym2608, coleco, msx_msx, spectrum, spec128, decocass, midssio, cchip, fdsbios, ngp, bubsys)
+// don't reduce for these as we display them in the list (neogeo, neocdz)
+#define REDUCE_TOTAL_SETS_BIOS		16
 // Limit CPU usage
 #define maxfps 25
 static Uint32 starting_stick;
@@ -268,6 +271,9 @@ static void DoFilterGames()
 		filterGames = NULL;
 	}
 
+	filterGames = (unsigned int*)malloc(nBurnDrvCount * sizeof(unsigned int));
+	filterGamesCount = 0;
+			
 	if (bShowAvailableOnly)
 	{
 		for(UINT32 i = 0; i < nBurnDrvCount; i++)
@@ -289,10 +295,6 @@ static void DoFilterGames()
 
 			}
 		}
-
-		filterGames = (unsigned int*)malloc(count * sizeof(unsigned int));
-
-		filterGamesCount = 0;
 
 		for(UINT32 i = 0; i < nBurnDrvCount; i++)
 		{
@@ -318,8 +320,6 @@ static void DoFilterGames()
 	}
 	else
 	{
-		filterGames = (unsigned int*)malloc(nBurnDrvCount * sizeof(unsigned int));
-		filterGamesCount = 0;
 		for(UINT32 i = 0; i < nBurnDrvCount; i++)
 		{
 			nBurnDrvActive = i;
@@ -755,7 +755,7 @@ void gui_init()
 
 
 	sdlWindow = SDL_CreateWindow(
-		"FBNeo - Choose your weapon...",
+		"FBNeo - Select Game...",
 		SDL_WINDOWPOS_CENTERED,
 		SDL_WINDOWPOS_CENTERED,
 		nVidGuiWidth,
@@ -878,7 +878,7 @@ void gui_render()
 	incolor(fbn_color, /* unused */ 0);
 	inprint(sdlRenderer, "FBNeo * F1 - Rescan / F2 - Filter Missing / F3 - System Filter / F4 - Filter Clones / F12 - Quit *", 10, 5);
 	if (strlen(systemName) != 0) {
-		snprintf(newLine, MAX_PATH, "Active Filter: %s", systemName);
+		snprintf(newLine, MAX_PATH, "Active Filter: %s - Showing : %d of %d", systemName, filterGamesCount, (nBurnDrvCount - REDUCE_TOTAL_SETS_BIOS));
 		inprint(sdlRenderer, newLine, 10, 15);
 	}
 	incolor(normal_color, /* unused */ 0);
@@ -955,8 +955,11 @@ int gui_process()
 {
 	SDL_Event e;
 	bool quit = false;
-	static UINT32 previousSelected;
+	static UINT32 previousSelected = -1;
 
+	snprintf(systemName, MAX_PATH, "Everything");
+	nSystemToCheckMask = HARDWARE_PUBLIC_MASK;
+	
 	while (!quit)
 	{
 		starting_stick = SDL_GetTicks();

--- a/src/intf/audio/sdl/aud_sdl.cpp
+++ b/src/intf/audio/sdl/aud_sdl.cpp
@@ -216,6 +216,9 @@ static int SDLSoundStop()
 
 static int SDLSoundSetVolume()
 {
+	nSDLVolume = int(SDL_MIX_MAXVOLUME * nAudVolume / 10000);
+	if (nSDLVolume > SDL_MIX_MAXVOLUME) nSDLVolume=SDL_MIX_MAXVOLUME;
+	if (nSDLVolume < 0) nSDLVolume=0;
 	return 1;
 }
 

--- a/src/intf/video/sdl/vid_sdl2.cpp
+++ b/src/intf/video/sdl/vid_sdl2.cpp
@@ -184,14 +184,11 @@ static int Init()
 			Windowtitle,
 			SDL_WINDOWPOS_CENTERED,
 			SDL_WINDOWPOS_CENTERED,
-			display_h,
 			display_w,
+			display_h,
 			screenFlags
 		);
 	}
-
-
-
 
 	// Check that the window was successfully created
 	if (sdlWindow == NULL)
@@ -249,6 +246,14 @@ static int Init()
 		SDL_RenderSetLogicalSize(sdlRenderer, display_w, display_h);
 	}
 
+	// Force to scale * 2
+	// TODO
+	int w;
+	int h;
+	SDL_GetWindowSize(sdlWindow, &w, &h);
+	SDL_SetWindowSize(sdlWindow, w*2, h*2);
+	SDL_SetWindowPosition(sdlWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+	
 	inrenderer(sdlRenderer); //TODO: this is not supposed to be here
 	prepare_inline_font();   // TODO: BAD
 	incolor(0xFFF000, 0);

--- a/src/intf/video/sdl/vid_sdl2.cpp
+++ b/src/intf/video/sdl/vid_sdl2.cpp
@@ -64,7 +64,10 @@ static int Exit()
 	SDL_DestroyRenderer(sdlRenderer);
 	SDL_DestroyWindow(sdlWindow);
 
-	free(VidMem);
+	if (VidMem)
+	{
+		free(VidMem);
+	}
 	return 0;
 }
 static int display_w = 400, display_h = 300;
@@ -91,7 +94,14 @@ static int Init()
 	{
 		// Get the game screen size
 		BurnDrvGetVisibleSize(&nVidImageWidth, &nVidImageHeight);
-		BurnDrvGetAspect(&GameAspectX, &GameAspectY);
+		if ((BurnDrvGetFlags() & (BDF_ORIENTATION_VERTICAL | BDF_ORIENTATION_FLIPPED)))
+		{
+			BurnDrvGetAspect(&GameAspectY, &GameAspectX);
+		}
+		else
+		{
+			BurnDrvGetAspect(&GameAspectX, &GameAspectY);
+		}
 
 		display_w = nVidImageWidth;
 #ifdef INCLUDE_SWITCHRES
@@ -101,7 +111,6 @@ static int Init()
 		if (BurnDrvGetFlags() & BDF_ORIENTATION_VERTICAL)
 		{
 			BurnDrvGetVisibleSize(&nVidImageHeight, &nVidImageWidth);
-			BurnDrvGetAspect(&GameAspectY, &GameAspectX);
 			printf("Vertical\n");
 			nRotateGame = 1;
 			sr_set_rotation(1);
@@ -114,7 +123,6 @@ static int Init()
 		if (BurnDrvGetFlags() & BDF_ORIENTATION_VERTICAL)
 		{
 			BurnDrvGetVisibleSize(&nVidImageHeight, &nVidImageWidth);
-			BurnDrvGetAspect(&GameAspectY, &GameAspectX);
 			printf("Vertical\n");
 			nRotateGame = 1;
 			display_w = nVidImageHeight * GameAspectX / GameAspectY;
@@ -342,20 +350,21 @@ static int Paint(int bValidate)
 	if (nRotateGame)
 	{
 		SDL_UpdateTexture(sdlTexture, NULL, pVidImage, nVidImagePitch);
-		if (nRotateGame && bFlipped)
+		if (bFlipped)
 		{
 			SDL_RenderCopyEx(sdlRenderer, sdlTexture, NULL, &dstrect, 90, NULL, SDL_FLIP_NONE);
 		}
-		if (nRotateGame && !bFlipped)
+		else
 		{
 			SDL_RenderCopyEx(sdlRenderer, sdlTexture, NULL, &dstrect, 270, NULL, SDL_FLIP_NONE);
 		}
 	}
 	else
 	{
-		SDL_LockTexture(sdlTexture, NULL, &pixels, &pitch);
-		memcpy(pixels, pVidImage, nVidImagePitch * nVidImageHeight);
-		SDL_UnlockTexture(sdlTexture);
+	//	SDL_LockTexture(sdlTexture, NULL, &pixels, &pitch);
+	//	memcpy(pixels, pVidImage, nVidImagePitch * nVidImageHeight);
+	//	SDL_UnlockTexture(sdlTexture);
+		SDL_UpdateTexture(sdlTexture, NULL, pVidImage, nVidImagePitch);
 		SDL_RenderCopy(sdlRenderer, sdlTexture, NULL, &dstrect);
 	}
 


### PR DESCRIPTION
- Add SDL_UpdateTexture instead of SDL_LockTexture / SDL_UnlockTexture
- Add SDL_WINDOWEVENT_CLOSE on pause game to quit
- GUI: change title to "Select Game..."
- GUI : add Filter "everything" by defaut
- GUI : fix background load on first start
- GUI : add number of games : filter and total
- GUI : move IMG_ReadXPLFromArray (not use yet)
- GUI : fix loading background title
- GUI : fix some typo
- SDL2 renderer : fix window size and force scale * 2
- SDL/SDL2: add volume support 
- SDL2 GUI : fix header and add HARDWARE_SEGA_SYSTEM24 in SEGA filter 

Preview :
![image](https://user-images.githubusercontent.com/36823759/102628569-2a6b6a00-414a-11eb-9475-ae20c802c386.png)
