### PR TITLE
d_cop01.cpp: Fix Mighty Guy some sound issues

### DIFF
--- a/src/burn/drv/pre90s/d_cop01.cpp
+++ b/src/burn/drv/pre90s/d_cop01.cpp
@@ -966,6 +966,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		SCAN_VAR(prot_dac_freq);
 		SCAN_VAR(prot_dac_playing);
 		SCAN_VAR(prot_const90);
+		SCAN_VAR(prot_timer_rate);
 	}
 
 	return 0;


### PR DESCRIPTION
Fixed various sound issues in Might Guy so that it sounds almost exactly like PCB.

- BGM tempo was unstable.
  - The frequency setting of the DAC and the clock of the timer are now linked.
  - When the sound driver changed the DAC's clock, the loop count ($C010) that calls the timer in anticipation of this action was fluctuating in the range of 2 to 4 times.
- The playback frequency of the DAC is incorrect.
  - I changed the frequency so that the sound plays as per the PCB.
- Implemented a protect command 0x11 to stop the DAC.
  - This is needed to stop the DAC when the psycho gun is stoppedv
- Bug in which some DAC sound effects did not sound correctly.
  - This is not in MAME, but seems to be a problem when it was ported to FinalBurn.
  - The DAC data reference address mask was wrong.