### PR TITLE
update cps-1 / neogeo hack games & pre90s

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -16836,7 +16836,7 @@ static void Jurassic99PatchCallback()
 	};
 
 	for (INT32 i = 0; i < (sizeof(patch_fix_a) / sizeof(UINT32)) >> 1; i++) {
-		CpsRom[patch_fix_a[(i << 1) + 0]] = patch_fix_a[(i << 1) + 1];
+		CpsRom[patch_fix_a[(i << 1) + 0]] = (UINT8)patch_fix_a[(i << 1) + 1];
 	}
 
 	if (Cps1QSDip & 1) {
@@ -16860,7 +16860,7 @@ static void Jurassic99PatchCallback()
 		};
 
 		for (INT32 i = 0; i < (sizeof(patch_fix_b) / sizeof(UINT32)) >> 1; i++) {
-			CpsRom[patch_fix_b[(i << 1) + 0]] = patch_fix_b[(i << 1) + 1];
+			CpsRom[patch_fix_b[(i << 1) + 0]] = (UINT8)patch_fix_b[(i << 1) + 1];
 		}
 	}
 }
@@ -18232,7 +18232,7 @@ static void PunipicPatchCallback()
 	};
 
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++) {
-		CpsRom[patch_fix[(i << 1) + 0]] = patch_fix[(i << 1) + 1];
+		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
 }
 
@@ -19943,7 +19943,7 @@ static void SlampicPatchCallback()
 	};
 
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++) {
-		CpsRom[patch_fix[(i << 1) + 0]] = patch_fix[(i << 1) + 1];
+		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
 }
 
@@ -20582,7 +20582,7 @@ static void WofsjbPatchCallback()
 	};
 
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT16)) >> 1; i++) {
-		CpsRom[patch_fix[(i << 1) + 0]] = patch_fix[(i << 1) + 1];
+		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
 }
 
@@ -20701,7 +20701,7 @@ static void WofpicPatchCallback()
 	};
 
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++) {
-		CpsRom[patch_fix[(i << 1) + 0]] = patch_fix[(i << 1) + 1];
+		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
 }
 
@@ -25149,10 +25149,10 @@ struct BurnDriver BurnDrvCpsDinore = {
 };
 
 // Tenchi wo Kurau II - Sekiheki no Tatakai (Master Edition, Hack)
-// Hacked by Bindi - 2022/05/13
+// Hacked by Bindi - 2022/05/25
 
 static struct BurnRomInfo WofjdrRomDesc[] = {
-	{ "tk2j_dr.bin",	0x200000, 0xf6a2bbc7, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "tk2j_dr.bin",	0x200000, 0xfabbc160, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
 	{ "tk2_01.3a",		0x080000, 0x0d9cb9bf, BRF_GRA | CPS1_TILES },
 	{ "tk2_02.4a",		0x080000, 0x45227027, BRF_GRA | CPS1_TILES },

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -17175,7 +17175,7 @@ static void kof97tPatchCallback()
 		};
 
 		for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++)
-			Neo68KROMActive[patch_fix[(i << 1) + 0]] = patch_fix[(i << 1) + 1];
+			Neo68KROMActive[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
 }
 
@@ -17369,7 +17369,7 @@ static void kof97ipCallback()
 		};
 
 		for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT16)) >> 1; i++)
-			Neo68KROMActive[patch_fix[(i << 1) + 0]] = patch_fix[(i << 1) + 1];
+			Neo68KROMActive[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
 }
 
@@ -17826,14 +17826,14 @@ struct BurnDriver BurnDrvkof98pfe = {
 };
 
 // The King of Fighters '98 - Easy Combo King (GOTVG Version, hack)
