### PR TITLE
neogeo update

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -18972,43 +18972,44 @@ struct BurnDriver BurnDrvkf2k2ps2 = {
 };
 
 // The King of Fighters 2002 (PlayStation 2, Hack)
-// Hack by Dream
+// Hacked by Dream
 
-static struct BurnRomInfo kf2k2ps2bRomDesc[] = {
+static struct BurnRomInfo kof2002ps2RomDesc[] = {
+	/* Encrypted */
 	{ "265-p1ps2.p1",		0x100000, 0x9da95b36, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "265-p2ps2.sp2",		0x500000, 0x9846db3a, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "265-p2ps2.sp2",		0x500000, 0x11419517, 1 | BRF_ESS | BRF_PRG }, //  1
 
-	{ "265-s1ps2.s1",		0x020000, 0x714ade47, 2 | BRF_GRA },           //  2 Text layer tiles
+	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
+	/* Encrypted */
+	{ "265-c1ps2.c1",		0x800000, 0xa92b140e, 3 | BRF_GRA },           //  2 Sprite data
+	{ "265-c2ps2.c2",		0x800000, 0x365e3945, 3 | BRF_GRA },           //  3
+	{ "265-c3ps2.c3",		0x800000, 0xe88beb81, 3 | BRF_GRA },           //  4
+	{ "265-c4ps2.c4",		0x800000, 0x06c374e8, 3 | BRF_GRA },           //  5
+	{ "265-c5ps2.c5",		0x800000, 0x4ffb0fdf, 3 | BRF_GRA },           //  6
+	{ "265-c6ps2.c6",		0x800000, 0xa33c38b9, 3 | BRF_GRA },           //  7
+	{ "265-c7ps2.c7",		0x800000, 0x186cd736, 3 | BRF_GRA },           //  8
+	{ "265-c8ps2.c8",		0x800000, 0xaf60bcf9, 3 | BRF_GRA },           //  9
+	{ "265-c9ps2.c9",		0x800000, 0xbbbd99e5, 3 | BRF_GRA },           // 10
+	{ "265-c10ps2.c10",		0x800000, 0x5d820e2e, 3 | BRF_GRA },           // 11
 
-	{ "265-c1ps2.c1",		0x800000, 0x7efa6ef7, 3 | BRF_GRA },           //  3 Sprite data
-	{ "265-c2ps2.c2",		0x800000, 0xaa82948b, 3 | BRF_GRA },           //  4
-	{ "265-c3ps2.c3",		0x800000, 0x959fad0b, 3 | BRF_GRA },           //  5
-	{ "265-c4ps2.c4",		0x800000, 0xefe6a468, 3 | BRF_GRA },           //  6
-	{ "265-c5ps2.c5",		0x800000, 0x74bba7c6, 3 | BRF_GRA },           //  7
-	{ "265-c6ps2.c6",		0x800000, 0xe20d2216, 3 | BRF_GRA },           //  8
-	{ "265-c7ps2.c7",		0x800000, 0xf0897b93, 3 | BRF_GRA },           //  9
-	{ "265-c8ps2.c8",		0x800000, 0x8d27a4a6, 3 | BRF_GRA },           // 10
-	{ "265-c9ps2.c9",		0x800000, 0x9939c08a, 3 | BRF_GRA },           // 11
-	{ "265-c10ps2.c10",		0x800000, 0xc724c069, 3 | BRF_GRA },           // 12
+	/* Encrypted */
+	{ "265-m1ps2.m1",		0x020000, 0x23961378, 4 | BRF_ESS | BRF_PRG }, // 12 Z80 code
 
-	{ "265-m1ps2.m1",		0x020000, 0xab9d360e, 4 | BRF_ESS | BRF_PRG }, // 13 Z80 code
-
-	{ "265-v1sp2.v1",		0x400000, 0x13d98607, 5 | BRF_SND },           // 14 Sound data
-	{ "265-v2sp2.v2",		0x400000, 0x9cf74677, 5 | BRF_SND },           // 15
-	{ "265-v3sp2.v3",		0x400000, 0x8e9448b5, 5 | BRF_SND },           // 16
-	{ "265-v4sp2.v4",		0x400000, 0x067271b5, 5 | BRF_SND },           // 17
+	/* Encrypted */
+	{ "265-v1.v1",			0x800000, 0x15e8f3f5, 5 | BRF_SND },           // 11 Sound data
+	{ "265-v2.v2",			0x800000, 0xda41d6f9, 5 | BRF_SND },           // 12
 };
 
-STDROMPICKEXT(kf2k2ps2b, kf2k2ps2b, neogeo)
-STD_ROM_FN(kf2k2ps2b)
+STDROMPICKEXT(kof2002ps2, kof2002ps2, neogeo)
+STD_ROM_FN(kof2002ps2)
 
-struct BurnDriver BurnDrvkf2k2ps2b = {
-	"kf2k2ps2b", "kof2002", "neogeo", NULL, "2018",
+struct BurnDriver BurnDrvkof2002ps2 = {
+	"kof2002ps2", "kof2002", "neogeo", NULL, "2018",
 	"The King of Fighters 2002 (PlayStation 2, Hack)\0", "hack only enabled in AES mode", "Hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
-	NULL, kf2k2ps2bRomInfo, kf2k2ps2bRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neoaesjapanDIPInfo,
-	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_CMC50 | HARDWARE_SNK_ENCRYPTED_M1, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof2002ps2RomInfo, kof2002ps2RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neoaesjapanDIPInfo,
+	kof2002Init, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 


### PR DESCRIPTION
[1-1] NON-PCB CMC-encrypted games now allow Sprite-ROM to be longer than 0x4000000;
[1-2] The excess also applies to CMC encryption/decryption.
[2-1] In the case of ips, the reserved length of P-ROM/C-ROM/V-ROM is increased.
[2-2] ips extends the length of sprite-ROM, and in this mode, there is a judgment of the true length to ensure that CMC built-in TextRom can be correctly recognized.
[2-3] When synchronizing ips cmc decrypts the length of the temporary memory, it avoids overflows caused by inconsistencies in the length of the two temporary memory.