### PR TITLE
1:1 pixel aspect ratio for vector games

### DIFF
--- a/src/burn/drv/pre90s/d_asteroids.cpp
+++ b/src/burn/drv/pre90s/d_asteroids.cpp
@@ -1193,7 +1193,7 @@ struct BurnDriver BurnDrvAsteroid = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, asteroidRomInfo, asteroidRomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AsteroidDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 // Asteroids (rev 2)
@@ -1218,7 +1218,7 @@ struct BurnDriver BurnDrvAsteroid2 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, asteroid2RomInfo, asteroid2RomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AsteroidDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1244,7 +1244,7 @@ struct BurnDriver BurnDrvAsteroid1 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, asteroid1RomInfo, asteroid1RomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AsteroidDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1284,7 +1284,7 @@ struct BurnDriver BurnDrvAsteroidb = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, asteroidbRomInfo, asteroidbRomName, NULL, NULL, NULL, NULL, AsteroidbInputInfo, AsteroidbDIPInfo,
 	AsteroidbInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1310,7 +1310,7 @@ struct BurnDriver BurnDrvSpcrocks = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, spcrocksRomInfo, spcrocksRomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AerolitosDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1336,7 +1336,7 @@ struct BurnDriver BurnDrvAerolitos = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, aerolitosRomInfo, aerolitosRomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AerolitosDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1380,7 +1380,7 @@ struct BurnDriver BurnDrvAsterock = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, asterockRomInfo, asterockRomName, NULL, NULL, NULL, NULL, AsterockInputInfo, AsterockDIPInfo,
 	AsterockInt, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1410,7 +1410,7 @@ struct BurnDriver BurnDrvAsterockv = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, asterockvRomInfo, asterockvRomName, NULL, NULL, NULL, NULL, AsterockInputInfo, AsterockDIPInfo,
 	AsterockInt, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1440,7 +1440,7 @@ struct BurnDriver BurnDrvMeteorite = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, meteoriteRomInfo, meteoriteRomName, NULL, NULL, NULL, NULL, AsterockInputInfo, AsterockDIPInfo,
 	AsterockInt, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1466,7 +1466,7 @@ struct BurnDriver BurnDrvMeteorts = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, meteortsRomInfo, meteortsRomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AsteroidDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1496,7 +1496,7 @@ struct BurnDriver BurnDrvMeteorho = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, meteorhoRomInfo, meteorhoRomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AsteroidDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 // Meteor (bootleg of Asteroids)
@@ -1525,7 +1525,7 @@ struct BurnDriver BurnDrvMeteorbl = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, meteorblRomInfo, meteorblRomName, NULL, NULL, NULL, NULL, AsterockInputInfo, AsterockDIPInfo,
 	AsterockInt, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1551,7 +1551,7 @@ struct BurnDriver BurnDrvHyperspc = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, hyperspcRomInfo, hyperspcRomName, NULL, NULL, NULL, NULL, AsteroidInputInfo, AsteroidDIPInfo,
 	AsteroidInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1579,7 +1579,7 @@ struct BurnDriver BurnDrvAstdelux = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, astdeluxRomInfo, astdeluxRomName, NULL, NULL, NULL, NULL, AstdeluxInputInfo, AstdeluxDIPInfo,
 	AstdeluxInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 // Asteroids Deluxe (rev 2)
@@ -1606,7 +1606,7 @@ struct BurnDriver BurnDrvAstdelux2 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, astdelux2RomInfo, astdelux2RomName, NULL, NULL, NULL, NULL, AstdeluxInputInfo, AstdeluxDIPInfo,
 	AstdeluxInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1634,7 +1634,7 @@ struct BurnDriver BurnDrvAstdelux1 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, astdelux1RomInfo, astdelux1RomName, NULL, NULL, NULL, NULL, AstdeluxInputInfo, AstdeluxDIPInfo,
 	AstdeluxInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1663,7 +1663,7 @@ struct BurnDriver BurnDrvLlander = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_MISC, 0,
 	NULL, llanderRomInfo, llanderRomName, NULL, NULL, NULL, NULL, LlanderInputInfo, LlanderDIPInfo,
 	LlanderInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1692,7 +1692,7 @@ struct BurnDriver BurnDrvLlander1 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_MISC, 0,
 	NULL, llander1RomInfo, llander1RomName, NULL, NULL, NULL, NULL, LlanderInputInfo, Llander1DIPInfo,
 	LlanderInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };
 
 