-/* Hacked by gunloc941 - Build 2020-04-09 */
+/* Hacked by gunloc941 - Build 2019-02-17 */
 
 static struct BurnRomInfo kof98eckgRomDesc[] = {
 	/* P1 Encrypted */
-	{ "242-p1eck.p1",	0x200000, 0x2aed3a91, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "242-p2eck.sp2",	0x400000, 0xef36876a, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "242-p1eckg.p1",	0x200000, 0x9746a706, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "242-p2eckg.sp2",	0x400000, 0x5d59e3ae, 1 | BRF_ESS | BRF_PRG }, //  1
 
-	{ "242-s1eck.s1",	0x020000, 0x5a498ed2, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "242-s1eckg.s1",	0x020000, 0xf91c29d2, 2 | BRF_GRA },           //  2 Text layer tiles
 
 	{ "242-c1eckg.c1",	0x800000, 0xd3da4dc1, 3 | BRF_GRA },           //  3 Sprite data
 	{ "242-c2eckg.c2",	0x800000, 0xf5a5d149, 3 | BRF_GRA },           //  4
@@ -17856,7 +17856,7 @@ STDROMPICKEXT(kof98eckg, kof98eckg, neogeo)
 STD_ROM_FN(kof98eckg)
 
 struct BurnDriver BurnDrvkof98eckg = {
-	"kof98eckg", "kof98", "neogeo", NULL, "2020",
+	"kof98eckg", "kof98", "neogeo", NULL, "2019",
 	"The King of Fighters '98 Easy Combo King (GOTVG Version, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
@@ -17869,10 +17869,10 @@ struct BurnDriver BurnDrvkof98eckg = {
 /* Hacked by gunloc941 - YZKOF Build 2020-04-09 */
 
 static struct BurnRomInfo kof98eckyRomDesc[] = {
-	{ "242-pn1eck.p1",	0x100000, 0x0ced4a93, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "242-p2eck.sp2",	0x400000, 0xef36876a, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "242-pn1ecky.p1",	0x100000, 0x0ced4a93, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "242-p2ecky.sp2",	0x400000, 0xef36876a, 1 | BRF_ESS | BRF_PRG }, //  1
 
-	{ "242-s1eck.s1", 	0x020000, 0x5a498ed2, 2 | BRF_GRA },           //  2 Text layer tiles
+	{ "242-s1ecky.s1", 	0x020000, 0x5a498ed2, 2 | BRF_GRA },           //  2 Text layer tiles
 
 	{ "242-c1ecky.c1", 	0x800000, 0xd528dab9, 3 | BRF_GRA },           //  3 Sprite data
 	{ "242-c2ecky.c2", 	0x800000, 0x73556130, 3 | BRF_GRA },           //  4

--- a/src/burn/drv/pre90s/d_jack.cpp
+++ b/src/burn/drv/pre90s/d_jack.cpp
@@ -1659,24 +1659,25 @@ struct BurnDriver BurnDrvZzyzzyxx2 = {
 
 
 // Brix
+// P-1244-1A PCB
 
 static struct BurnRomInfo brixRomDesc[] = {
-	{ "a",			0x1000, 0x050e0d70, 1 | BRF_PRG | BRF_ESS }, //  0 Z80 #0 Code
-	{ "b",			0x1000, 0x668118ae, 1 | BRF_PRG | BRF_ESS }, //  1
-	{ "c",			0x1000, 0xff5ed6cf, 1 | BRF_PRG | BRF_ESS }, //  2
-	{ "d",			0x1000, 0xc3ae45a9, 1 | BRF_PRG | BRF_ESS }, //  3
-	{ "e",			0x1000, 0xdef99fa9, 1 | BRF_PRG | BRF_ESS }, //  4
-	{ "f",			0x1000, 0xdde717ed, 1 | BRF_PRG | BRF_ESS }, //  5
-	{ "g",			0x1000, 0xadca02d8, 1 | BRF_PRG | BRF_ESS }, //  6
-	{ "h",			0x1000, 0xbc3b878c, 1 | BRF_PRG | BRF_ESS }, //  7
+	{ "brix_a.2f",	0x1000, 0x050e0d70, 1 | BRF_PRG | BRF_ESS }, //  0 Z80 #0 Code
+	{ "brix_b.3f",	0x1000, 0x668118ae, 1 | BRF_PRG | BRF_ESS }, //  1
+	{ "brix_c.4f",	0x1000, 0xff5ed6cf, 1 | BRF_PRG | BRF_ESS }, //  2
+	{ "brix_d.6f",	0x1000, 0xc3ae45a9, 1 | BRF_PRG | BRF_ESS }, //  3
+	{ "brix_e.7f",	0x1000, 0xdef99fa9, 1 | BRF_PRG | BRF_ESS }, //  4
+	{ "brix_f.7e",	0x1000, 0xdde717ed, 1 | BRF_PRG | BRF_ESS }, //  5
+	{ "brix_g.6e",	0x1000, 0xadca02d8, 1 | BRF_PRG | BRF_ESS }, //  6
+	{ "brix_h.4e",	0x1000, 0xbc3b878c, 1 | BRF_PRG | BRF_ESS }, //  7
 
-	{ "i.5a",		0x1000, 0xc7742460, 2 | BRF_PRG | BRF_ESS }, //  8 Z80 #1 Code
-	{ "j.6a",		0x1000, 0x72166ccd, 2 | BRF_PRG | BRF_ESS }, //  9
+	{ "brix_i.5a",	0x1000, 0xc7742460, 2 | BRF_PRG | BRF_ESS }, //  8 Z80 #1 Code
+	{ "brix_j.6a",	0x1000, 0x72166ccd, 2 | BRF_PRG | BRF_ESS }, //  9
 
-	{ "n",			0x1000, 0x8064910e, 3 | BRF_GRA },           // 10 Graphics
-	{ "m.1d",		0x1000, 0x217b1402, 3 | BRF_GRA },           // 11
-	{ "k",			0x1000, 0xc7d7e2a0, 3 | BRF_GRA },           // 12
-	{ "l.1a",		0x1000, 0xab421a83, 3 | BRF_GRA },           // 13
+	{ "brix_n.1c",	0x1000, 0x8064910e, 3 | BRF_GRA },           // 10 Graphics
+	{ "brix_m.1d",	0x1000, 0x217b1402, 3 | BRF_GRA },           // 11
+	{ "brix_k.1b",	0x1000, 0xc7d7e2a0, 3 | BRF_GRA },           // 12
+	{ "brix_l.1a",	0x1000, 0xab421a83, 3 | BRF_GRA },           // 13
 };
 
 STD_ROM_PICK(brix)

--- a/src/burn/drv/pre90s/d_sidearms.cpp
+++ b/src/burn/drv/pre90s/d_sidearms.cpp
@@ -1593,9 +1593,9 @@ struct BurnDriver BurnDrvSidearmsj = {
 // Turtle Ship (North America)
 
 static struct BurnRomInfo turtshipRomDesc[] = {
-	{ "t-3.bin",		0x08000, 0xb73ed7f2, 1 | BRF_PRG | BRF_ESS }, //  0 Main CPU
+	{ "t-3.5g",			0x08000, 0xb73ed7f2, 1 | BRF_PRG | BRF_ESS }, //  0 Main CPU
 	{ "t-2.3g",			0x08000, 0x2327b35a, 1 | BRF_PRG | BRF_ESS }, //  1
-	{ "t-1.bin",		0x08000, 0xa258ffec, 1 | BRF_PRG | BRF_ESS }, //  2
+	{ "t-1.3e",			0x08000, 0xa258ffec, 1 | BRF_PRG | BRF_ESS }, //  2
 
 	{ "t-4.8a",			0x08000, 0x1cbe48e8, 2 | BRF_PRG | BRF_ESS }, //  3 Sound CPU
 
@@ -1609,11 +1609,15 @@ static struct BurnRomInfo turtshipRomDesc[] = {
 	{ "t-9.3a",			0x10000, 0x44762916, 4 | BRF_GRA },           // 10
 
 	{ "t-13.1i",		0x10000, 0x599f5246, 5 | BRF_GRA },           // 11 Sprites
-	{ "t-15.bin",		0x10000, 0x6489b7b4, 5 | BRF_GRA },           // 12
+	{ "t-15.3i",		0x10000, 0x6489b7b4, 5 | BRF_GRA },           // 12
 	{ "t-12.1g",		0x10000, 0xfb54cd33, 5 | BRF_GRA },           // 13
-	{ "t-14.bin",		0x10000, 0x1b67b674, 5 | BRF_GRA },           // 14
+	{ "t-14.3g",		0x10000, 0x1b67b674, 5 | BRF_GRA },           // 14
 
 	{ "t-16.9f",		0x08000, 0x1a5a45d7, 6 | BRF_GRA },           // 15 Tilemap
+
+	{ "82s129.11p",		0x00100, 0x75af3553, 7 | BRF_OPT },           // 16 Vertical timing
+	{ "82s129.11r",		0x00100, 0xc47c182a, 7 | BRF_OPT },           // 17 Horizontal timing
+	{ "82s123.9e",		0x00020, 0xc5817816, 7 | BRF_OPT },           // 18 Tied to the sound Z80 and without it there's no sound on the real PCB
 };
 
 STD_ROM_PICK(turtship)
@@ -1654,6 +1658,10 @@ static struct BurnRomInfo turtshipjRomDesc[] = {
 	{ "t-14.3g",		0x10000, 0xd636873c, 5 | BRF_GRA },           // 14
 
 	{ "t-16.9f",		0x08000, 0x1a5a45d7, 6 | BRF_GRA },           // 15 Tilemap
+
+	{ "82s129.11p",		0x00100, 0x75af3553, 7 | BRF_OPT },           // 16 Vertical timing
+	{ "82s129.11r",		0x00100, 0xc47c182a, 7 | BRF_OPT },           // 17 Horizontal timing
+	{ "82s123.9e",		0x00020, 0xc5817816, 7 | BRF_OPT },           // 18 Tied to the sound Z80 and without it there's no sound on the real PCB
 };
 
 STD_ROM_PICK(turtshipj)
@@ -1694,6 +1702,10 @@ static struct BurnRomInfo turtshipkRomDesc[] = {
 	{ "turtship.014",	0x10000, 0xb3ea74a3, 5 | BRF_GRA },           // 14
 
 	{ "turtship.016",	0x08000, 0xaffd51dd, 6 | BRF_GRA },           // 15 Tilemap
+
+	{ "82s129.11p",		0x00100, 0x75af3553, 7 | BRF_OPT },           // 16 Vertical timing
+	{ "82s129.11r",		0x00100, 0xc47c182a, 7 | BRF_OPT },           // 17 Horizontal timing
+	{ "82s123.9e",		0x00020, 0xc5817816, 7 | BRF_OPT },           // 18 Tied to the sound Z80 and without it there's no sound on the real PCB
 };
 
 STD_ROM_PICK(turtshipk)
@@ -1734,6 +1746,10 @@ static struct BurnRomInfo turtshipkoRomDesc[] = {
 	{ "t-14.g3",		0x10000, 0xa30e3346, 5 | BRF_GRA },           // 14
 
 	{ "t-16.f9",		0x08000, 0x9b377277, 6 | BRF_GRA },           // 15 Tilemap
+
+	{ "82s129.11p",		0x00100, 0x75af3553, 7 | BRF_OPT },           // 16 Vertical timing
+	{ "82s129.11r",		0x00100, 0xc47c182a, 7 | BRF_OPT },           // 17 Horizontal timing
+	{ "82s123.9e",		0x00020, 0xc5817816, 7 | BRF_OPT },           // 18 Tied to the sound Z80 and without it there's no sound on the real PCB
 };
 
 STD_ROM_PICK(turtshipko)
@@ -1774,6 +1790,10 @@ static struct BurnRomInfo turtshipknRomDesc[] = {
 	{ "t-14.g3",		0x10000, 0xee162dc0, 5 | BRF_GRA },           // 14
 
 	{ "t-16.f9",		0x08000, 0x9b377277, 6 | BRF_GRA },           // 15 Tilemap
+
+	{ "82s129.11p",		0x00100, 0x75af3553, 7 | BRF_OPT },           // 16 Vertical timing
+	{ "82s129.11r",		0x00100, 0xc47c182a, 7 | BRF_OPT },           // 17 Horizontal timing
+	{ "82s123.9e",		0x00020, 0xc5817816, 7 | BRF_OPT },           // 18 Tied to the sound Z80 and without it there's no sound on the real PCB
 };
 
 STD_ROM_PICK(turtshipkn)


### PR DESCRIPTION
[d_cps-1.cpp] wofjdr update to 20220525.
[d_neogeo.cpp] kof98eckg has some graphics errors, returning Build 2019-02-17.

<graphics error>
![1233](https://user-images.githubusercontent.com/67533945/170767308-fd091c1a-cf1c-4805-a720-698570829afa.jpg)
<Build 2019-02-17>
![kof98eckg-05-27-175755](https://user-images.githubusercontent.com/67533945/170767348-4ba6fdb2-2a71-49f1-8542-c64f38272d8d.png)

[d_sidearms.cpp] Sync mame, adjust rom labels for [turtship] and its clones.
[d_jack.cpp] Sync mame, adjust rom labels for [brix].

test sets:
https://drive.google.com/drive/folders/1qqk2cNlE5ecb6wMGjJmAqTef2xVgshyJ?usp=sharing