### PR TITLE
Neo Geo: kof2001rpf

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -18599,7 +18599,7 @@ struct BurnDriver BurnDrvkof2001ru = {
 
 static struct BurnRomInfo kof2001rpfRomDesc[] = {
 	{ "262rp-p1.p1",       0x100000, 0xe9e42e55, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "262rp-sp2.sp2",     0x500000, 0x37a818ed, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "262rp-sp2.sp2",     0x400000, 0x91668d86, 1 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "262rp-s1d.s1",      0x020000, 0x492f5efe, 2 | BRF_GRA },     //  2 Text layer tiles
 
@@ -18612,7 +18612,7 @@ static struct BurnRomInfo kof2001rpfRomDesc[] = {
 	{ "262-c7d.c7",        0x800000, 0xd1408776, 3 | BRF_GRA },     //  9
 	{ "262-c8d.c8",        0x800000, 0x954d0e16, 3 | BRF_GRA },     //  10
 
-	{ "262rp-m1d.m1",      0x040000, 0x4bcc537b, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "262rp-m1d.m1",      0x020000, 0x2fb0a8a5, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
 	{ "262-v1-08-e0.v1",   0x400000, 0x83d49ecf, 5 | BRF_SND },           // 12 Sound data
 	{ "262-v2-08-e0.v2",   0x400000, 0x003f1843, 5 | BRF_SND },           // 13

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -18597,39 +18597,47 @@ struct BurnDriver BurnDrvkof2001ru = {
 // The King of Fighters 2001 Remix Pro v1.02 Final
 // Version 2004-03-01 Hack By Jason,Kim & Raymonose
 
-static struct BurnRomInfo kof2001rpfRomDesc[] = {
-	{ "262rp-p1.p1",       0x100000, 0xe9e42e55, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "262rp-sp2.sp2",     0x400000, 0x91668d86, 1 | BRF_ESS | BRF_PRG }, //  1
+static struct BurnRomInfo kof2k1rpRomDesc[] = {
+	{ "262rp-p1.p1",           0x100000, 0xe9e42e55, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "262rp-sp2.sp2",         0x400000, 0x91668d86, 1 | BRF_ESS | BRF_PRG }, //  1
 
-	{ "262rp-s1d.s1",      0x020000, 0x492f5efe, 2 | BRF_GRA },     //  2 Text layer tiles
+	{ "262rp-s1.s1",           0x020000, 0x492f5efe, 2 | BRF_GRA },     //  2 Text layer tiles
 
-	{ "262-c1d.c1",        0x800000, 0x103225b1, 3 | BRF_GRA },     //  3 Sprite Data
-	{ "262-c2d.c2",        0x800000, 0xf9d05d99, 3 | BRF_GRA },     //  4
-	{ "262-c3d.c3",        0x800000, 0x4c7ec427, 3 | BRF_GRA },     //  5
-	{ "262-c4d.c4",        0x800000, 0x1d237aa6, 3 | BRF_GRA },     //  6
-	{ "262-c5d.c5",        0x800000, 0xc2256db5, 3 | BRF_GRA },     //  7
-	{ "262-c6d.c6",        0x800000, 0x8d6565a9, 3 | BRF_GRA },     //  8
-	{ "262-c7d.c7",        0x800000, 0xd1408776, 3 | BRF_GRA },     //  9
-	{ "262-c8d.c8",        0x800000, 0x954d0e16, 3 | BRF_GRA },     //  10
+	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
+	/* Encrypted */
+	{ "262-c1-08-e0.c1",       0x800000, 0x99cc785a, 3 | BRF_GRA },     //  2 Sprite data
+	{ "262-c2-08-e0.c2",       0x800000, 0x50368cbf, 3 | BRF_GRA },     //  3
+	{ "262-c3-08-e0.c3",       0x800000, 0xfb14ff87, 3 | BRF_GRA },     //  4
+	{ "262-c4-08-e0.c4",       0x800000, 0x4397faf8, 3 | BRF_GRA },     //  5
+	{ "262-c5-08-e0.c5",       0x800000, 0x91f24be4, 3 | BRF_GRA },     //  6
+	{ "262-c6-08-e0.c6",       0x800000, 0xa31e4403, 3 | BRF_GRA },     //  7
+	{ "262-c7-08-e0.c7",       0x800000, 0x54d9d1ec, 3 | BRF_GRA },     //  8
+	{ "262-c8-08-e0.c8",       0x800000, 0x59289a6b, 3 | BRF_GRA },     //  9
 
-	{ "262rp-m1d.m1",      0x020000, 0x2fb0a8a5, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+	{ "262rp-m1d.m1",          0x020000, 0x2fb0a8a5, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
 
-	{ "262-v1-08-e0.v1",   0x400000, 0x83d49ecf, 5 | BRF_SND },           // 12 Sound data
-	{ "262-v2-08-e0.v2",   0x400000, 0x003f1843, 5 | BRF_SND },           // 13
-	{ "262-v3-08-e0.v3",   0x400000, 0x2ae38dbe, 5 | BRF_SND },           // 14
-	{ "262-v4-08-e0.v4",   0x400000, 0x26ec4dd9, 5 | BRF_SND },           // 15
+	{ "262-v1-08-e0.v1",       0x400000, 0x83d49ecf, 5 | BRF_SND },           // 12 Sound data
+	{ "262-v2-08-e0.v2",       0x400000, 0x003f1843, 5 | BRF_SND },           // 13
+	{ "262-v3-08-e0.v3",       0x400000, 0x2ae38dbe, 5 | BRF_SND },           // 14
+	{ "262-v4-08-e0.v4",       0x400000, 0x26ec4dd9, 5 | BRF_SND },           // 15
 };
 
-STDROMPICKEXT(kof2001rpf, kof2001rpf, neogeo)
-STD_ROM_FN(kof2001rpf)
+STDROMPICKEXT(kof2k1rp, kof2k1rp, neogeo)
+STD_ROM_FN(kof2k1rp)
 
-struct BurnDriver BurnDrvkof2001rpf = {
-	"kof2001rpf", "kof2001", "neogeo", NULL, "Version 2004-03-01",
+static INT32 kof2k1rpInit()
+{
+	nNeoProtectionXor = 0x1E;
+	return NeoInit();
+}
+
+struct BurnDriver BurnDrvkof2k1rp = {
+	"kof2k1rp", "kof2001", "neogeo", NULL, "Version 2004-03-01",
 	"The King of Fighters 2001 Remix Pro v1.02 Final (Hack By Jason, Kim & Raymonose)\0", NULL, "Hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
-	NULL, kof2001rpfRomInfo, kof2001rpfRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_CMC50, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof2k1rpRomInfo, kof2k1rpRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	kof2k1rpInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
 


### PR DESCRIPTION
Correct P2 and M1d as on HBMAME.

current version is just hbmame p2 + 1mb of junkdata (bytes00 and bytesFE).
Use the '.bat' to generate junkdata file and join the roms with junkdata file and:
remix pro    - p2 4mb (91668d86) + junkdata = p2 5mb (37a818ed).
original aes - p2 4mb (91eea062) + junkdata = p2 5mb (aa4ef2f0).


[create_junkdata.zip](https://github.com/finalburnneo/FBNeo/files/8465166/create_junkdata.zip)
