### PR TITLE
SDL2: Fix black screen when some games resize screen

### DIFF
--- a/src/burner/sdl/scrn.cpp
+++ b/src/burner/sdl/scrn.cpp
@@ -1,8 +1,10 @@
 #include "burner.h"
 
+bool didReinitialise = false;
+
 void Reinitialise()
 {
-	//POST_INITIALISE_MESSAGE;
+	didReinitialise = true;
 	VidReInitialise();
 }
 

--- a/src/intf/video/sdl/vid_sdl2.cpp
+++ b/src/intf/video/sdl/vid_sdl2.cpp
@@ -23,6 +23,7 @@ static SDL_Rect dstrect;
 static char Windowtitle[512];
 
 extern UINT16 maxLinesMenu;	// sdl2_gui_ingame.cpp: number of lines to show in ingame menus
+extern bool didReinitialise;
 
 void RenderMessage()
 {
@@ -333,6 +334,10 @@ static int vidScale(RECT*, int, int)
 // Run one frame and render the screen
 static int Frame(bool bRedraw)                                          // bRedraw = 0
 {
+	if ((didReinitialise) && (pVidImage == NULL)) {
+		Exit();
+		Init();
+	}
 	if (pVidImage == NULL)
 	{
 		return 1;


### PR DESCRIPTION
Tested:
- Wide screen DIP switch in sfiii.
- megadrive games - Micro Machines and Mortal Kombat 1, 2, 3 and 5.