### PR TITLE
SDL2: fix loading inputs from *.ini

### DIFF
--- a/src/burner/gami.cpp
+++ b/src/burner/gami.cpp
@@ -2048,7 +2048,12 @@ void GetHistoryDatHardwareToken(char *to_string)
 
 INT32 ConfigGameLoadHardwareDefaults()
 {
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	TCHAR *szFolderName = _T("");
+	TCHAR szFileName[MAX_PATH] = _T("");
+#else
 	TCHAR *szFileName = _T("");
+#endif
 	INT32 nApplyHardwareDefaults = 0;
 
 	INT32 nHardwareFlag = (BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK);
@@ -2058,7 +2063,16 @@ INT32 ConfigGameLoadHardwareDefaults()
 		for (INT32 hw = 0; gamehw_cfg[i].hw[hw] != 0; hw++) {
 			if (gamehw_cfg[i].hw[hw] == nHardwareFlag)
 			{
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+				szFolderName = SDL_GetPrefPath(NULL, "fbneo");		// Get fbneo folder path
+				#if defined(UNICODE)
+				swprintf(szFileName, MAX_PATH, L"%s%s", szFolderName, gamehw_cfg[i].ini);
+				#else
+				snprintf(szFileName, MAX_PATH, "%s%s", szFolderName, gamehw_cfg[i].ini);
+				#endif
+#else
 				szFileName = gamehw_cfg[i].ini;
+#endif
 				nApplyHardwareDefaults = 1;
 				break;
 			}

--- a/src/burner/sdl/drv.cpp
+++ b/src/burner/sdl/drv.cpp
@@ -84,7 +84,6 @@ int DrvInit(int nDrvNum, bool bRestore)
 
 	nBurnDrvActive = nDrvNum;		// Set the driver number
 
-
 	if ((BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK) == HARDWARE_SNK_NEOCD) {
 		if (CDEmuInit()) {
 			printf("CD emu failed\n");
@@ -108,8 +107,9 @@ int DrvInit(int nDrvNum, bool bRestore)
 
 	// if a config file was loaded, set bSaveInputs so that this config file won't be reset to default at exit
 	bSaveInputs = ConfigGameLoad(true);
-	InputMake(true);
+	if(bSaveInputs) ConfigGameLoadHardwareDefaults();
 
+	InputMake(true);
 	GameInpDefault();
 
 	if (DoLibInit())                         // Init the Burn library's driver

--- a/src/burner/sdl/input_sdl2.cpp
+++ b/src/burner/sdl/input_sdl2.cpp
@@ -86,7 +86,6 @@ static int GameInpConfig(int nPlayer, int nPcDev, int nAnalog)
 
 static void GameInpConfigOne(int nPlayer, int nPcDev, int nAnalog, struct GameInp* pgi, char* szi)
 {
-
 	GamcPlayer(pgi, szi, nPlayer, nPcDev - 1);
 	// nPcDev == 0 is Keyboard, nPcDev == 1 is joy0, etc.
 	if (nPcDev) GamcAnalogJoy(pgi, szi, nPlayer, nPcDev - 1, nAnalog);
@@ -267,14 +266,14 @@ INT32 display_set_controls()
 INT32 Init_Joysticks(int p_one_use_joystick)
 {
 	if (p_one_use_joystick) {
-		/*init all joysticks (4 max atm) to map or the default will think 
-		p1 is keyboard and p2 p3 p4 is joy 0 1 2 instead of joy 1 2 3 */
-		for (int i = 0; i < 4; ++i) {
+		// init all joysticks (4 max atm) to map or the default will think 
+		// p1 is keyboard and p2 p3 p4 is joy 0 1 2 instead of joy 1 2 3
+		for (int i = 0; i < nMaxPlayers; ++i) {
 			GameInpConfig(i, i+1, 1);
 		}
 	} else {
-		/*keyboard p1, joy0 p2, joy1 p3, joy2 p4) */
-		for (int i = 0; i < 4; ++i) {
+		// keyboard p1, joy0 p2, joy1 p3, joy2 p4)
+		for (int i = 0; i < nMaxPlayers; ++i) {
 			GameInpConfig(i, i, 1);
 		}
 	}

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -237,7 +237,7 @@ void DoGame(int gameToRun)
 		if (!DrvInit(gameToRun, 0))
 		{
 			MediaInit();
-			Init_Joysticks(usejoy);
+			if (usejoy) Init_Joysticks(1);	// This will ignore inputs defined in *.ini and use joysticks for all players
 			RunMessageLoop();
 		}
 		else

--- a/src/burner/sdl/sdl2_gui_ingame.cpp
+++ b/src/burner/sdl/sdl2_gui_ingame.cpp
@@ -175,8 +175,8 @@ int DIPMenuSelected()
 
 
 // Controllers stuff
+#define MAX_JOYSTICKS 8
 #define JOYSTICK_DEAD_ZONE 8000
-#define MAX_JOYSTICKS 4
 #define BUTTONS_TO_MAP 8
 
 struct MenuItem controllerMenu[MAX_JOYSTICKS + 1];	// One more for BACK
@@ -385,7 +385,8 @@ int ControllerMenuSelected()
 		controllerMenu[i] = (MenuItem){joystickNames[i], MappingMenuSelected, NULL};
 		controllermenucount++;
 	}
-	controllerMenu[controllermenucount] = (MenuItem){"BACK\0", MainMenuSelected, NULL};
+	if (controllermenucount > 0) controllerMenu[controllermenucount] = (MenuItem){"BACK\0", MainMenuSelected, NULL};
+	else controllerMenu[controllermenucount] = (MenuItem){"BACK (no controllers found)\0", MainMenuSelected, NULL};
 	controllermenucount++;
   return 0;
 }

--- a/src/intf/input/sdl/inp_sdl2.cpp
+++ b/src/intf/input/sdl/inp_sdl2.cpp
@@ -3,8 +3,8 @@
 
 #include "burner.h"
 
-#define MAX_JOYSTICKS 4				// Changed from 8 to 4, only 4 are supported anyway
 #define JOYSTICK_DEAD_ZONE 8000		// Replace DEADZONE to make it coherent with other declarations
+#define MAX_JOYSTICKS 8
 
 static int FBKtoSDL[512] = { 0 };
 static int SDLtoFBK[512] = { -1 };


### PR DESCRIPTION
Fixed inputs always being reset to defaults (ignoring custom inputs from <romname>.ini).

Also fixed loading presets when <romname>.ini does not exist.

Note: -joy parameter will always ignore inputs from *.ini and set joystick inputs for all players.
If the -joy parameter is used when a game is launched for the first time, player 1 inputs will be set to joysticks and won't work without -joy after that, because without -joy the keyboard is assigned to player 1.