### PR TITLE
SDL2: fix missing declarations for macOS build

### DIFF
--- a/src/burner/macos/burner_macos.h
+++ b/src/burner/macos/burner_macos.h
@@ -53,7 +53,21 @@ int MediaInit();
 int MediaExit();
 
 //inpdipsw.cpp
+#define DIP_MAX_NAME 64
+#define MAXDIPSWITCHES 32
+#define MAXDIPOPTIONS 32
+bool setDIPSwitchOption(int dipgroup, int dipoption);
+int InpDIPSWCreate();
 void InpDIPSWResetDIPs();
+
+struct GroupOfDIPSwitches
+{
+	BurnDIPInfo dipSwitch;
+	UINT16 DefaultDIPOption;
+	UINT16 SelectedDIPOption;
+	char OptionsNamesWithCheckBoxes[MAXDIPOPTIONS][DIP_MAX_NAME];
+	BurnDIPInfo dipSwitchesOptions[MAXDIPOPTIONS];
+};
 
 //interface/inp_interface.cpp
 int InputInit();


### PR DESCRIPTION
macOS port fails to build because some declarations are missing in burner_macos.h