### PR TITLE
SDL2: fix inputs from <romname>.ini being ignored (and presets/*.ini …

### DIFF
--- a/src/burner/burner.h
+++ b/src/burner/burner.h
@@ -136,8 +136,9 @@ void GetHistoryDatHardwareToken(char *to_string);
 extern INT32 nAutoFireRate;
 
 // Player Default Controls
-extern INT32 nPlayerDefaultControls[8];
-extern TCHAR szPlayerDefaultIni[5][MAX_PATH];
+#define MAX_JOYSTICKS 4
+extern INT32 nPlayerDefaultControls[MAX_JOYSTICKS];
+extern TCHAR szPlayerDefaultIni[MAX_JOYSTICKS][MAX_PATH];
 
 // mappable System Macros for the Input Dialogue
 extern UINT8 macroSystemPause;

--- a/src/burner/sdl/drv.cpp
+++ b/src/burner/sdl/drv.cpp
@@ -84,7 +84,6 @@ int DrvInit(int nDrvNum, bool bRestore)
 
 	nBurnDrvActive = nDrvNum;		// Set the driver number
 
-
 	if ((BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK) == HARDWARE_SNK_NEOCD) {
 		if (CDEmuInit()) {
 			printf("CD emu failed\n");
@@ -108,8 +107,9 @@ int DrvInit(int nDrvNum, bool bRestore)
 
 	// if a config file was loaded, set bSaveInputs so that this config file won't be reset to default at exit
 	bSaveInputs = ConfigGameLoad(true);
-	InputMake(true);
+	if(bSaveInputs) ConfigGameLoadHardwareDefaults();
 
+	InputMake(true);
 	GameInpDefault();
 
 	if (DoLibInit())                         // Init the Burn library's driver

--- a/src/burner/sdl/input_sdl2.cpp
+++ b/src/burner/sdl/input_sdl2.cpp
@@ -86,7 +86,6 @@ static int GameInpConfig(int nPlayer, int nPcDev, int nAnalog)
 
 static void GameInpConfigOne(int nPlayer, int nPcDev, int nAnalog, struct GameInp* pgi, char* szi)
 {
-
 	GamcPlayer(pgi, szi, nPlayer, nPcDev - 1);
 	// nPcDev == 0 is Keyboard, nPcDev == 1 is joy0, etc.
 	if (nPcDev) GamcAnalogJoy(pgi, szi, nPlayer, nPcDev - 1, nAnalog);
@@ -263,21 +262,24 @@ INT32 display_set_controls()
    return 0;
 }
 
-
+/*
+// This seems to be useless and was restoring inputs to defaults
+// ignoring any inputs defined in <romname>.ini by the user
 INT32 Init_Joysticks(int p_one_use_joystick)
 {
 	if (p_one_use_joystick) {
-		/*init all joysticks (4 max atm) to map or the default will think 
-		p1 is keyboard and p2 p3 p4 is joy 0 1 2 instead of joy 1 2 3 */
-		for (int i = 0; i < 4; ++i) {
+		// init all joysticks (4 max atm) to map or the default will think 
+		// p1 is keyboard and p2 p3 p4 is joy 0 1 2 instead of joy 1 2 3
+		for (int i = 0; i < nMaxPlayers; ++i) {
 			GameInpConfig(i, i+1, 1);
 		}
 	} else {
-		/*keyboard p1, joy0 p2, joy1 p3, joy2 p4) */
-		for (int i = 0; i < 4; ++i) {
+		// keyboard p1, joy0 p2, joy1 p3, joy2 p4)
+		for (int i = 0; i < nMaxPlayers; ++i) {
 			GameInpConfig(i, i, 1);
 		}
 	}
 	display_set_controls();
 	return 0;
 }
+*/

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -15,7 +15,7 @@
 
 #include "burner.h"
 
-INT32 Init_Joysticks(int p1_use_joystick);
+// INT32 Init_Joysticks(int p1_use_joystick);
 
 int  nAppVirtualFps = 0;         // App fps * 100
 bool bRunPause = 0;
@@ -237,7 +237,7 @@ void DoGame(int gameToRun)
 		if (!DrvInit(gameToRun, 0))
 		{
 			MediaInit();
-			Init_Joysticks(usejoy);
+			// Init_Joysticks(usejoy);
 			RunMessageLoop();
 		}
 		else
@@ -341,6 +341,11 @@ int main(int argc, char* argv[])
 		{
 			return 0;
 		}
+	}
+
+	if (!usejoy) {		// Player 1 will use keyboard
+		for (int j = 0; j < MAX_JOYSTICKS; j++) 
+			nPlayerDefaultControls[j] = nPlayerDefaultControls[j] - 1;
 	}
 
 	// Do these bits before override via ConfigAppLoad

--- a/src/burner/sdl/sdl2_gui_ingame.cpp
+++ b/src/burner/sdl/sdl2_gui_ingame.cpp
@@ -176,7 +176,6 @@ int DIPMenuSelected()
 
 // Controllers stuff
 #define JOYSTICK_DEAD_ZONE 8000
-#define MAX_JOYSTICKS 4
 #define BUTTONS_TO_MAP 8
 
 struct MenuItem controllerMenu[MAX_JOYSTICKS + 1];	// One more for BACK
@@ -385,7 +384,8 @@ int ControllerMenuSelected()
 		controllerMenu[i] = (MenuItem){joystickNames[i], MappingMenuSelected, NULL};
 		controllermenucount++;
 	}
-	controllerMenu[controllermenucount] = (MenuItem){"BACK\0", MainMenuSelected, NULL};
+	if (controllermenucount > 0) controllerMenu[controllermenucount] = (MenuItem){"BACK\0", MainMenuSelected, NULL};
+	else controllerMenu[controllermenucount] = (MenuItem){"BACK (no controllers found)\0", MainMenuSelected, NULL};
 	controllermenucount++;
   return 0;
 }

--- a/src/intf/input/sdl/inp_sdl2.cpp
+++ b/src/intf/input/sdl/inp_sdl2.cpp
@@ -3,7 +3,6 @@
 
 #include "burner.h"
 
-#define MAX_JOYSTICKS 4				// Changed from 8 to 4, only 4 are supported anyway
 #define JOYSTICK_DEAD_ZONE 8000		// Replace DEADZONE to make it coherent with other declarations
 
 static int FBKtoSDL[512] = { 0 };


### PR DESCRIPTION
…too)

Any changes made to inputs would always be ignored and reset to defaults.

Also fixed presets being ignored in SDL builds (for example, presets/cps.ini will be used for any CPS game if <romname>.ini did not exist).

Note about -joy parameter and player 1 using keyboard or joystick:
If <romname>.ini or presets/*.ini exists when a game is launched, whatever is defined for player 1 is what is used, being irrelevant if -joy parameter is used or not.