@@ -1720,5 +1720,5 @@ struct BurnDriverD BurnDrvLlandert = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_MISC, 0,
 	NULL, llandertRomInfo, llandertRomName, NULL, NULL, NULL, NULL, LlandertInputInfo, LlandertDIPInfo,
 	LlanderInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	600, 500, 4, 3
+	600, 500, 6, 5
 };

--- a/src/burn/drv/pre90s/d_bzone.cpp
+++ b/src/burn/drv/pre90s/d_bzone.cpp
@@ -1037,7 +1037,7 @@ struct BurnDriver BurnDrvBzone = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, bzoneRomInfo, bzoneRomName, NULL, NULL, NULL, NULL, BzoneInputInfo, BzoneDIPInfo,
 	BzoneInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	580, 400, 4, 3
+	580, 400, 580, 400
 };
 
 
@@ -1076,7 +1076,7 @@ struct BurnDriver BurnDrvBzonea = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, bzoneaRomInfo, bzoneaRomName, NULL, NULL, NULL, NULL, BzoneInputInfo, BzoneDIPInfo,
 	BzoneInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	580, 400, 4, 3
+	580, 400, 580, 400
 };
 
 
@@ -1116,7 +1116,7 @@ struct BurnDriver BurnDrvBzonec = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, bzonecRomInfo, bzonecRomName, NULL, NULL, NULL, NULL, BzoneInputInfo, BzoneDIPInfo,
 	BzoneInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	580, 400, 4, 3
+	580, 400, 580, 400
 };
 
 
@@ -1157,7 +1157,7 @@ struct BurnDriver BurnDrvBradley = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, bradleyRomInfo, bradleyRomName, NULL, NULL, NULL, NULL, BradleyInputInfo, BradleyDIPInfo,
 	BradleyInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	580, 400, 4, 3
+	580, 400, 580, 400
 };
 
 
@@ -1198,7 +1198,7 @@ struct BurnDriver BurnDrvRedbaron = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, redbaronRomInfo, redbaronRomName, NULL, NULL, NULL, NULL, RedbaronInputInfo, RedbaronDIPInfo,
 	RedbaronInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	520, 400, 4, 3
+	520, 400, 520, 400
 };
 
 static INT32 RedbaronaInit()
@@ -1246,5 +1246,5 @@ struct BurnDriver BurnDrvRedbarona = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, redbaronaRomInfo, redbaronaRomName, NULL, NULL, NULL, NULL, RedbaronInputInfo, RedbaronDIPInfo,
 	RedbaronaInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x2000,
-	520, 400, 4, 3
+	520, 400, 520, 400
 };

--- a/src/burn/drv/pre90s/d_omegrace.cpp
+++ b/src/burn/drv/pre90s/d_omegrace.cpp
@@ -552,7 +552,7 @@ struct BurnDriver BurnDrvOmegrace = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, omegraceRomInfo, omegraceRomName, NULL, NULL, NULL, NULL, OmegraceInputInfo, OmegraceDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
-	800, 800, 4, 3
+	800, 800, 1, 1
 };
 
 
@@ -581,7 +581,7 @@ struct BurnDriver BurnDrvOmegrace2 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, omegrace2RomInfo, omegrace2RomName, NULL, NULL, NULL, NULL, OmegraceInputInfo, OmegraceDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
-	800, 800, 4, 3
+	800, 800, 1, 1
 };
 
 
