### PR TITLE
SDL2: Improve resetting buttons mapping by restoring previous mapping

### DIFF
--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -34,8 +34,8 @@ int gameSelectedFromFilter = -1;
 TCHAR szAppBurnVer[16];
 char videofiltering[3];
 
-#ifdef BUILD_SDL2
 bool do_reload_game = false;	// To reload game when buttons mapping changed
+#ifdef BUILD_SDL2
 SDL_Window* sdlWindow = NULL;
 
 static char* szSDLeepromPath = NULL;

--- a/src/burner/sdl/sdl2_gui_ingame.cpp
+++ b/src/burner/sdl/sdl2_gui_ingame.cpp
@@ -199,7 +199,27 @@ int UpdateMappingMenuSelected()
 
 int ResetMappedButtons()
 {
-	for (int i = 0; i < BUTTONS_TO_MAP; i++) {
+	SDL_GameControllerButtonBind bind;
+	SDL_GameController *currentGameController = SDL_GameControllerOpen(current_selected_joystick);
+	if (currentGameController)
+	{
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_A );
+		mappedbuttons[0] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_B);
+		mappedbuttons[1] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_X );
+		mappedbuttons[2] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_Y);
+		mappedbuttons[3] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_LEFTSHOULDER  );
+		mappedbuttons[4] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER );
+		mappedbuttons[5] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_BACK   );
+		mappedbuttons[6] = bind.value.button;
+		bind = SDL_GameControllerGetBindForButton(currentGameController, SDL_CONTROLLER_BUTTON_START  );
+		mappedbuttons[7] = bind.value.button;
+	} else for (int i = 0; i < BUTTONS_TO_MAP; i++) {
 		mappedbuttons[i] = -1;
 	}
 	UpdateMappingMenuSelected();


### PR DESCRIPTION
Now if a controller was previously mapped it will be restored instead of making null all binds.

Unrelated fix (main.cpp): moved declaration of "do_reload_game" variable to avoid breaking Linux SDL 1.2 build.