### PR TITLE
state.h : Fixed compiler errors

### DIFF
--- a/src/burn/state.h
+++ b/src/burn/state.h
@@ -43,7 +43,7 @@ void StateRunAheadLoad();
 #define ACB_VOLATILE    (ACB_MEMORY_RAM | ACB_DRIVER_DATA)
 
 /* Structure used for area scanning */
-struct BurnArea { void *Data; UINT32 nLen; INT32 nAddress; char *szName; };
+typedef struct BurnArea { void *Data; UINT32 nLen; INT32 nAddress; char *szName; };
 
 /* Application-defined callback for processing the area */
 extern INT32 (__cdecl *BurnAcb) (struct BurnArea* pba);


### PR DESCRIPTION
Since the last update, the following error has occurred.

struct BurnArea - Incomplete class types are not allowed.
![1](https://user-images.githubusercontent.com/67533945/167280318-20b145d9-a628-48f2-bb64-ad7763f8aa6b.png)
![2](https://user-images.githubusercontent.com/67533945/167280320-04f33afd-f153-4dcd-a594-2a81fb95cddd.png)
![3](https://user-images.githubusercontent.com/67533945/167280321-5c905e28-1b2e-472d-b3d2-b3b715addb5b.png)

to

typedef struct BurnArea - ok
![4](https://user-images.githubusercontent.com/67533945/167280329-48497ea9-974e-4164-be86-529dd760b318.png)
![5](https://user-images.githubusercontent.com/67533945/167280332-74e0424b-63f5-4163-97d5-276265f6da5b.png)
![6](https://user-images.githubusercontent.com/67533945/167280335-886d5dc8-7a9f-44a6-ad4d-a3e221c23cda.png)

It is recommended to update, although it does not affect the passing of the actual compilation, a bunch of errors will interfere with the judgment