### PR TITLE
Updated main.cpp to fix the broken Mortal Kombat audio

### DIFF
--- a/src/burner/win32/main.cpp
+++ b/src/burner/win32/main.cpp
@@ -1132,6 +1132,10 @@ int ProcessCmdLine()
 		MenuEnableItems();
 	}
 
+	// audio pitch fix for Mortal Kombat games
+	MediaExit();
+	MediaInit();
+
 	return 0;
 }
 


### PR DESCRIPTION
The Mortal Kombat games would play audio at the wrong speed and pitch when being loaded from via a command line argument (EG: "umk3 -w"). These two lines of code restart the audio subsystem and fix the audio pitch fix for all Mortal Kombat games.