@@ -610,5 +610,5 @@ struct BurnDriver BurnDrvDeltrace = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, deltraceRomInfo, deltraceRomName, NULL, NULL, NULL, NULL, OmegraceInputInfo, OmegraceDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
-	800, 800, 4, 3
+	800, 800, 1, 1
 };

--- a/src/burn/drv/pre90s/d_quantum.cpp
+++ b/src/burn/drv/pre90s/d_quantum.cpp
@@ -627,7 +627,7 @@ struct BurnDriver BurnDrvQuantum = {
 	BDF_GAME_WORKING | BDF_ORIENTATION_VERTICAL, 2, HARDWARE_MISC_PRE90S, GBF_ACTION, 0,
 	NULL, quantumRomInfo, quantumRomName, NULL, NULL, NULL, NULL, QuantumInputInfo, QuantumDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x1000,
-	600, 900, 3, 4
+	600, 900, 2, 3
 };
 
 
@@ -660,7 +660,7 @@ struct BurnDriver BurnDrvQuantum1 = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_ORIENTATION_VERTICAL, 2, HARDWARE_MISC_PRE90S, GBF_ACTION, 0,
 	NULL, quantum1RomInfo, quantum1RomName, NULL, NULL, NULL, NULL, QuantumInputInfo, QuantumDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x1000,
-	600, 900, 3, 4
+	600, 900, 2, 3
 };
 
 
@@ -693,5 +693,5 @@ struct BurnDriver BurnDrvQuantump = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_ORIENTATION_VERTICAL, 2, HARDWARE_MISC_PRE90S, GBF_ACTION, 0,
 	NULL, quantumpRomInfo, quantumpRomName, NULL, NULL, NULL, NULL, QuantumInputInfo, QuantumDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x1000,
-	600, 900, 3, 4
+	600, 900, 2, 3
 };

--- a/src/burn/drv/pre90s/d_starwars.cpp
+++ b/src/burn/drv/pre90s/d_starwars.cpp
@@ -1196,7 +1196,7 @@ struct BurnDriver BurnDrvStarwars = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, starwarsRomInfo, starwarsRomName, NULL, NULL, NULL, NULL, StarwarsInputInfo, StarwarsDIPInfo,
 	StarwarsInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 32 * 256,
-	500, 400, 4, 3
+	500, 400, 5, 4
 };
 
 
@@ -1231,7 +1231,7 @@ struct BurnDriver BurnDrvStarwars1 = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, starwars1RomInfo, starwars1RomName, NULL, NULL, NULL, NULL, StarwarsInputInfo, StarwarsDIPInfo,
 	StarwarsInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 32 * 256,
-	500, 400, 4, 3
+	500, 400, 5, 4
 };
 
 
@@ -1266,7 +1266,7 @@ struct BurnDriver BurnDrvStarwarso = {
 	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, starwarsoRomInfo, starwarsoRomName, NULL, NULL, NULL, NULL, StarwarsInputInfo, StarwarsDIPInfo,
 	StarwarsInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 32 * 256,
-	500, 400, 4, 3
+	500, 400, 5, 4
 };
 
 
@@ -1347,7 +1347,7 @@ struct BurnDriver BurnDrvEsb = {
 	BDF_GAME_WORKING, 2, HARDWARE_MISC_PRE90S, GBF_SHOOT, 0,
 	NULL, esbRomInfo, esbRomName, NULL, NULL, NULL, NULL, StarwarsInputInfo, EsbDIPInfo,
 	EsbInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 32 * 256,
-	500, 400, 4, 3
+	500, 400, 5, 4
 };
 
 


### PR DESCRIPTION
all those vector games don't have smooth lines at the moment, this is especially visible if you use the hires mode and look at some scrolling (watch letters in starwars intro, or landscape in bzone), setting pixel aspect ratio to 1:1 (display aspect ratio to width:height) everywhere seems to fix this issue.

btw, i did this PR without merging it because i'm not sure about this solution, my other theory would be that current 4:3 display aspect ratios are actually fine, but the line drawing algorythm need to somehow account for it.