### PR TITLE
Feature/neogeo coins problem

### DIFF
--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -2097,7 +2097,12 @@ static void WriteIO1(INT32 nOffset, UINT8 byteValue)
 		case 0xE1:
 //			bprintf(PRINT_NORMAL, _T("  - Chute 2 coin lockout -> Low / Input bank 1 selected (0x%02X).\n"), byteValue);
 // 			This was previously + 8, fixes MVS Fighting Games coin issue!
-			NeoInputBank = NeoInput + 0;
+			if (nNeoControlConfig == HARDWARE_SNK_4_JOYSTICKS) {
+				NeoInputBank = NeoInput + 8;
+			}
+			else{
+				NeoInputBank = NeoInput + 0;
+			}
 			break;
 		case 0xE3:
 //			bprintf(PRINT_NORMAL, _T("  - Chute 2 coin lockout -> Low (0x%02X).\n"), byteValue);

--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -4519,10 +4519,10 @@ INT32 NeoRender()
 
 inline static void NeoClearOpposites(UINT8* nJoystickInputs)
 {
-	// Must Debug to Check what's going on
-	// 0x03 to Binary = 00000011 (Up and Down)
-	// 0x0C to Binary = 00001100 (Left and Right)
-	// I would add a SOCD Here lol
+	// 0x03 to Binary = 00000011 (Up and Down enabled)
+	// 0x0C to Binary = 00001100 (Left and Right enabled)
+	// SOCD Option in Inputs config would be appreciated.
+	// Standard SOCD Config is Up + Down = Up, Left+Right = Neutral
 	bool SOCD = false;
 	if ((*nJoystickInputs & 0x03) == 0x03) {
 		*nJoystickInputs &= ~0x03;
@@ -4535,7 +4535,7 @@ inline static void NeoClearOpposites(UINT8* nJoystickInputs)
 
 static void NeoStandardInputs(INT32 nBank)
 {
-	if (nBank) { 													// Four Player?
+	if (nBank) { 													// Four Player? HARDWARE_SNK_4_JOYSTICKS
 		NeoInput[ 8] = 0x00;					   					// Player 1
 		NeoInput[ 9] = 0x00;				   						// Player 2
 		NeoInput[10] = 0x00;				   						// Buttons

--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -4518,7 +4518,7 @@ inline static void NeoClearOpposites(UINT8* nJoystickInputs)
 	// 0x03 to Binary = 00000011 (Up and Down)
 	// 0x0C to Binary = 00001100 (Left and Right)
 	// I would add a SOCD Here lol
-	bool SOCD = true;
+	bool SOCD = false;
 	if ((*nJoystickInputs & 0x03) == 0x03) {
 		*nJoystickInputs &= ~0x03;
 		if (SOCD) *nJoystickInputs |= 0x01;

--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -2096,7 +2096,8 @@ static void WriteIO1(INT32 nOffset, UINT8 byteValue)
 
 		case 0xE1:
 //			bprintf(PRINT_NORMAL, _T("  - Chute 2 coin lockout -> Low / Input bank 1 selected (0x%02X).\n"), byteValue);
-			NeoInputBank = NeoInput + 8;
+// 			This was previously + 8, fixes MVS Fighting Games coin issue!
+			NeoInputBank = NeoInput + 0;
 			break;
 		case 0xE3:
 //			bprintf(PRINT_NORMAL, _T("  - Chute 2 coin lockout -> Low (0x%02X).\n"), byteValue);

--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -4513,8 +4513,14 @@ INT32 NeoRender()
 
 inline static void NeoClearOpposites(UINT8* nJoystickInputs)
 {
+	// Must Debug to Check what's going on
+	// 0x03 to Binary = 00000011 (Up and Down)
+	// 0x0C to Binary = 00001100 (Left and Right)
+	// I would add a SOCD Here lol
+	bool SOCD = true;
 	if ((*nJoystickInputs & 0x03) == 0x03) {
 		*nJoystickInputs &= ~0x03;
+		if (SOCD) *nJoystickInputs |= 0x01;
 	}
 	if ((*nJoystickInputs & 0x0C) == 0x0C) {
 		*nJoystickInputs &= ~0x0C;
@@ -4523,7 +4529,7 @@ inline static void NeoClearOpposites(UINT8* nJoystickInputs)
 
 static void NeoStandardInputs(INT32 nBank)
 {
-	if (nBank) {
+	if (nBank) { 													// Four Player?
 		NeoInput[ 8] = 0x00;					   					// Player 1
 		NeoInput[ 9] = 0x00;				   						// Player 2
 		NeoInput[10] = 0x00;				   						// Buttons
@@ -4540,7 +4546,7 @@ static void NeoStandardInputs(INT32 nBank)
 		if (NeoDiag[1]) {
 			NeoInput[13] |= 0x80;
 		}
-	} else {
+	} else {														// Two Players (Fighting Gaemz) most of the time this is used
 		NeoInput[ 0] = 0x00;					   					// Player 1
 		NeoInput[ 1] = 0x00;					   					// Player 2
 		NeoInput[ 2] = 0x00;					   					// Buttons

--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -4552,7 +4552,7 @@ static void NeoStandardInputs(INT32 nBank)
 		if (NeoDiag[1]) {
 			NeoInput[13] |= 0x80;
 		}
-	} else {														// Two Players (Fighting Gaemz) most of the time this is used
+	} else {														// Two Players (most of the time this is used)
 		NeoInput[ 0] = 0x00;					   					// Player 1
 		NeoInput[ 1] = 0x00;					   					// Player 2
 		NeoInput[ 2] = 0x00;					   					// Buttons


### PR DESCRIPTION
Added a condition for the Coin Lockout Problem.. it seems that it switched Input Banks for whatever reason..

The only condition that the input bank was changed/shifted was the SNK_4_JOYSTICKS case.

Also SOCD would be appreciated for keyboard players. It's not a must but with a few lines of code i got it running on NeoGeo :)

Needs testing in more games.. i can't test all of them :/