### PR TITLE
increase default dial speed in Forgotten World

### DIFF
--- a/src/burn/drv/capcom/cps_rw.cpp
+++ b/src/burn/drv/capcom/cps_rw.cpp
@@ -533,19 +533,19 @@ INT32 CpsRwGetInp()
 	if (Forgottn) {
 		// Handle analog controls
 		if (fFakeDip & 0x80) {
-			if (CpsDigUD[0]) nDial055 += 4080; // p1
-			if (CpsDigUD[1]) nDial055 -= 4080;
-			if (CpsDigUD[2]) nDial05d += 4080; // p2
-			if (CpsDigUD[3]) nDial05d -= 4080;
-			nDial055 += (INT32)((INT16)CpsInp055) * 4;
-			nDial05d += (INT32)((INT16)CpsInp05d) * 4;
+			if (CpsDigUD[0]) nDial055 += 1<<13; // p1
+			if (CpsDigUD[1]) nDial055 -= 1<<13;
+			if (CpsDigUD[2]) nDial05d += 1<<13; // p2
+			if (CpsDigUD[3]) nDial05d -= 1<<13;
+			nDial055 += (INT32)((INT16)CpsInp055)<<3;
+			nDial05d += (INT32)((INT16)CpsInp05d)<<3;
 		} else {
-			if (CpsDigUD[0]) nDial055 -= 4080; // p1
-			if (CpsDigUD[1]) nDial055 += 4080;
-			if (CpsDigUD[2]) nDial05d -= 4080; // p2
-			if (CpsDigUD[3]) nDial05d += 4080;
-			nDial055 -= (INT32)((INT16)CpsInp055) * 4;
-			nDial05d -= (INT32)((INT16)CpsInp05d) * 4;
+			if (CpsDigUD[0]) nDial055 -= 1<<13; // p1
+			if (CpsDigUD[1]) nDial055 += 1<<13;
+			if (CpsDigUD[2]) nDial05d -= 1<<13; // p2
+			if (CpsDigUD[3]) nDial05d += 1<<13;
+			nDial055 -= (INT32)((INT16)CpsInp055)<<3;
+			nDial05d -= (INT32)((INT16)CpsInp05d)<<3;
 		}
 	}
 	


### PR DESCRIPTION
@dinkc64 the current 100% dial speed for this game feels wrong, if you look at the attract mode for some time, you'll see a player with a flamethrower rotating a lot faster than what we allow at 100% analog speed, this is only a test fix because i guess we should actually move to `ProcessAnalog` here ?