### PR TITLE
Add right-stick rotary support to other drivers

### DIFF
--- a/src/burn/drv/dataeast/d_dec0.cpp
+++ b/src/burn/drv/dataeast/d_dec0.cpp
@@ -2501,7 +2501,7 @@ static void SuperJoy2Rotate() {
 	/// let's try not to over-optimize
 	UINT8 FakeDrvInputPort0[4] = {0, 0, 0, 0};
 	UINT8 FakeDrvInputPort1[4] = {0, 0, 0, 0};
-	UINT8 NeedsAutoFire[2] = {0, 0};
+	UINT8 NeedsSecondStick[2] = {0, 0};
 
 	// prepare for right-stick rotation
 	// this is not especially readable though
@@ -2509,12 +2509,14 @@ static void SuperJoy2Rotate() {
 		for (INT32 n = 0; n < 4; n++) {
 			UINT8* RotationInput = (!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0];
 			RotationInput[n] = DrvFakeInput[6 + i*4 + n];
-			NeedsAutoFire[i] |= RotationInput[n];
+			NeedsSecondStick[i] |= RotationInput[n];
 		}
 	}
 
 	for (INT32 i = 0; i < 2; i++) { // p1 = 0, p2 = 1
-		if (NeedsAutoFire[i]) { // or using Second Stick
+		if (!NeedsSecondStick[i])
+			nAutoFireCounter[i] = 0;
+		if (NeedsSecondStick[i]) { // or using Second Stick
 			UINT8 rot = Joy2Rotate(((!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0]));
 			if (rot != 0xff) {
 				nRotateTarget[i] = rot * rotate_gunpos_multiplier;
@@ -5841,6 +5843,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		SCAN_VAR(nRotateTry);
 		SCAN_VAR(nRotateHoldInput);
 		SCAN_VAR(nAutoFireCounter);
+		SCAN_VAR(nRotateTime);
 
 		SCAN_VAR(nExtraCycles);
 	}

--- a/src/burn/drv/konami/d_jackal.cpp
+++ b/src/burn/drv/konami/d_jackal.cpp
@@ -36,7 +36,7 @@ static UINT8 DrvJoy1[8];
 static UINT8 DrvJoy2[8];
 static UINT8 DrvJoy3[8];
 static UINT8 DrvInputs[3];
-static UINT8 DrvDips[3];
+static UINT8 DrvDips[4];
 static UINT8 DrvReset;
 
 static INT32 watchdog;
@@ -49,13 +49,14 @@ static INT32 bootleg = 0;
 //static UINT32 nRotateTime[2] = { 0, 0 };
 //static UINT8 DrvFakeInput[4] = { 0, 0, 0, 0 };
 // Rotation stuff! -dink
-static UINT8  DrvFakeInput[6]       = {0, 0, 0, 0, 0, 0};
+static UINT8  DrvFakeInput[14]      = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}; // 0-5 legacy; 6-9 P1, 10-13 P2
 static UINT8  nRotateHoldInput[2]   = {0, 0};
 static INT32  nRotate[2]            = {0, 0};
 static INT32  nRotateTarget[2]      = {0, 0};
 static INT32  nRotateTry[2]         = {0, 0};
 static UINT32 nRotateTime[2]        = {0, 0};
 static UINT8  game_rotates = 0;
+static UINT8  nAutoFireCounter[2] 	= {0, 0};
 
 static struct BurnInputInfo DrvInputList[] = {
 	{"P1 Coin",			BIT_DIGITAL,	DrvJoy3 + 0,	"p1 coin"	},
@@ -97,6 +98,10 @@ static struct BurnInputInfo DrvrotateInputList[] = {
 	{"P1 Rotate Left",     BIT_DIGITAL, DrvFakeInput + 0, "p1 rotate left" },
 	{"P1 Rotate Right",    BIT_DIGITAL, DrvFakeInput + 1, "p1 rotate right" },
 	{"P1 Button 3 (rotate)" , BIT_DIGITAL  , DrvFakeInput + 4,  "p1 fire 3" },
+	{"P1 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 8,  "p1 up 2" }, // 6
+	{"P1 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 9,  "p1 down 2" }, // 7
+	{"P1 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 6,  "p1 left 2" }, // 8
+	{"P1 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 7,  "p1 right 2" }, // 9
 
 	{"P2 Coin",			BIT_DIGITAL,	DrvJoy3 + 1,	"p2 coin"	},
 	{"P2 Start",		BIT_DIGITAL,	DrvJoy3 + 4,	"p2 start"	},
@@ -109,12 +114,17 @@ static struct BurnInputInfo DrvrotateInputList[] = {
 	{"P2 Rotate Left",     BIT_DIGITAL, DrvFakeInput + 2, "p2 rotate left" },
 	{"P2 Rotate Right",    BIT_DIGITAL, DrvFakeInput + 3, "p2 rotate right" },
 	{"P2 Button 3 (rotate)" , BIT_DIGITAL  , DrvFakeInput + 5,  "p2 fire 3" },
+	{"P2 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 12, "p2 up 2" },
+	{"P2 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 13, "p2 down 2" },
+	{"P2 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 10, "p2 left 2" },
+	{"P2 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 11, "p2 right 2" },
 
 	{"Reset",			BIT_DIGITAL,	&DrvReset,		"reset"		},
 	{"Service",			BIT_DIGITAL,	DrvJoy3 + 2,	"service"	},
 	{"Dip A",			BIT_DIPSWITCH,	DrvDips + 0,	"dip"		},
 	{"Dip B",			BIT_DIPSWITCH,	DrvDips + 1,	"dip"		},
 	{"Dip C",			BIT_DIPSWITCH,	DrvDips + 2,	"dip"		},
+	{"Dip D", 			BIT_DIPSWITCH, 	DrvDips + 3, 	"dip"       },
 };
 
 STDINPUTINFO(Drvrotate)
@@ -200,79 +210,87 @@ STDDIPINFO(Drv)
 
 static struct BurnDIPInfo DrvrotateDIPList[]=
 {
-	{0x18, 0xff, 0xff, 0xff, NULL					},
-	{0x19, 0xff, 0xff, 0xff, NULL					},
-	{0x1a, 0xff, 0xff, 0x20, NULL					},
+	DIP_OFFSET(0x20)
+
+	{0x00, 0xff, 0xff, 0xff, NULL					},
+	{0x01, 0xff, 0xff, 0xff, NULL					},
+	{0x02, 0xff, 0xff, 0x20, NULL					},
+	{0x03, 0xff, 0xff, 0x00, NULL                   },
 
 	{0   , 0xfe, 0   ,   16, "Coin A"				},
-	{0x18, 0x01, 0x0f, 0x02, "4 Coins 1 Credit"			},
-	{0x18, 0x01, 0x0f, 0x05, "3 Coins 1 Credit"			},
-	{0x18, 0x01, 0x0f, 0x06, "2 Coins 1 Credit"			},
-	{0x18, 0x01, 0x0f, 0x04, "3 Coins 2 Credits"			},
-	{0x18, 0x01, 0x0f, 0x01, "4 Coins 3 Credits"			},
-	{0x18, 0x01, 0x0f, 0x0f, "1 Coin  1 Credit"			},
-	{0x18, 0x01, 0x0f, 0x03, "3 Coins 4 Credits"			},
-	{0x18, 0x01, 0x0f, 0x07, "2 Coins 3 Credits"			},
-	{0x18, 0x01, 0x0f, 0x0e, "1 Coin  2 Credits"			},
-	{0x18, 0x01, 0x0f, 0x06, "2 Coins 5 Credits"			},
-	{0x18, 0x01, 0x0f, 0x0d, "1 Coin  3 Credits"			},
-	{0x18, 0x01, 0x0f, 0x0c, "1 Coin  4 Credits"			},
-	{0x18, 0x01, 0x0f, 0x0b, "1 Coin  5 Credits"			},
-	{0x18, 0x01, 0x0f, 0x0a, "1 Coin  6 Credits"			},
-	{0x18, 0x01, 0x0f, 0x09, "1 Coin  7 Credits"			},
-	{0x18, 0x01, 0x0f, 0x00, "Free Play"				},
+	{0x00, 0x01, 0x0f, 0x02, "4 Coins 1 Credit"			},
+	{0x00, 0x01, 0x0f, 0x05, "3 Coins 1 Credit"			},
+	{0x00, 0x01, 0x0f, 0x06, "2 Coins 1 Credit"			},
+	{0x00, 0x01, 0x0f, 0x04, "3 Coins 2 Credits"			},
+	{0x00, 0x01, 0x0f, 0x01, "4 Coins 3 Credits"			},
+	{0x00, 0x01, 0x0f, 0x0f, "1 Coin  1 Credit"			},
+	{0x00, 0x01, 0x0f, 0x03, "3 Coins 4 Credits"			},
+	{0x00, 0x01, 0x0f, 0x07, "2 Coins 3 Credits"			},
+	{0x00, 0x01, 0x0f, 0x0e, "1 Coin  2 Credits"			},
+	{0x00, 0x01, 0x0f, 0x06, "2 Coins 5 Credits"			},
+	{0x00, 0x01, 0x0f, 0x0d, "1 Coin  3 Credits"			},
+	{0x00, 0x01, 0x0f, 0x0c, "1 Coin  4 Credits"			},
+	{0x00, 0x01, 0x0f, 0x0b, "1 Coin  5 Credits"			},
+	{0x00, 0x01, 0x0f, 0x0a, "1 Coin  6 Credits"			},
+	{0x00, 0x01, 0x0f, 0x09, "1 Coin  7 Credits"			},
+	{0x00, 0x01, 0x0f, 0x00, "Free Play"				},
 
 	{0   , 0xfe, 0   ,   16, "Coin B"				},
-	{0x18, 0x01, 0xf0, 0x20, "4 Coins 1 Credit"			},
-	{0x18, 0x01, 0xf0, 0x50, "3 Coins 1 Credit"			},
-	{0x18, 0x01, 0xf0, 0x60, "2 Coins 1 Credit"			},
-	{0x18, 0x01, 0xf0, 0x40, "3 Coins 2 Credits"			},
-	{0x18, 0x01, 0xf0, 0x10, "4 Coins 3 Credits"			},
-	{0x18, 0x01, 0xf0, 0xf0, "1 Coin  1 Credit"			},
-	{0x18, 0x01, 0xf0, 0x30, "3 Coins 4 Credits"			},
-	{0x18, 0x01, 0xf0, 0x70, "2 Coins 3 Credits"			},
-	{0x18, 0x01, 0xf0, 0xe0, "1 Coin  2 Credits"			},
-	{0x18, 0x01, 0xf0, 0x60, "2 Coins 5 Credits"			},
-	{0x18, 0x01, 0xf0, 0xd0, "1 Coin  3 Credits"			},
-	{0x18, 0x01, 0xf0, 0xc0, "1 Coin  4 Credits"			},
-	{0x18, 0x01, 0xf0, 0xb0, "1 Coin  5 Credits"			},
-	{0x18, 0x01, 0xf0, 0xa0, "1 Coin  6 Credits"			},
-	{0x18, 0x01, 0xf0, 0x90, "1 Coin  7 Credits"			},
-	{0x18, 0x01, 0xf0, 0x00, "No Coin B"				},
+	{0x00, 0x01, 0xf0, 0x20, "4 Coins 1 Credit"			},
+	{0x00, 0x01, 0xf0, 0x50, "3 Coins 1 Credit"			},
+	{0x00, 0x01, 0xf0, 0x60, "2 Coins 1 Credit"			},
+	{0x00, 0x01, 0xf0, 0x40, "3 Coins 2 Credits"			},
+	{0x00, 0x01, 0xf0, 0x10, "4 Coins 3 Credits"			},
+	{0x00, 0x01, 0xf0, 0xf0, "1 Coin  1 Credit"			},
+	{0x00, 0x01, 0xf0, 0x30, "3 Coins 4 Credits"			},
+	{0x00, 0x01, 0xf0, 0x70, "2 Coins 3 Credits"			},
+	{0x00, 0x01, 0xf0, 0xe0, "1 Coin  2 Credits"			},
+	{0x00, 0x01, 0xf0, 0x60, "2 Coins 5 Credits"			},
+	{0x00, 0x01, 0xf0, 0xd0, "1 Coin  3 Credits"			},
+	{0x00, 0x01, 0xf0, 0xc0, "1 Coin  4 Credits"			},
+	{0x00, 0x01, 0xf0, 0xb0, "1 Coin  5 Credits"			},
+	{0x00, 0x01, 0xf0, 0xa0, "1 Coin  6 Credits"			},
+	{0x00, 0x01, 0xf0, 0x90, "1 Coin  7 Credits"			},
+	{0x00, 0x01, 0xf0, 0x00, "No Coin B"				},
 
 	{0   , 0xfe, 0   ,    4, "Lives"				},	
-	{0x19, 0x01, 0x03, 0x03, "2"					},
-	{0x19, 0x01, 0x03, 0x02, "3"					},
-	{0x19, 0x01, 0x03, 0x01, "4"					},
-	{0x19, 0x01, 0x03, 0x00, "7"					},
+	{0x01, 0x01, 0x03, 0x03, "2"					},
+	{0x01, 0x01, 0x03, 0x02, "3"					},
+	{0x01, 0x01, 0x03, 0x01, "4"					},
+	{0x01, 0x01, 0x03, 0x00, "7"					},
 
 	{0   , 0xfe, 0   ,    4, "Bonus Life"				},
-	{0x19, 0x01, 0x18, 0x18, "30k 150k"				},
-	{0x19, 0x01, 0x18, 0x10, "50k 200k"				},
-	{0x19, 0x01, 0x18, 0x08, "30k"					},
-	{0x19, 0x01, 0x18, 0x00, "50k"					},
+	{0x01, 0x01, 0x18, 0x18, "30k 150k"				},
+	{0x01, 0x01, 0x18, 0x10, "50k 200k"				},
+	{0x01, 0x01, 0x18, 0x08, "30k"					},
+	{0x01, 0x01, 0x18, 0x00, "50k"					},
 
 	{0   , 0xfe, 0   ,    4, "Difficulty"				},
-	{0x19, 0x01, 0x60, 0x60, "Easy"					},
-	{0x19, 0x01, 0x60, 0x40, "Normal"				},
-	{0x19, 0x01, 0x60, 0x20, "Difficult"				},
-	{0x19, 0x01, 0x60, 0x00, "Very Difficult"			},
+	{0x01, 0x01, 0x60, 0x60, "Easy"					},
+	{0x01, 0x01, 0x60, 0x40, "Normal"				},
+	{0x01, 0x01, 0x60, 0x20, "Difficult"				},
+	{0x01, 0x01, 0x60, 0x00, "Very Difficult"			},
 
 	{0   , 0xfe, 0   ,    2, "Demo Sounds"				},
-	{0x19, 0x01, 0x80, 0x80, "Off"					},
-	{0x19, 0x01, 0x80, 0x00, "On"					},
+	{0x01, 0x01, 0x80, 0x80, "Off"					},
+	{0x01, 0x01, 0x80, 0x00, "On"					},
 
 	{0   , 0xfe, 0   ,    2, "Flip Screen"				},
-	{0x1a, 0x01, 0x20, 0x20, "Off"					},
-	{0x1a, 0x01, 0x20, 0x00, "On"					},
+	{0x02, 0x01, 0x20, 0x20, "Off"					},
+	{0x02, 0x01, 0x20, 0x00, "On"					},
 
 	{0   , 0xfe, 0   ,    2, "Sound Adjustment"			},
-	{0x1a, 0x01, 0x40, 0x00, "Upright"				},
-	{0x1a, 0x01, 0x40, 0x40, "Cocktail"				},
+	{0x02, 0x01, 0x40, 0x00, "Upright"				},
+	{0x02, 0x01, 0x40, 0x40, "Cocktail"				},
 
 	{0   , 0xfe, 0   ,    2, "Sound Mode"				},
-	{0x1a, 0x01, 0x80, 0x00, "Stereo"				},
-	{0x1a, 0x01, 0x80, 0x80, "Mono"					},
+	{0x02, 0x01, 0x80, 0x00, "Stereo"				},
+	{0x02, 0x01, 0x80, 0x80, "Mono"					},
+
+	// Dip 4
+	{0   , 0xfe, 0   , 2   , "Second Stick"           },
+	{0x03, 0x01, 0x01, 0x00, "Moves & Shoots"         },
+	{0x03, 0x01, 0x01, 0x01, "Moves"                  },
 };
 
 STDDIPINFO(Drvrotate)
@@ -420,8 +438,43 @@ static void RotateDoTick() {
 }
 
 static void SuperJoy2Rotate() {
+	UINT8 FakeDrvInputPort0[4] = {0, 0, 0, 0};
+	UINT8 FakeDrvInputPort1[4] = {0, 0, 0, 0};
+	UINT8 NeedsSecondStick[2] = {0, 0};
+
+	// prepare for right-stick rotation
+	// this is not especially readable though
+	for (INT32 i = 0; i < 2; i++) {
+		for (INT32 n = 0; n < 4; n++) {
+			UINT8* RotationInput = (!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0];
+			RotationInput[n] = DrvFakeInput[6 + i*4 + n];
+			NeedsSecondStick[i] |= RotationInput[n];
+		}
+	}
+
 	for (INT32 i = 0; i < 2; i++) { // p1 = 0, p2 = 1
-		if (DrvFakeInput[4 + i]) { //  rotate-button had been pressed
+		if (!NeedsSecondStick[i])
+			nAutoFireCounter[i] = 0;
+		if (NeedsSecondStick[i]) { // or using Second Stick
+			UINT8 rot = Joy2Rotate(((!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0]));
+			if (rot != 0xff) {
+				nRotateTarget[i] = rot * rotate_gunpos_multiplier;
+			}
+			nRotateTry[i] = 0;
+
+			if (~DrvDips[3] & 1) {
+				// fake auto-fire - there's probably a more elegant solution for this
+				if (nAutoFireCounter[i]++ & 0x4)
+				{
+					DrvInputs[i] &= 0xef; // remove the fire bit &= ~0x10; //
+				}
+				else
+				{
+					DrvInputs[i] |= 0x10; // turn on the fire bit
+				}
+			}
+		}
+		else if (DrvFakeInput[4 + i]) { //  rotate-button had been pressed
 			UINT8 rot = Joy2Rotate(((!i) ? &DrvJoy1[0] : &DrvJoy2[0]));
 			if (rot != 0xff) {
 				nRotateTarget[i] = rot * rotate_gunpos_multiplier;
@@ -1021,6 +1074,12 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		SCAN_VAR(DrvSprRAMBank);
 		SCAN_VAR(DrvROMBank);
 		SCAN_VAR(DrvIRQEnable);
+		SCAN_VAR(nRotate);
+		SCAN_VAR(nRotateTarget);
+		SCAN_VAR(nRotateTry);
+		SCAN_VAR(nRotateHoldInput);
+		SCAN_VAR(nAutoFireCounter);
+		SCAN_VAR(nRotateTime);
 	}
 
 	if (nAction & ACB_WRITE) {

--- a/src/burn/drv/pre90s/d_alpha68k2.cpp
+++ b/src/burn/drv/pre90s/d_alpha68k2.cpp
@@ -59,19 +59,20 @@ static UINT8 DrvJoy1[8];
 static UINT8 DrvJoy2[8];
 static UINT8 DrvJoy3[8];
 static UINT8 DrvJoy4[8];
-static UINT8 DrvDips[2];
+static UINT8 DrvDips[3];
 static UINT8 DrvSrv[1];
 static UINT8 DrvInputs[6];
 static UINT8 DrvReset;
 
 // Rotation stuff! -dink
-static UINT8  DrvFakeInput[6]       = {0, 0, 0, 0, 0, 0};
+static UINT8  DrvFakeInput[14]      = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}; // 0-5 legacy; 6-9 P1, 10-13 P2
 static UINT8  nRotateHoldInput[2]   = {0, 0};
 static INT32  nRotate[2]            = {0, 0};
 static INT32  nRotateTarget[2]      = {0, 0};
 static INT32  nRotateTry[2]         = {0, 0};
 static UINT32 nRotateTime[2]        = {0, 0};
 static UINT8  game_rotates = 0;
+static UINT8  nAutoFireCounter[2] 	= {0, 0};
 
 static struct BurnInputInfo TimesoldInputList[] = {
 	{"P1 Coin",			BIT_DIGITAL,	DrvJoy3 + 0,	"p1 coin"	},
@@ -85,6 +86,10 @@ static struct BurnInputInfo TimesoldInputList[] = {
 	{"P1 Rotate Left"       , BIT_DIGITAL  , DrvFakeInput + 0, "p1 rotate left" },
 	{"P1 Rotate Right"      , BIT_DIGITAL  , DrvFakeInput + 1, "p1 rotate right" },
 	{"P1 Button 3 (rotate)" , BIT_DIGITAL  , DrvFakeInput + 4,  "p1 fire 3" },
+	{"P1 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 6,  "p1 up 2" }, // 6
+	{"P1 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 7,  "p1 down 2" }, // 7
+	{"P1 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 8,  "p1 left 2" }, // 8
+	{"P1 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 9,  "p1 right 2" }, // 9
 
 	{"P2 Coin",			BIT_DIGITAL,	DrvJoy3 + 1,	"p2 coin"	},
 	{"P2 Start",		BIT_DIGITAL,	DrvJoy2 + 7,	"p2 start"	},
@@ -97,12 +102,18 @@ static struct BurnInputInfo TimesoldInputList[] = {
 	{"P2 Rotate Left"  , BIT_DIGITAL  , DrvFakeInput + 2, "p2 rotate left" },
 	{"P2 Rotate Right" , BIT_DIGITAL  , DrvFakeInput + 3, "p2 rotate right" },
 	{"P2 Button 3 (rotate)" , BIT_DIGITAL  , DrvFakeInput + 5,  "p2 fire 3" },
+	{"P2 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 10, "p2 up 2" },
+	{"P2 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 11, "p2 down 2" },
+	{"P2 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 12, "p2 left 2" },
+	{"P2 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 13, "p2 right 2" },
 
 	{"Reset",			BIT_DIGITAL,	&DrvReset,		"reset"		},
 	{"Service",			BIT_DIGITAL,	DrvJoy4 + 0,	"service"	},
 	{"Service Mode",	BIT_DIGITAL,    DrvSrv + 0,     "diag"      },
 	{"Dip A",			BIT_DIPSWITCH,	DrvDips + 0,	"dip"		},
 	{"Dip B",			BIT_DIPSWITCH,	DrvDips + 1,	"dip"		},
+	// Auto-fire on right-stick
+	{"Dip C", 			BIT_DIPSWITCH,	DrvDips + 2,	"dip"       },
 };
 
 STDINPUTINFO(Timesold)
@@ -119,6 +130,10 @@ static struct BurnInputInfo BtlfieldInputList[] = {
 	{"P1 Rotate Left"       , BIT_DIGITAL  , DrvFakeInput + 0, "p1 rotate left" },
 	{"P1 Rotate Right"      , BIT_DIGITAL  , DrvFakeInput + 1, "p1 rotate right" },
 	{"P1 Button 3 (rotate)" , BIT_DIGITAL  , DrvFakeInput + 4,  "p1 fire 3" },
+	{"P1 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 6,  "p1 up 2" }, // 6
+	{"P1 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 7,  "p1 down 2" }, // 7
+	{"P1 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 8,  "p1 left 2" }, // 8
+	{"P1 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 9,  "p1 right 2" }, // 9
 
 	{"P2 Coin",			BIT_DIGITAL,	DrvJoy3 + 1,	"p2 coin"	},
 	{"P2 Start",		BIT_DIGITAL,	DrvJoy2 + 7,	"p2 start"	},
@@ -131,12 +146,18 @@ static struct BurnInputInfo BtlfieldInputList[] = {
 	{"P2 Rotate Left"  , BIT_DIGITAL  , DrvFakeInput + 2, "p2 rotate left" },
 	{"P2 Rotate Right" , BIT_DIGITAL  , DrvFakeInput + 3, "p2 rotate right" },
 	{"P2 Button 3 (rotate)" , BIT_DIGITAL  , DrvFakeInput + 5,  "p2 fire 3" },
+	{"P2 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 10, "p2 up 2" },
+	{"P2 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 11, "p2 down 2" },
+	{"P2 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 12, "p2 left 2" },
+	{"P2 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 13, "p2 right 2" },
 
 	{"Reset",			BIT_DIGITAL,	&DrvReset,		"reset"		},
 	{"Service",			BIT_DIGITAL,	DrvJoy4 + 0,	"service"	},
 	{"Service Mode",	BIT_DIGITAL,    DrvSrv + 0,     "diag"      },
 	{"Dip A",			BIT_DIPSWITCH,	DrvDips + 0,	"dip"		},
 	{"Dip B",			BIT_DIPSWITCH,	DrvDips + 1,	"dip"		},
+	// Auto-fire on right-stick
+	{"Dip C", 			BIT_DIPSWITCH,	DrvDips + 2,	"dip"       },
 };
 
 STDINPUTINFO(Btlfield)
@@ -290,90 +311,107 @@ STDINPUTINFO(Sbasebal)
 
 static struct BurnDIPInfo TimesoldDIPList[]=
 {
-	{0x19, 0xff, 0xff, 0xdc, NULL				},
-	{0x1a, 0xff, 0xff, 0xff, NULL				},
+	DIP_OFFSET(0x21)
+
+	{0x00, 0xff, 0xff, 0xdc, NULL				},
+	{0x01, 0xff, 0xff, 0xff, NULL				},
+	{0x02, 0xff, 0xff, 0x00, NULL               },
+
 
 	{0   , 0xfe, 0   ,    2, "Flip Screen"			},
-	{0x19, 0x01, 0x04, 0x04, "Off"				},
-	{0x19, 0x01, 0x04, 0x00, "On"				},
+	{0x00, 0x01, 0x04, 0x04, "Off"				},
+	{0x00, 0x01, 0x04, 0x00, "On"				},
 
 	{0   , 0xfe, 0   ,    3, "Difficulty"			},
-	{0x19, 0x01, 0x18, 0x00, "Easy"				},
-	{0x19, 0x01, 0x18, 0x18, "Normal"			},
-	{0x19, 0x01, 0x18, 0x10, "Hard"				},
+	{0x00, 0x01, 0x18, 0x00, "Easy"				},
+	{0x00, 0x01, 0x18, 0x18, "Normal"			},
+	{0x00, 0x01, 0x18, 0x10, "Hard"				},
 
 	{0   , 0xfe, 0   ,    2, "Language"			},
-	{0x19, 0x01, 0x20, 0x00, "English"			},
-	{0x19, 0x01, 0x20, 0x20, "Japanese"			},
+	{0x00, 0x01, 0x20, 0x00, "English"			},
+	{0x00, 0x01, 0x20, 0x20, "Japanese"			},
 
 	{0   , 0xfe, 0   ,    2, "Invulnerability (Cheat)"	},
-	{0x19, 0x01, 0x80, 0x80, "Off"				},
-	{0x19, 0x01, 0x80, 0x00, "On"				},
+	{0x00, 0x01, 0x80, 0x80, "Off"				},
+	{0x00, 0x01, 0x80, 0x00, "On"				},
 
 	{0   , 0xfe, 0   ,    2, "Demo Sounds"			},
-	{0x1a, 0x01, 0x08, 0x08, "Off"				},
-	{0x1a, 0x01, 0x08, 0x00, "On"				},
+	{0x01, 0x01, 0x08, 0x08, "Off"				},
+	{0x01, 0x01, 0x08, 0x00, "On"				},
 
 	{0   , 0xfe, 0   ,    8, "Coinage"			},
-	{0x1a, 0x01, 0x07, 0x07, "A 1C/1C B 1C/1C"		},
-	{0x1a, 0x01, 0x07, 0x06, "A 1C/2C B 2C/1C"		},
-	{0x1a, 0x01, 0x07, 0x05, "A 1C/3C B 3C/1C"		},
-	{0x1a, 0x01, 0x07, 0x04, "A 1C/4C B 4C/1C"		},
-	{0x1a, 0x01, 0x07, 0x03, "A 1C/5C B 5C/1C"		},
-	{0x1a, 0x01, 0x07, 0x02, "A 1C/6C B 6C/1C"		},
-	{0x1a, 0x01, 0x07, 0x01, "A 2C/3C B 7C/1C"		},
-	{0x1a, 0x01, 0x07, 0x00, "A 3C/2C B 8C/1C"		},
+	{0x01, 0x01, 0x07, 0x07, "A 1C/1C B 1C/1C"		},
+	{0x01, 0x01, 0x07, 0x06, "A 1C/2C B 2C/1C"		},
+	{0x01, 0x01, 0x07, 0x05, "A 1C/3C B 3C/1C"		},
+	{0x01, 0x01, 0x07, 0x04, "A 1C/4C B 4C/1C"		},
+	{0x01, 0x01, 0x07, 0x03, "A 1C/5C B 5C/1C"		},
+	{0x01, 0x01, 0x07, 0x02, "A 1C/6C B 6C/1C"		},
+	{0x01, 0x01, 0x07, 0x01, "A 2C/3C B 7C/1C"		},
+	{0x01, 0x01, 0x07, 0x00, "A 3C/2C B 8C/1C"		},
 
 	{0   , 0xfe, 0   ,    4, "Lives"			},
-	{0x1a, 0x01, 0x30, 0x30, "3"				},
-	{0x1a, 0x01, 0x30, 0x20, "4"				},
-	{0x1a, 0x01, 0x30, 0x10, "5"				},
-	{0x1a, 0x01, 0x30, 0x00, "6"				},
+	{0x01, 0x01, 0x30, 0x30, "3"				},
+	{0x01, 0x01, 0x30, 0x20, "4"				},
+	{0x01, 0x01, 0x30, 0x10, "5"				},
+	{0x01, 0x01, 0x30, 0x00, "6"				},
+
+	// Dip 3
+	{0   , 0xfe, 0   , 2   , "Second Stick"           },
+	{0x02, 0x01, 0x01, 0x00, "Moves & Shoots"         },
+	{0x02, 0x01, 0x01, 0x01, "Moves"                  },
 };
 
 STDDIPINFO(Timesold)
 
 static struct BurnDIPInfo BtlfieldDIPList[]=
 {
-	{0x19, 0xff, 0xff, 0xfd, NULL				},
-	{0x1a, 0xff, 0xff, 0xf7, NULL				},
+	DIP_OFFSET(0x21)
+
+	{0x00, 0xff, 0xff, 0xfd, NULL				},
+	{0x01, 0xff, 0xff, 0xf7, NULL				},
+	{0x02, 0xff, 0xff, 0x00, NULL               },
 
 	{0   , 0xfe, 0   ,    2, "Flip Screen"			},
-	{0x19, 0x01, 0x04, 0x04, "Off"				},
-	{0x19, 0x01, 0x04, 0x00, "On"				},
+	{0x00, 0x01, 0x04, 0x04, "Off"				},
+	{0x00, 0x01, 0x04, 0x00, "On"				},
 
 	{0   , 0xfe, 0   ,    3, "Difficulty"			},
-	{0x19, 0x01, 0x18, 0x00, "Easy"				},
-	{0x19, 0x01, 0x18, 0x18, "Normal"			},
-	{0x19, 0x01, 0x18, 0x10, "Hard"				},
+	{0x00, 0x01, 0x18, 0x00, "Easy"				},
+	{0x00, 0x01, 0x18, 0x18, "Normal"			},
+	{0x00, 0x01, 0x18, 0x10, "Hard"				},
 
 	{0   , 0xfe, 0   ,    2, "Language"			},
-	{0x19, 0x01, 0x20, 0x00, "English"			},
-	{0x19, 0x01, 0x20, 0x20, "Japanese"			},
+	{0x00, 0x01, 0x20, 0x00, "English"			},
+	{0x00, 0x01, 0x20, 0x20, "Japanese"			},
 
 	{0   , 0xfe, 0   ,    2, "Invulnerability (Cheat)"	},
-	{0x19, 0x01, 0x80, 0x80, "Off"				},
-	{0x19, 0x01, 0x80, 0x00, "On"				},
+	{0x00, 0x01, 0x80, 0x80, "Off"				},
+	{0x00, 0x01, 0x80, 0x00, "On"				},
 
 	{0   , 0xfe, 0   ,    8, "Coinage"			},
-	{0x1a, 0x01, 0x07, 0x07, "A 1C/1C B 1C/1C"		},
-	{0x1a, 0x01, 0x07, 0x06, "A 1C/2C B 2C/1C"		},
-	{0x1a, 0x01, 0x07, 0x05, "A 1C/3C B 3C/1C"		},
-	{0x1a, 0x01, 0x07, 0x04, "A 1C/4C B 4C/1C"		},
-	{0x1a, 0x01, 0x07, 0x03, "A 1C/5C B 5C/1C"		},
-	{0x1a, 0x01, 0x07, 0x02, "A 1C/6C B 6C/1C"		},
-	{0x1a, 0x01, 0x07, 0x01, "A 2C/3C B 7C/1C"		},
-	{0x1a, 0x01, 0x07, 0x00, "A 3C/2C B 8C/1C"		},
+	{0x01, 0x01, 0x07, 0x07, "A 1C/1C B 1C/1C"		},
+	{0x01, 0x01, 0x07, 0x06, "A 1C/2C B 2C/1C"		},
+	{0x01, 0x01, 0x07, 0x05, "A 1C/3C B 3C/1C"		},
+	{0x01, 0x01, 0x07, 0x04, "A 1C/4C B 4C/1C"		},
+	{0x01, 0x01, 0x07, 0x03, "A 1C/5C B 5C/1C"		},
+	{0x01, 0x01, 0x07, 0x02, "A 1C/6C B 6C/1C"		},
+	{0x01, 0x01, 0x07, 0x01, "A 2C/3C B 7C/1C"		},
+	{0x01, 0x01, 0x07, 0x00, "A 3C/2C B 8C/1C"		},
 
 	{0   , 0xfe, 0   ,    2, "Demo Sounds"			},
-	{0x1a, 0x01, 0x08, 0x08, "Off"				},
-	{0x1a, 0x01, 0x08, 0x00, "On"				},
+	{0x01, 0x01, 0x08, 0x08, "Off"				},
+	{0x01, 0x01, 0x08, 0x00, "On"				},
 
 	{0   , 0xfe, 0   ,    4, "Lives"			},
-	{0x1a, 0x01, 0x30, 0x30, "3"				},
-	{0x1a, 0x01, 0x30, 0x20, "4"				},
-	{0x1a, 0x01, 0x30, 0x10, "5"				},
-	{0x1a, 0x01, 0x30, 0x00, "6"				},
+	{0x01, 0x01, 0x30, 0x30, "3"				},
+	{0x01, 0x01, 0x30, 0x20, "4"				},
+	{0x01, 0x01, 0x30, 0x10, "5"				},
+	{0x01, 0x01, 0x30, 0x00, "6"				},
+
+	// Dip 3
+	{0   , 0xfe, 0   , 2   , "Second Stick"           },
+	{0x02, 0x01, 0x01, 0x00, "Moves & Shoots"         },
+	{0x02, 0x01, 0x01, 0x01, "Moves"                  },
 };
 
 STDDIPINFO(Btlfield)
@@ -895,8 +933,43 @@ static void RotateDoTick() {
 }
 
 static void SuperJoy2Rotate() {
+	UINT8 FakeDrvInputPort0[4] = {0, 0, 0, 0};
+	UINT8 FakeDrvInputPort1[4] = {0, 0, 0, 0};
+	UINT8 NeedsSecondStick[2] = {0, 0};
+
+	// prepare for right-stick rotation
+	// this is not especially readable though
+	for (INT32 i = 0; i < 2; i++) {
+		for (INT32 n = 0; n < 4; n++) {
+			UINT8* RotationInput = (!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0];
+			RotationInput[n] = DrvFakeInput[6 + i*4 + n];
+			NeedsSecondStick[i] |= RotationInput[n];
+		}
+	}
+
 	for (INT32 i = 0; i < 2; i++) { // p1 = 0, p2 = 1
-		if (DrvFakeInput[4 + i]) { //  rotate-button had been pressed
+		if (!NeedsSecondStick[i])
+			nAutoFireCounter[i] = 0;
+		if (NeedsSecondStick[i]) { // or using Second Stick
+			UINT8 rot = Joy2Rotate(((!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0]));
+			if (rot != 0xff) {
+				nRotateTarget[i] = rot * rotate_gunpos_multiplier;
+			}
+			nRotateTry[i] = 0;
+
+			if (~DrvDips[2] & 1) {
+				// fake auto-fire - there's probably a more elegant solution for this
+				if (nAutoFireCounter[i]++ & 0x4)
+				{
+					DrvInputs[i] &= 0xef; // remove the fire bit &= ~0x10; //
+				}
+				else
+				{
+					DrvInputs[i] |= 0x10; // turn on the fire bit
+				}
+			}
+		}
+		else if (DrvFakeInput[4 + i]) { //  rotate-button had been pressed
 			UINT8 rot = Joy2Rotate(((!i) ? &DrvJoy1[0] : &DrvJoy2[0]));
 			if (rot != 0xff) {
 				nRotateTarget[i] = rot * rotate_gunpos_multiplier;
@@ -2084,6 +2157,12 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		SCAN_VAR(deposits1);
 		SCAN_VAR(coin_latch);
 		SCAN_VAR(microcontroller_data);
+		SCAN_VAR(nRotate);
+		SCAN_VAR(nRotateTarget);
+		SCAN_VAR(nRotateTry);
+		SCAN_VAR(nRotateHoldInput);
+		SCAN_VAR(nAutoFireCounter);
+		SCAN_VAR(nRotateTime);
 	}
 
 	if (nAction & ACB_WRITE)

--- a/src/burn/drv/pre90s/d_snk.cpp
+++ b/src/burn/drv/pre90s/d_snk.cpp
@@ -4342,7 +4342,7 @@ static INT32 BermudatInit()
 	game_select = 2;
 	game_rotates = 1;
 
-	RotateSetGunPosRAM(&DrvSprRAM[0x041], &DrvSprRAM[0x055], 1);
+	RotateSetGunPosRAM(&DrvSprRAM[0x1408], &DrvSprRAM[0x14a8], 1);
 
 	DrvDoReset();
 
@@ -4353,7 +4353,7 @@ static INT32 BermudatwwInit()
 {
 	INT32 nRet = BermudatInit();
 	if (!nRet) {
-		RotateSetGunPosRAM(&DrvSprRAM[0x041], &DrvSprRAM[0x049], 1);
+		RotateSetGunPosRAM(&DrvSprRAM[0x1408], &DrvSprRAM[0x1448], 2);
 	}
 
 	return nRet;
@@ -4474,6 +4474,8 @@ static INT32 GwaraInit()
 	game_select = 3;
 	game_rotates = 1;
 	bonus_dip_config = 0x3004;
+
+	RotateSetGunPosRAM(&DrvSprRAM[0x3d3], &DrvSprRAM[0x437], 2);
 
 	DrvDoReset();
 

--- a/src/burn/drv/pre90s/d_snk.cpp
+++ b/src/burn/drv/pre90s/d_snk.cpp
@@ -2282,9 +2282,9 @@ static UINT8 rotate_gunpos_multiplier = 1;
 // game      p1   p2    clockwise value in memory
 // victroad: fdb6 fe06  0 2 4 6 8 a c e
 // ikari   : fdb6 fe06  0 2 4 6 8 a c e
-// tnk3    : fd43 fd89  0 1 2 3 4 5 6 7   // fd47 fd8d?
+// tnk3    : fd47 fd8d  0 2 4 6 8 a c e
 // gwar    : e3d3 e437  0 2 4 6 8 a c e
-// bermudat: e041 e055  0 1 2 3 4 5 6 7
+// bermudat: f408 f4a8  0 1 2 3 4 5 6 7
 
 static void RotateSetGunPosRAM(UINT8 *p1, UINT8 *p2, UINT8 multiplier) {
 	rotate_gunpos[0] = p1;
@@ -6418,6 +6418,12 @@ static INT32 Tnk3Frame()
 		}
 
 		if (game_rotates) {
+			if (~DrvDips[0] & 2) { // TNK3 Upright Mode (P1 joy for both players)
+				INT32 Player = (DrvTxtRAM[0x458] & 0x10) >> 4; // (0xFC58 & 0x10) == P2
+				const INT32 pl_rot[2] = { 0x547, 0x58d };
+				RotateSetGunPosRAM(&DrvTxtRAM[pl_rot[Player]], &DrvTxtRAM[0x58d], 2); // TNK3
+			}
+
 			SuperJoy2Rotate();
 		}
 		

--- a/src/burn/drv/pst90s/d_seta.cpp
+++ b/src/burn/drv/pst90s/d_seta.cpp
@@ -122,7 +122,7 @@ static INT32 track_x2_last = 0;
 static INT32 track_y2_last = 0;
 
 // Rotation stuff! -dink
-static UINT8  DrvFakeInput[6]       = {0, 0, 0, 0, 0, 0};
+static UINT8  DrvFakeInput[14]      = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}; // 0-5 legacy; 6-9 P1, 10-13 P2
 static UINT8  nRotateHoldInput[2]   = {0, 0};
 static INT32  nRotate[2]            = {0, 0};
 static INT32  nRotateTarget[2]      = {0, 0};
@@ -130,6 +130,7 @@ static INT32  nRotateTry[2]         = {0, 0};
 static UINT32 nRotateTime[2]        = {0, 0};
 static UINT8  game_rotates = 0;
 static UINT8  clear_opposites = 0;
+static UINT8  nAutoFireCounter[2] 	= {0, 0};
 
 #define A(a, b, c, d) { a, b, (UINT8*)(c), d }
 
@@ -921,6 +922,10 @@ static struct BurnInputInfo DowntownInputList[] = {
 	{"P1 Button 1",		BIT_DIGITAL,	DrvJoy1 + 4,	"p1 fire 1"	},
 	{"P1 Button 2",		BIT_DIGITAL,	DrvJoy1 + 5,	"p1 fire 2"	},
 	{"P1 Button 3 (rotate)",		BIT_DIGITAL,	DrvFakeInput + 4,	"p1 fire 3"	},
+	{"P1 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 6,  "p1 up 2" }, // 6
+	{"P1 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 7,  "p1 down 2" }, // 7
+	{"P1 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 8,  "p1 left 2" }, // 8
+	{"P1 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 9,  "p1 right 2" }, // 9
 
 	{"P2 Coin",		BIT_DIGITAL,	DrvJoy3 + 6,	"p2 coin"	},
 	{"P2 Start",		BIT_DIGITAL,	DrvJoy2 + 7,	"p2 start"	},
@@ -931,6 +936,10 @@ static struct BurnInputInfo DowntownInputList[] = {
 	{"P2 Button 1",		BIT_DIGITAL,	DrvJoy2 + 4,	"p2 fire 1"	},
 	{"P2 Button 2",		BIT_DIGITAL,	DrvJoy2 + 5,	"p2 fire 2"	},
 	{"P2 Button 3 (rotate)",		BIT_DIGITAL,	DrvFakeInput + 5,	"p2 fire 3"	},
+	{"P2 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 10, "p2 up 2" },
+	{"P2 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 11, "p2 down 2" },
+	{"P2 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 12, "p2 left 2" },
+	{"P2 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 13, "p2 right 2" },
 
 	{"Reset",		BIT_DIGITAL,	&DrvReset,	"reset"		},
 	{"Service",		BIT_DIGITAL,	DrvJoy3 + 5,	"service"	},
@@ -938,6 +947,9 @@ static struct BurnInputInfo DowntownInputList[] = {
 	{"Dip A",		BIT_DIPSWITCH,	DrvDips + 0,	"dip"		},
 	{"Dip B",		BIT_DIPSWITCH,	DrvDips + 1,	"dip"		},
 	{"Dip C",		BIT_DIPSWITCH,	DrvDips + 2,	"dip"		},
+	// Auto-fire on right-stick
+	{"Dip D", 		BIT_DIPSWITCH, 	DrvDips + 3, 	"dip"       },
+
 };
 
 STDINPUTINFO(Downtown)
@@ -1167,6 +1179,10 @@ static struct BurnInputInfo Calibr50InputList[] = {
 	{"P1 Button 1",		BIT_DIGITAL,	DrvJoy1 + 4,	"p1 fire 1"	},
 	{"P1 Button 2",		BIT_DIGITAL,	DrvJoy1 + 5,	"p1 fire 2"	},
 	{"P1 Button 3 (rotate)",		BIT_DIGITAL,	DrvFakeInput + 4,	"p1 fire 3"	},
+	{"P1 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 6,  "p1 up 2" }, // 6
+	{"P1 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 7,  "p1 down 2" }, // 7
+	{"P1 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 8,  "p1 left 2" }, // 8
+	{"P1 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 9,  "p1 right 2" }, // 9
 
 	{"P2 Coin",		BIT_DIGITAL,	DrvJoy3 + 6,	"p2 coin"	},
 	{"P2 Start",		BIT_DIGITAL,	DrvJoy2 + 7,	"p2 start"	},
@@ -1177,6 +1193,10 @@ static struct BurnInputInfo Calibr50InputList[] = {
 	{"P2 Button 1",		BIT_DIGITAL,	DrvJoy2 + 4,	"p2 fire 1"	},
 	{"P2 Button 2",		BIT_DIGITAL,	DrvJoy2 + 5,	"p2 fire 2"	},
 	{"P2 Button 3 (rotate)",		BIT_DIGITAL,	DrvFakeInput + 5,	"p2 fire 3"	},
+	{"P2 Shoot Up"       	, BIT_DIGITAL  , DrvFakeInput + 10, "p2 up 2" },
+	{"P2 Shoot Down"      	, BIT_DIGITAL  , DrvFakeInput + 11, "p2 down 2" },
+	{"P2 Shoot Left"       	, BIT_DIGITAL  , DrvFakeInput + 12, "p2 left 2" },
+	{"P2 Shoot Right"      	, BIT_DIGITAL  , DrvFakeInput + 13, "p2 right 2" },
 
 	{"Reset",		BIT_DIGITAL,	&DrvReset,	"reset"		},
 	{"Service",		BIT_DIGITAL,	DrvJoy3 + 5,	"service"	},
@@ -1184,6 +1204,8 @@ static struct BurnInputInfo Calibr50InputList[] = {
 	{"Dip A",		BIT_DIPSWITCH,	DrvDips + 0,	"dip"		},
 	{"Dip B",		BIT_DIPSWITCH,	DrvDips + 1,	"dip"		},
 	{"Dip C",		BIT_DIPSWITCH,	DrvDips + 2,	"dip"		},
+	// Auto-fire on right-stick
+	{"Dip D", 		BIT_DIPSWITCH, 	DrvDips + 3, 	"dip"       },
 };
 
 STDINPUTINFO(Calibr50)
@@ -1407,63 +1429,71 @@ STDDIPINFO(Usclssic)
 
 static struct BurnDIPInfo Calibr50DIPList[]=
 {
-	{0x15, 0xff, 0xff, 0xfe, NULL			},
-	{0x16, 0xff, 0xff, 0xfd, NULL			},
-	{0x17, 0xff, 0xff, 0xff, NULL			},
+	DIP_OFFSET(0x1d)
+
+	{0x00, 0xff, 0xff, 0xfe, NULL			},
+	{0x01, 0xff, 0xff, 0xfd, NULL			},
+	{0x02, 0xff, 0xff, 0xff, NULL			},
+	{0x03, 0xff, 0xff, 0x00, NULL			},
 
 	{0   , 0xfe, 0   ,    2, "Licensed To"		},
-	{0x15, 0x01, 0x01, 0x01, "Romstar"		},
-	{0x15, 0x01, 0x01, 0x00, "None (Japan)"		},
+	{0x00, 0x01, 0x01, 0x01, "Romstar"		},
+	{0x00, 0x01, 0x01, 0x00, "None (Japan)"		},
 
 	{0   , 0xfe, 0   ,    2, "Flip Screen"		},
-	{0x15, 0x01, 0x02, 0x02, "Off"			},
-	{0x15, 0x01, 0x02, 0x00, "On"			},
+	{0x00, 0x01, 0x02, 0x02, "Off"			},
+	{0x00, 0x01, 0x02, 0x00, "On"			},
 
 	{0   , 0xfe, 0   ,    2, "Service Mode"		},
-	{0x15, 0x01, 0x04, 0x04, "Off"			},
-	{0x15, 0x01, 0x04, 0x00, "On"			},
+	{0x00, 0x01, 0x04, 0x04, "Off"			},
+	{0x00, 0x01, 0x04, 0x00, "On"			},
 
 	{0   , 0xfe, 0   ,    2, "Demo Sounds"		},
-	{0x15, 0x01, 0x08, 0x00, "Off"			},
-	{0x15, 0x01, 0x08, 0x08, "On"			},
+	{0x00, 0x01, 0x08, 0x00, "Off"			},
+	{0x00, 0x01, 0x08, 0x08, "On"			},
 
 	{0   , 0xfe, 0   ,    4, "Coin A"		},
-	{0x15, 0x01, 0x30, 0x10, "2 Coins 1 Credits"	},
-	{0x15, 0x01, 0x30, 0x30, "1 Coin  1 Credits"	},
-	{0x15, 0x01, 0x30, 0x00, "2 Coins 3 Credits"	},
-	{0x15, 0x01, 0x30, 0x20, "1 Coin  2 Credits"	},
+	{0x00, 0x01, 0x30, 0x10, "2 Coins 1 Credits"	},
+	{0x00, 0x01, 0x30, 0x30, "1 Coin  1 Credits"	},
+	{0x00, 0x01, 0x30, 0x00, "2 Coins 3 Credits"	},
+	{0x00, 0x01, 0x30, 0x20, "1 Coin  2 Credits"	},
 
 	{0   , 0xfe, 0   ,    4, "Coin B"		},
-	{0x15, 0x01, 0xc0, 0x40, "2 Coins 1 Credits"	},
-	{0x15, 0x01, 0xc0, 0xc0, "1 Coin  1 Credits"	},
-	{0x15, 0x01, 0xc0, 0x00, "2 Coins 3 Credits"	},
-	{0x15, 0x01, 0xc0, 0x80, "1 Coin  2 Credits"	},
+	{0x00, 0x01, 0xc0, 0x40, "2 Coins 1 Credits"	},
+	{0x00, 0x01, 0xc0, 0xc0, "1 Coin  1 Credits"	},
+	{0x00, 0x01, 0xc0, 0x00, "2 Coins 3 Credits"	},
+	{0x00, 0x01, 0xc0, 0x80, "1 Coin  2 Credits"	},
 
 	{0   , 0xfe, 0   ,    4, "Difficulty"		},
-	{0x16, 0x01, 0x03, 0x03, "Easiest"		},
-	{0x16, 0x01, 0x03, 0x02, "Easy"			},
-	{0x16, 0x01, 0x03, 0x01, "Normal"		},
-	{0x16, 0x01, 0x03, 0x00, "Hard"			},
+	{0x01, 0x01, 0x03, 0x03, "Easiest"		},
+	{0x01, 0x01, 0x03, 0x02, "Easy"			},
+	{0x01, 0x01, 0x03, 0x01, "Normal"		},
+	{0x01, 0x01, 0x03, 0x00, "Hard"			},
 
 	{0   , 0xfe, 0   ,    2, "Score Digits"		},
-	{0x16, 0x01, 0x04, 0x04, "7"			},
-	{0x16, 0x01, 0x04, 0x00, "3"			},
+	{0x01, 0x01, 0x04, 0x04, "7"			},
+	{0x01, 0x01, 0x04, 0x00, "3"			},
 
 	{0   , 0xfe, 0   ,    2, "Lives"		},
-	{0x16, 0x01, 0x08, 0x08, "3"			},
-	{0x16, 0x01, 0x08, 0x00, "4"			},
+	{0x01, 0x01, 0x08, 0x08, "3"			},
+	{0x01, 0x01, 0x08, 0x00, "4"			},
 
 	{0   , 0xfe, 0   ,    2, "Display Score"	},
-	{0x16, 0x01, 0x10, 0x00, "Off"			},
-	{0x16, 0x01, 0x10, 0x10, "On"			},
+	{0x01, 0x01, 0x10, 0x00, "Off"			},
+	{0x01, 0x01, 0x10, 0x10, "On"			},
 
 	{0   , 0xfe, 0   ,    2, "Erase Backup Ram"	},
-	{0x16, 0x01, 0x20, 0x00, "Off"			},
-	{0x16, 0x01, 0x20, 0x20, "On"			},
+	{0x01, 0x01, 0x20, 0x00, "Off"			},
+	{0x01, 0x01, 0x20, 0x20, "On"			},
 
 	{0   , 0xfe, 0   ,    2, "Licensed To"		},
-	{0x16, 0x01, 0x40, 0x40, "Taito America"	},
-	{0x16, 0x01, 0x40, 0x00, "Taito"		},
+	{0x01, 0x01, 0x40, 0x40, "Taito America"	},
+	{0x01, 0x01, 0x40, 0x00, "Taito"		},
+
+	// Dip D
+	{0   , 0xfe, 0   , 2   , "Second Stick"           },
+	{0x03, 0x01, 0x01, 0x00, "Moves & Shoots"         },
+	{0x03, 0x01, 0x01, 0x01, "Moves"                  },
 };
 
 STDDIPINFO(Calibr50)
@@ -1723,63 +1753,71 @@ STDDIPINFO(Arbalest)
 
 static struct BurnDIPInfo DowntownDIPList[]=
 {
-	{0x15, 0xff, 0xff, 0xf6, NULL			},
-	{0x16, 0xff, 0xff, 0xbd, NULL			},
-	{0x17, 0xff, 0xff, 0xff, NULL			},
+	DIP_OFFSET(0x1d)
+
+	{0x00, 0xff, 0xff, 0xf6, NULL			},
+	{0x01, 0xff, 0xff, 0xbd, NULL			},
+	{0x02, 0xff, 0xff, 0xff, NULL			},
+	{0x03, 0xff, 0xff, 0x00, NULL			},
 
 	{0   , 0xfe, 0   ,    2, "Sales"		},
-	{0x15, 0x01, 0x01, 0x01, "Japan Only"		},
-	{0x15, 0x01, 0x01, 0x00, "World"		},
+	{0x00, 0x01, 0x01, 0x01, "Japan Only"		},
+	{0x00, 0x01, 0x01, 0x00, "World"		},
 
 	{0   , 0xfe, 0   ,    2, "Flip Screen"		},
-	{0x15, 0x01, 0x02, 0x02, "Off"			},
-	{0x15, 0x01, 0x02, 0x00, "On"			},
+	{0x00, 0x01, 0x02, 0x02, "Off"			},
+	{0x00, 0x01, 0x02, 0x00, "On"			},
 
 	{0   , 0xfe, 0   ,    2, "Service Mode"		},
-	{0x15, 0x01, 0x04, 0x04, "Off"			},
-	{0x15, 0x01, 0x04, 0x00, "On"			},
+	{0x00, 0x01, 0x04, 0x04, "Off"			},
+	{0x00, 0x01, 0x04, 0x00, "On"			},
 
 	{0   , 0xfe, 0   ,    2, "Demo Sounds"		},
-	{0x15, 0x01, 0x08, 0x08, "Off"			},
-	{0x15, 0x01, 0x08, 0x00, "On"			},
+	{0x00, 0x01, 0x08, 0x08, "Off"			},
+	{0x00, 0x01, 0x08, 0x00, "On"			},
 
 	{0   , 0xfe, 0   ,    4, "Coin A"		},
-	{0x15, 0x01, 0x30, 0x10, "2 Coins 1 Credits"	},
-	{0x15, 0x01, 0x30, 0x30, "1 Coin  1 Credits"	},
-	{0x15, 0x01, 0x30, 0x00, "2 Coins 3 Credits"	},
-	{0x15, 0x01, 0x30, 0x20, "1 Coin  2 Credits"	},
+	{0x00, 0x01, 0x30, 0x10, "2 Coins 1 Credits"	},
+	{0x00, 0x01, 0x30, 0x30, "1 Coin  1 Credits"	},
+	{0x00, 0x01, 0x30, 0x00, "2 Coins 3 Credits"	},
+	{0x00, 0x01, 0x30, 0x20, "1 Coin  2 Credits"	},
 
 	{0   , 0xfe, 0   ,    4, "Coin B"		},
-	{0x15, 0x01, 0xc0, 0x40, "2 Coins 1 Credits"	},
-	{0x15, 0x01, 0xc0, 0xc0, "1 Coin  1 Credits"	},
-	{0x15, 0x01, 0xc0, 0x00, "2 Coins 3 Credits"	},
-	{0x15, 0x01, 0xc0, 0x80, "1 Coin  2 Credits"	},
+	{0x00, 0x01, 0xc0, 0x40, "2 Coins 1 Credits"	},
+	{0x00, 0x01, 0xc0, 0xc0, "1 Coin  1 Credits"	},
+	{0x00, 0x01, 0xc0, 0x00, "2 Coins 3 Credits"	},
+	{0x00, 0x01, 0xc0, 0x80, "1 Coin  2 Credits"	},
 
 	{0   , 0xfe, 0   ,    4, "Difficulty"		},
-	{0x16, 0x01, 0x03, 0x02, "Easy"			},
-	{0x16, 0x01, 0x03, 0x03, "Normal"		},
-	{0x16, 0x01, 0x03, 0x01, "Hard"			},
-	{0x16, 0x01, 0x03, 0x00, "Hardest"		},
+	{0x01, 0x01, 0x03, 0x02, "Easy"			},
+	{0x01, 0x01, 0x03, 0x03, "Normal"		},
+	{0x01, 0x01, 0x03, 0x01, "Hard"			},
+	{0x01, 0x01, 0x03, 0x00, "Hardest"		},
 
 	{0   , 0xfe, 0   ,    4, "Bonus Life"		},
-	{0x16, 0x01, 0x0c, 0x0c, "Never"		},
-	{0x16, 0x01, 0x0c, 0x08, "50K Only"		},
-	{0x16, 0x01, 0x0c, 0x04, "100K Only"		},
-	{0x16, 0x01, 0x0c, 0x00, "50K, Every 150K"	},
+	{0x01, 0x01, 0x0c, 0x0c, "Never"		},
+	{0x01, 0x01, 0x0c, 0x08, "50K Only"		},
+	{0x01, 0x01, 0x0c, 0x04, "100K Only"		},
+	{0x01, 0x01, 0x0c, 0x00, "50K, Every 150K"	},
 
 	{0   , 0xfe, 0   ,    4, "Lives"		},
-	{0x16, 0x01, 0x30, 0x10, "2"			},
-	{0x16, 0x01, 0x30, 0x30, "3"			},
-	{0x16, 0x01, 0x30, 0x00, "4"			},
-	{0x16, 0x01, 0x30, 0x20, "5"			},
+	{0x01, 0x01, 0x30, 0x10, "2"			},
+	{0x01, 0x01, 0x30, 0x30, "3"			},
+	{0x01, 0x01, 0x30, 0x00, "4"			},
+	{0x01, 0x01, 0x30, 0x20, "5"			},
 
 	{0   , 0xfe, 0   ,    2, "World License"	},
-	{0x16, 0x01, 0x40, 0x40, "Romstar"		},
-	{0x16, 0x01, 0x40, 0x00, "Taito"		},
+	{0x01, 0x01, 0x40, 0x40, "Romstar"		},
+	{0x01, 0x01, 0x40, 0x00, "Taito"		},
 
 	{0   , 0xfe, 0   ,    2, "Coinage Type"		},
-	{0x16, 0x01, 0x80, 0x80, "1"			},
-	{0x16, 0x01, 0x80, 0x00, "2"			},
+	{0x01, 0x01, 0x80, 0x80, "1"			},
+	{0x01, 0x01, 0x80, 0x00, "2"			},
+
+	// Dip D
+	{0   , 0xfe, 0   , 2   , "Second Stick"           },
+	{0x03, 0x01, 0x01, 0x00, "Moves & Shoots"         },
+	{0x03, 0x01, 0x01, 0x01, "Moves"                  },
 };
 
 STDDIPINFO(Downtown)
@@ -5324,9 +5362,45 @@ static void RotateDoTick() {
 	}
 }
 
+
 static void SuperJoy2Rotate() {
+	UINT8 FakeDrvInputPort0[4] = {0, 0, 0, 0};
+	UINT8 FakeDrvInputPort1[4] = {0, 0, 0, 0};
+	UINT8 NeedsSecondStick[2] = {0, 0};
+
+	// prepare for right-stick rotation
+	// this is not especially readable though
+	for (INT32 i = 0; i < 2; i++) {
+		for (INT32 n = 0; n < 4; n++) {
+			UINT8* RotationInput = (!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0];
+			RotationInput[n] = DrvFakeInput[6 + i*4 + n];
+			NeedsSecondStick[i] |= RotationInput[n];
+		}
+	}
+
 	for (INT32 i = 0; i < 2; i++) { // p1 = 0, p2 = 1
-		if (DrvFakeInput[4 + i]) { //  rotate-button had been pressed
+		if (!NeedsSecondStick[i])
+			nAutoFireCounter[i] = 0;
+		if (NeedsSecondStick[i]) { // or using Second Stick
+			UINT8 rot = Joy2Rotate(((!i) ? &FakeDrvInputPort0[0] : &FakeDrvInputPort1[0]));
+			if (rot != 0xff) {
+				nRotateTarget[i] = rot * rotate_gunpos_multiplier;
+			}
+			nRotateTry[i] = 0;
+
+			if (~DrvDips[3] & 1) {
+				// fake auto-fire - there's probably a more elegant solution for this
+				if (nAutoFireCounter[i]++ & 0x2)
+				{
+					DrvInputs[i] &= 0xef; // remove the fire bit &= ~0x10; //
+				}
+				else
+				{
+					DrvInputs[i] |= 0x10; // turn on the fire bit
+				}
+			}
+		}
+		else if (DrvFakeInput[4 + i]) { //  rotate-button had been pressed
 			UINT8 rot = Joy2Rotate(((!i) ? &DrvJoy1[0] : &DrvJoy2[0]));
 			if (rot != 0xff) {
 				//bprintf(0, _T("joy2rotate[%x] = %X\n"), i, rot);
@@ -8057,6 +8131,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 			SCAN_VAR(nRotateTarget);
 			SCAN_VAR(nRotateTry);
 			SCAN_VAR(nRotateTime);
+			SCAN_VAR(nAutoFireCounter);
 		}
 		keroppi_pairslove_scan();
 	}


### PR DESCRIPTION
Following the previous PR, I'm adding the same support to all the other drivers that have support for a "rotate button" to adjust rotary controls. These are (not exclusively, I didn't include some bootlegs and variants):

- d_seta: downtown, calibr50
- d_snk68: ikari3w, searcharu
- d_snk: bermudat, gwar, tnk3, ikari, victroad /// has issues
- d_alpha68k2: timesold, Btlfield
- d_jackal: jackalr, topgunbl
- d_dec8: gondo

Some notes of what I did and what I found:
- Most games work exactly as intended, which is good. However, this implementation surfaced some existing issues with the existing "rotate button" in games from the *d_snk* driver that I could not solve after digging into the code. Specifically the following:

> * Bermuda Triangle (bermudat): When pressing the rotate button and Fire 1, the rotation goes crazy for a bit. If you press the rotate button and click Fire 1 several times you'll see it go into a constant rotation motion. You can currently replicate it in the stable version - going back to fbalpha - by pressing those buttons. It's not a regression, at least not recent, but messes things up with this control scheme in this game. As I said in the other PR, I don't have a proper debug setup - running things on the Pi - but I suspect it might be related to RotateDoTick going horribly wrong, getDistance is probably breaking for some reason. But you might have much better context on the rotation code :)
> * TNK3: Same behavior, but only for Player 2, but in this case you can replicate it by just pressing the rotate button and a direction. Since this is a "non-simultaneous two-player" game, it was hard to find it out.
> * Guerrilla War (Version 1) / gwara: doesn't rotate with the rotate button, so it doesn't rotate here. Couldn't quite figure out why.

- I tried to make variable scanning consistent across all drivers for rotation variables. Not all drivers scanned all variables, so please confirm whether that is the right thing to do. With this change all of these drivers are scanning nRotate, nRotateTarget, nRotateTry, nAutoFireCounter and nRotateTime.
- I added the DIP option to all, per your recommendation.
- I tested the following games in single and 2 player modes. Here are my notes.
```
// d_seta - OK
Calibre 50 - OK, tested 2 players. Quite fun!
Downtown - OK.
// d_snk - Has issues
Bermuda T: fix autofire - it's always rotating. Not regression, but messes things up. // must be related to RotateDoTick going horribly wrong
TNK3: P2 always rotates - not regression.
Ikari Warriors: Works.
Victory Road: works. 
GWar - Done.
GWara - doesn't rotate.
// d_snk68
Search and Rescue: OK
Ikari 3: OK
//
Time Soldiers:ok
// d_dec8
Gondo - OK
// d_jackal
jackalr: OK 
topgunbl: OK
```
- Last but not least, when developing and testing this, one thing became more obvious. If your analog sticks don't have a good deadzone configured and RetroArch starts with the joystick in a non-centered position, it will somehow detect that you're pressing that joystick all the time. Happens more often when your analog stick is tilting slightly to the left, which makes it assume I'm pushing it to the right. It might be my controllers - an original PS3 SixAxis controller - but since this happened in the past in other emulators, I'm just highlighting it here for the sake of transparency.
 
Hope this works and that it is helpful. It was loads of fun, educational (for me), and I found out a couple of games that turned out to be quite fun to play this way, namely Calibre 50!

As always, happy to hear your feedback.

I suppose, after this, I am missing Forgotten Worlds but that is a completely different beast. I don't think it even has support for a "rotate" button, so that's a bit outside of my current league but happy to take pointers :D