### PR TITLE
Allow cross compiling on EmuELEC aarch64 (possibly others?)

### DIFF
--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -50,7 +50,7 @@ srcdir	= src/
 include makefile.burn_rules
 
 # Platform stuff
-alldir	+= 	burner burner/sdl burner/sdl dep/libs/libpng dep/libs/lib7z dep/libs/zlib intf intf/video \
+alldir	+= 	burner burner/sdl burner/sdl dep/libs/lib7z dep/libs/zlib intf intf/video \
 			intf/video/scalers 	intf/video/sdl intf/audio intf/audio/sdl intf/input intf/input/sdl intf/cd intf/cd/sdl \
 			intf/perfcount intf/perfcount/sdl dep/generated
 
@@ -61,15 +61,21 @@ depobj	+= 	neocdlist.o \
 			adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o gzwrite.o infback.o inffast.o inflate.o inftrees.o \
 			trees.o uncompr.o zutil.o \
 			\
-			png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o pngrio.o pngrtran.o pngrutil.o pngset.o pngtrans.o pngwio.o \
-			pngwrite.o pngwtran.o pngwutil.o \
-			\
 			aud_dsp.o aud_interface.o cd_interface.o inp_interface.o interface.o lowpass2.o  vid_interface.o \
 			vid_support.o \
 			\
 			inp_sdl2.o aud_sdl.o support_paths.o ips_manager.o scrn.o \
 			cd_sdl2.o config.o main.o run.o stringset.o bzip.o drv.o media.o sdl2_gui_ingame.o sdl2_gui_common.o \
 			inpdipsw.o vid_sdl2opengl.o vid_sdl2.o dynhuff.o replay.o sdl2_gui.o sdl2_inprint.o input_sdl2.o stated.o
+
+ifndef FORCE_SYSTEM_LIBPNG
+alldir	+= 	dep/libs/libpng
+
+depobj	+= 	png.o \ 
+            \
+            pngerror.o pngget.o pngmem.o pngpread.o pngread.o pngrio.o pngrtran.o pngrutil.o pngset.o pngtrans.o pngwio.o \
+			pngwrite.o pngwtran.o pngwutil.o
+endif
 
 ifdef FORCE_PULSE_AUDIO
 alldir	+= 	intf/audio/linux
@@ -100,6 +106,10 @@ ifdef WINDOWS
 lib	= -lstdc++ `sdl2-config --libs` -lopengl32 -lSDL2_image -lm
 else
 lib	= -lstdc++ `sdl2-config --libs` -lGL -lSDL2_image -lm
+endif
+
+ifdef FORCE_SYSTEM_LIBPNG
+lib += -lpng
 endif
 
 ifdef FORCE_PULSE_AUDIO
@@ -178,6 +188,17 @@ endif
 CXX	= $(CC)
 LD	= $(CC)
 AS	= nasm
+
+# We need to compile the tools with host to make them available while cross compiling.
+# Cross compiling in EmuELEC has this variables set by default, HOST_CC, HOST_CXXFLAGS, HOST_LDFLAGS, HOST_CFLAGS
+# But if HOST_CC is not defined we assume not crosscompiling.
+
+ifeq ($(HOST_CC),)
+HOST_CC := $(CC)
+HOST_CXXFLAGS := $(CXXFLAGS)
+HOST_LDFLAGS := $(LDFLAGS)
+HOST_CFLAGS := $(CFLAGS)
+endif
 
 #LDFLAGS	= -static
 
@@ -446,7 +467,7 @@ $(objdir)dep/generated/m68kops.h $(objdir)dep/generated/m68kops.c: $(objdir)cpu/
 
 $(objdir)cpu/m68k/m68kmake: $(srcdir)cpu/m68k/m68kmake.c
 	@echo Compiling Musashi MC680x0 core \(m68kmake.c\)...
-	@$(CC) $(CFLAGS) $(srcdir)cpu/m68k/m68kmake.c -o $(objdir)cpu/m68k/m68kmake -Dmain=main
+	@$(HOST_CC) $(HOST_CFLAGS) $(srcdir)cpu/m68k/m68kmake.c -o $(objdir)cpu/m68k/m68kmake -Dmain=main
 
 
 #
@@ -457,7 +478,7 @@ ctv.d ctv.o:	$(ctv.h)
 
 $(ctv.h):	ctv_make.cpp
 	@echo Generating $(srcdir)dep/generated/$(@F)...
-	@$(CC) $(CXXFLAGS) $(LDFLAGS) $< \
+	@$(HOST_CC) $(HOST_CXXFLAGS) $(HOST_LDFLAGS) $< \
 		-o $(subst $(srcdir),$(objdir),$(<D))/$(<F:.cpp=.exe)  -Dmain=main
 	@$(subst $(srcdir),$(objdir),$(<D))/$(<F:.cpp=.exe) >$@
 
@@ -514,7 +535,7 @@ pgm_draw.d pgm_draw.o:	$(pgm_sprite.h)
 
 $(pgm_sprite.h):	pgm_sprite_create.cpp
 	@echo Generating $(srcdir)dep/generated/$(@F)...
-	@$(CC) $(CXXFLAGS) $(LDFLAGS) $< \
+	@$(HOST_CC) $(HOST_CXXFLAGS) $(HOST_LDFLAGS) $< \
 		-o $(subst $(srcdir),$(objdir),$(<D))/$(<F:.cpp=.exe)  -Dmain=main
 	@$(subst $(srcdir),$(objdir),$(<D))/$(<F:.cpp=.exe) >$@
 

--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -189,9 +189,9 @@ CXX	= $(CC)
 LD	= $(CC)
 AS	= nasm
 
-# We need to compile the tools with host to make them available while cross compiling.
-# Cross compiling in EmuELEC has this variables set by default, HOST_CC, HOST_CXXFLAGS, HOST_LDFLAGS, HOST_CFLAGS
-# But if HOST_CC is not defined we assume not crosscompiling.
+# We need to compile the tools with host to make them available while cross-compiling.
+# Cross-compiling in EmuELEC has these variables set by default, HOST_CC, HOST_CXXFLAGS, HOST_LDFLAGS, HOST_CFLAGS
+# But if HOST_CC is not defined we assume not cross-compiling.
 
 ifeq ($(HOST_CC),)
 HOST_CC := $(CC)


### PR DESCRIPTION
Allows EmuELEC aarch64 to cross compile FBNEO SDL2, by allowing it use system libpng and compiling the tools needed with host_cc.

The reason we need system libpng (enabled by FORCE_SYSTEM_LIBPNG) is because the one included complains about NEON support. 

Please review and test in other environments, as I have only tested this while cross compiling but the changes should not interfere with regular builds. 

NOTE: Since FBneo is not available with SDL2 GLES, it needs gl4es as external dependency to work in EmuELEC .