### PR TITLE
Fixed compilation failure (vc cmd)

### DIFF
--- a/makefile.vc
+++ b/makefile.vc
@@ -105,7 +105,7 @@ srcdir	= src/
 include makefile.burn_rules
 include makefile.burner_win32_rules
 
-incdir	= $(foreach dir,$(alldir),/I$(srcdir)$(dir)) /I$(objdir)dep/generated
+incdir	= $(foreach dir,$(alldir),/I$(srcdir)$(dir)) /I$(objdir)dep/generated /I$(srcdir)dep/mingw/include/directx9 /I$(srcdir)dep/vc/include/xaudio2
 
 ifdef UNICODE
 # lib	= unicows.lib
@@ -146,7 +146,7 @@ allobj	= $(objdir)cpu/m68k/m68kcpu.o $(objdir)cpu/m68k/m68kops.o $(objdir)burner
 	  $(foreach file,$(autobj:.o=.asm), \
 		$(foreach dir,$(alldir),$(subst $(srcdir),$(objdir), \
 		$(firstword $(subst .asm,.o,$(wildcard $(srcdir)$(dir)/$(file)))))))
-		
+
 ifdef BUILD_A68K
 allobj += $(a68k.o)
 endif
@@ -226,7 +226,7 @@ ifdef BUILD_X86_ASM
 endif
 
 ifdef BUILD_X64_EXE
-	DEF := $(DEF) /DBUILD_X64_EXE /DXBYAK_NO_OP_NAMES /DMIPS3_X64_DRC
+	DEF := $(DEF) /DBUILD_X64_EXE # /DXBYAK_NO_OP_NAMES /DMIPS3_X64_DRC
 endif
 
 ifdef BUILD_VS_XP_TARGET


### PR DESCRIPTION
[Tip] do not use: -j[n] parallel compilation
[1] add incdir - dx9 / xaudio2
[2] disable DMIPS3_X64_DRC (form makefile.burn_rules)