### PR TITLE
neogeo: bugfix for minor gfx issue introduced in commit - f412f7b5387…

### DIFF
--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -4805,12 +4805,6 @@ INT32 NeoFrame()
 	bRenderImage = false;
 	bForceUpdateOnStatusRead = false;
 
-	if (pBurnDraw) {
-		NeoUpdatePalette();											// Update the palette
-		NeoClearScreen();
-	}
-	nSliceEnd = 0x10;
-
 	SekNewFrame();
 	ZetNewFrame();
 
@@ -4875,6 +4869,11 @@ INT32 NeoFrame()
 	bForcePartialRender = false;
 
 	// Display starts here
+	if (pBurnDraw) {
+		NeoUpdatePalette();											// Update the palette
+		NeoClearScreen();
+	}
+	nSliceEnd = 0x10;
 
 	nCyclesVBlank = nCyclesTotal[0]; //nSekCyclesScanline * 248;
 	if (bRenderLineByLine) {


### PR DESCRIPTION
…ae04fcda42a0b00321cb2c051ff0e

fixes an issue that can occur in the metal slug games (particularly 1) when firing the shotgun. the blast is supposed to white out all sprites for 2 frames but after the prev patch it will sometimes white out only some sprites on 1 frame, all on the 2nd, and then rest on the 3rd.  delaying the renderer updating the palette to just before any visible scanlines fixes this