### PR TITLE
(luaengine.cpp,m68kcpu,m68000_intf) - fix luamemhook fns

### DIFF
--- a/src/cpu/m68000_intf.cpp
+++ b/src/cpu/m68000_intf.cpp
@@ -3,6 +3,20 @@
 #include "burnint.h"
 #include "m68000_intf.h"
 #include "m68000_debug.h"
+#include <m68k/m68kcpu.h>
+
+enum LuaMemHookType
+{
+	LUAMEMHOOK_WRITE,
+	LUAMEMHOOK_READ,
+	LUAMEMHOOK_EXEC,
+	LUAMEMHOOK_WRITE_SUB,
+	LUAMEMHOOK_READ_SUB,
+	LUAMEMHOOK_EXEC_SUB,
+
+	LUAMEMHOOK_COUNT
+};
+void CallRegisteredLuaMemHook(unsigned int address, int size, unsigned int value, LuaMemHookType hookType);
 
 #ifdef EMU_M68K
 INT32 nSekM68KContextSize[SEK_MAX];
@@ -262,6 +276,7 @@ inline static UINT8 ReadByte(UINT32 a)
 	a &= nSekAddressMaskActive;
 
 //	bprintf(PRINT_NORMAL, _T("read8 0x%08X\n"), a);
+	CallRegisteredLuaMemHook(a, 1, 0, LUAMEMHOOK_READ);
 
 	pr = FIND_R(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER) {
@@ -292,7 +307,7 @@ inline static void WriteByte(UINT32 a, UINT8 d)
 	UINT8* pr;
 
 	a &= nSekAddressMaskActive;
-
+	CallRegisteredLuaMemHook(a, 1, d, LUAMEMHOOK_WRITE);
 //	bprintf(PRINT_NORMAL, _T("write8 0x%08X\n"), a);
 
 	pr = FIND_W(a);
@@ -309,6 +324,7 @@ inline static void WriteByteROM(UINT32 a, UINT8 d)
 	UINT8* pr;
 
 	a &= nSekAddressMaskActive;
+	CallRegisteredLuaMemHook(a, 1, d, LUAMEMHOOK_WRITE);
 
 	// changed from FIND_R to allow for encrypted games (fd1094 etc) to work -dink apr. 23, 2021
 	// (on non-encrypted games, Fetch is mapped to Read)
@@ -328,7 +344,7 @@ inline static UINT16 ReadWord(UINT32 a)
 	a &= nSekAddressMaskActive;
 
 //	bprintf(PRINT_NORMAL, _T("read16 0x%08X\n"), a);
-
+	CallRegisteredLuaMemHook(a, 2, 0, LUAMEMHOOK_READ);
 	pr = FIND_R(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER)
 	{
@@ -375,6 +391,7 @@ inline static void WriteWord(UINT32 a, UINT16 d)
 	a &= nSekAddressMaskActive;
 
 //	bprintf(PRINT_NORMAL, _T("write16 0x%08X\n"), a);
+	CallRegisteredLuaMemHook(a, 2, d, LUAMEMHOOK_WRITE);
 
 	pr = FIND_W(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER)
@@ -403,6 +420,7 @@ inline static void WriteWordROM(UINT32 a, UINT16 d)
 	UINT8* pr;
 
 	a &= nSekAddressMaskActive;
+	CallRegisteredLuaMemHook(a, 2, d, LUAMEMHOOK_WRITE);
 
 	pr = FIND_R(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER) {
@@ -423,6 +441,7 @@ inline static UINT32 ReadLong(UINT32 a)
 	a &= nSekAddressMaskActive;
 
 //	bprintf(PRINT_NORMAL, _T("read32 0x%08X\n"), a);
+	CallRegisteredLuaMemHook(a, 4, 0, LUAMEMHOOK_READ);
 
 	pr = FIND_R(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER)
@@ -491,6 +510,7 @@ inline static void WriteLong(UINT32 a, UINT32 d)
 	a &= nSekAddressMaskActive;
 
 //	bprintf(PRINT_NORMAL, _T("write32 0x%08X\n"), a);
+	CallRegisteredLuaMemHook(a, 4, d, LUAMEMHOOK_WRITE);
 
 	pr = FIND_W(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER)
@@ -522,6 +542,7 @@ inline static void WriteLongROM(UINT32 a, UINT32 d)
 	UINT8* pr;
 
 	a &= nSekAddressMaskActive;
+	CallRegisteredLuaMemHook(a, 4, d, LUAMEMHOOK_WRITE);
 
 	pr = FIND_R(a);
 	if ((uintptr_t)pr >= SEK_MAXHANDLER) {
@@ -1051,6 +1072,11 @@ UINT8 SekCheatRead(UINT32 a)
 	return SekReadByte(a);
 }
 
+static void CallLuaExec(unsigned int newPC)
+{
+	CallRegisteredLuaMemHook(newPC, 1, 0, LUAMEMHOOK_EXEC);
+}
+
 INT32 SekInit(INT32 nCount, INT32 nCPUType)
 {
 	DebugCPU_SekInitted = 1;
@@ -1181,6 +1207,7 @@ INT32 SekInit(INT32 nCount, INT32 nCPUType)
 			SekExit();
 			return 1;
 		}
+		m68k_set_pc_changed_callback(CallLuaExec);
 #endif
 
 #ifdef EMU_A68K
@@ -1230,6 +1257,7 @@ static void SekCPUExitM68K(INT32 i)
 }
 #endif
 
+
 INT32 SekExit()
 {
 #if defined FBNEO_DEBUG
@@ -1248,7 +1276,7 @@ INT32 SekExit()
 #ifdef EMU_M68K
 		SekCPUExitM68K(i);
 #endif
-
+		m68k_set_pc_changed_callback(NULL);
 		// Deallocate other context data
 		if (SekExt[i]) {
 			free(SekExt[i]);
@@ -1310,7 +1338,6 @@ void SekReset(INT32 nCPU)
 
 	SekCPUPop();
 }
-
 // ----------------------------------------------------------------------------
 // Control the active CPU
 
@@ -1757,7 +1784,7 @@ INT32 SekRun(const INT32 nCycles)
 
 #ifdef EMU_M68K
 		nSekCyclesToDo = nCycles;
-
+		
 		if (nSekRESETLine[nSekActive] || nSekHALT[nSekActive])
 		{
 			nSekCyclesSegment = nCycles; // idle when RESET high or halted

--- a/src/cpu/m68k/m68kcpu.c
+++ b/src/cpu/m68k/m68kcpu.c
@@ -2,6 +2,7 @@
 /* ========================= LICENSING & COPYRIGHT ======================== */
 /* ======================================================================== */
 
+
 #if 1
 static const char copyright_notice[] =
 "MUSASHI\n"
@@ -451,7 +452,10 @@ const uint8 m68ki_ea_idx_cycle_table[64] =
 /* Default callbacks used if the callback hasn't been set yet, or if the
  * callback is set to NULL
  */
-
+static void (*pc_changed_cb)(UINT32) = NULL;
+void m68k_set_pc_changed_cb(void (*cbf)(UINT32)) {
+	pc_changed_cb = cbf;
+}
 /* Interrupt acknowledge */
 static int default_int_ack_callback_data;
 static int default_int_ack_callback(int int_level)
@@ -666,7 +670,11 @@ void m68k_set_tas_instr_callback(int  (*callback)(void))
 void m68k_set_pc_changed_callback(void  (*callback)(unsigned int new_pc))
 {
 	CALLBACK_PC_CHANGED = callback ? callback : default_pc_changed_callback;
+	// Figure out why the above doesnt work but this does
+	pc_changed_cb = callback;
+
 }
+
 
 void m68k_set_fc_callback(void  (*callback)(unsigned int new_fc))
 {
@@ -825,6 +833,10 @@ int m68k_execute(int num_cycles)
 			/* Record previous program counter */
 			REG_PPC = REG_PC;
 
+			if (pc_changed_cb) {
+				pc_changed_cb(REG_PC);
+			}
+
 			/* Read an instruction and call its handler */
 			REG_IR = m68ki_read_imm_16();
 			m68ki_instruction_jump_table[REG_IR]();
@@ -839,6 +851,7 @@ int m68k_execute(int num_cycles)
 	}
 	else
 		SET_CYCLES(0);
+
 
 	/* return how many clocks we used */
 	return m68ki_cpu.initial_cycles - GET_CYCLES();


### PR DESCRIPTION
I can't figure out why the CALLBACK_PC_CHANGED  callback is not exposed to lua when working this way. It seems to never get updated!

Getting the Z80 to work has similar problems as m68k, It seems the way it was handled was changed as well since fba-rr.

Let me know what errors I have made, and I will try my best to fix them.

The changes have been tested by Alice and myself from the LUA scripting end.   