### PR TITLE
fbneo sdl2: enabling cheats in ingame menu

### DIFF
--- a/src/burner/conc.cpp
+++ b/src/burner/conc.cpp
@@ -392,7 +392,7 @@ static INT32 ConfigParseNebulaFile(TCHAR* pszFilename)
 		while (i < nLen)
 		{
 			if (szLine[i] == '=' && i < 4) j = i+1;
-			if (szLine[i] == ',' || szLine[i] == '\n')
+			if (szLine[i] == ',' || szLine[i] == '\r' || szLine[i] == '\n')
 			{
 				if (pCurrentCheat->pOption[n] == NULL) {
 					pCurrentCheat->pOption[n] = (CheatOption*)malloc(sizeof(CheatOption));
@@ -413,7 +413,7 @@ static INT32 ConfigParseNebulaFile(TCHAR* pszFilename)
 		{
 			if (i == nLen) break;
 
-			if (szLine[i] == ',' || szLine[i] == '\n')
+			if (szLine[i] == ',' || szLine[i] == '\r' || szLine[i] == '\n')
 			{
 				_tcsncpy (tmp, szLine + j, i-j);
 				tmp[i-j] = '\0';
@@ -550,7 +550,7 @@ static INT32 ConfigParseMAMEFile_internal(FILE *fz, const TCHAR *name)
 
 		INT32 c0[16], c1 = 0;					// find colons / break
 		for (INT32 i = 0; i < nLen; i++)
-			if (szLine[i] == ':' || szLine[i] == '\n')
+			if (szLine[i] == ':' || szLine[i] == '\r' || szLine[i] == '\n')
 				c0[c1++] = i;
 
 		tmpcpy(1);						// control flags

--- a/src/intf/video/sdl/vid_sdl2.cpp
+++ b/src/intf/video/sdl/vid_sdl2.cpp
@@ -22,6 +22,7 @@ static bool bFlipped = false;
 static SDL_Rect dstrect;
 static char Windowtitle[512];
 
+extern UINT16 maxLinesMenu;	// sdl2_gui_ingame.cpp: number of lines to show in ingame menus
 
 void RenderMessage()
 {
@@ -249,10 +250,12 @@ static int Init()
 #endif
 	if (nRotateGame)
 	{
+		maxLinesMenu = display_w / 10 - 6;		// Get number of lines to show in ingame menus
 		SDL_RenderSetLogicalSize(sdlRenderer, display_h, display_w);
 	}
 	else
 	{
+		maxLinesMenu = display_h / 10 - 6;		// Get number of lines to show in ingame menus
 		SDL_RenderSetLogicalSize(sdlRenderer, display_w, display_h);
 	}
 


### PR DESCRIPTION
Cheats menu is now populated and working in the ingame menu.

(conc.cpp) Also ignore carriage return chars when parsing cheats *.ini

Some games have big list of cheats that won't fit on screen, so scrolling is also implemented.

Dynamic menu title helps navigation, particularly when going into sub menus.

Corrected aspect ratio of game screenshot shown in ingame menu.

Also, game screenshot is only shown in top menu, as it can make difficult to read menu's options when text overlaps.
