### PR TITLE
Spectrum - lareliquia: crc/size fix

### DIFF
--- a/src/burn/drv/spectrum/d_spectrum.cpp
+++ b/src/burn/drv/spectrum/d_spectrum.cpp
@@ -21770,7 +21770,7 @@ struct BurnDriver BurnSpecJetpacrx = {
 // La Reliquia (HB)
 
 static struct BurnRomInfo SpecLareliquiaRomDesc[] = {
-	{ "La Reliquia (2020)(Angel Colaso).tap", 46629, 0x183c5158, BRF_ESS | BRF_PRG },
+	{ "La Reliquia (2020)(Angel Colaso).tap", 46885, 0x8164dbff, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(SpecLareliquia, SpecLareliquia, Spec128)


### PR DESCRIPTION
Correct crc and size for lareliquia, previous one is the same than english version (relic)

2021/07/04 ~ 11h41 (utc -3)