### PR TITLE
SDL2: fix support paths (that fixes hiscores and samples)

### DIFF
--- a/src/burner/cong.cpp
+++ b/src/burner/cong.cpp
@@ -6,22 +6,15 @@ const INT32 nConfigMinVersion = 0x020921;
 
 bool bSaveInputs = true;
 
-#ifdef BUILD_SDL2
-static char* szSDLconfigPath = NULL;
-#endif
-
 static TCHAR* GameConfigName()
 {
 	static TCHAR szName[MAX_PATH];
 
-	#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)	
-	 	if (szSDLconfigPath == NULL) {
-			szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
-		}
+	#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
 		if (NeoCDInfo_ID()) {
-		  snprintf(szName, MAX_PATH, "%sngcd_%s.ini", szSDLconfigPath, BurnDrvGetText(DRV_NAME));
+		  _stprintf(szName, _T("%sngcd_%s.ini"), szAppEEPROMPath, BurnDrvGetText(DRV_NAME));
 		} else {
-			snprintf(szName, MAX_PATH, "%s%s.ini", szSDLconfigPath, BurnDrvGetText(DRV_NAME));
+			_stprintf(szName, _T("%s%s.ini"), szAppEEPROMPath, BurnDrvGetText(DRV_NAME));
 		}
 	#else
 		// Return the path of the config file for this game
@@ -55,8 +48,13 @@ INT32 ConfigGameLoad(bool bOverWrite)
 		TCHAR *szValue;
 		INT32 nLen = _tcslen(szLine);
 
-		// Get rid of the linefeed at the end
+		// Get rid of the linefeed and carriage return at the end
 		if (szLine[nLen - 1] == 10) {
+			szLine[nLen - 1] = 0;
+			nLen--;
+		}
+		if (szLine[nLen - 1] == 13)
+		{
 			szLine[nLen - 1] = 0;
 			nLen--;
 		}

--- a/src/burner/gami.cpp
+++ b/src/burner/gami.cpp
@@ -1911,8 +1911,13 @@ INT32 GameInputAutoIni(INT32 nPlayer, TCHAR* lpszFile, bool bOverWrite)
 		TCHAR* szValue;
 		INT32 nLen = _tcslen(szLine);
 
-		// Get rid of the linefeed at the end
+		// Get rid of the linefeed and carriage return at the end
 		if (szLine[nLen - 1] == 10) {
+			szLine[nLen - 1] = 0;
+			nLen--;
+		}
+		if (szLine[nLen - 1] == 13)
+		{
 			szLine[nLen - 1] = 0;
 			nLen--;
 		}
@@ -2049,7 +2054,8 @@ void GetHistoryDatHardwareToken(char *to_string)
 INT32 ConfigGameLoadHardwareDefaults()
 {
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-	TCHAR *szFolderName = _T("");
+	TCHAR *szFolderName = NULL;
+	szFolderName = SDL_GetPrefPath(NULL, "fbneo");		// Get fbneo folder path
 	TCHAR szFileName[MAX_PATH] = _T("");
 #else
 	TCHAR *szFileName = _T("");
@@ -2064,12 +2070,7 @@ INT32 ConfigGameLoadHardwareDefaults()
 			if (gamehw_cfg[i].hw[hw] == nHardwareFlag)
 			{
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-				szFolderName = SDL_GetPrefPath(NULL, "fbneo");		// Get fbneo folder path
-				#if defined(UNICODE)
-				swprintf(szFileName, MAX_PATH, L"%s%s", szFolderName, gamehw_cfg[i].ini);
-				#else
-				snprintf(szFileName, MAX_PATH, "%s%s", szFolderName, gamehw_cfg[i].ini);
-				#endif
+				_stprintf(szFileName, _T("%s%s"), szFolderName, gamehw_cfg[i].ini);
 #else
 				szFileName = gamehw_cfg[i].ini;
 #endif
@@ -2085,6 +2086,9 @@ INT32 ConfigGameLoadHardwareDefaults()
 		}
 	}
 
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	SDL_free(szFolderName);
+#endif
 	return 0;
 }
 

--- a/src/burner/sdl/burner_sdl.h
+++ b/src/burner/sdl/burner_sdl.h
@@ -134,23 +134,6 @@ public:
 };
 
 // support_paths.cpp
-extern TCHAR szAppPreviewsPath[MAX_PATH];
-extern TCHAR szAppTitlesPath[MAX_PATH];
-extern TCHAR szAppSelectPath[MAX_PATH];
-extern TCHAR szAppVersusPath[MAX_PATH];
-extern TCHAR szAppHowtoPath[MAX_PATH];
-extern TCHAR szAppScoresPath[MAX_PATH];
-extern TCHAR szAppBossesPath[MAX_PATH];
-extern TCHAR szAppGameoverPath[MAX_PATH];
-extern TCHAR szAppFlyersPath[MAX_PATH];
-extern TCHAR szAppMarqueesPath[MAX_PATH];
-extern TCHAR szAppControlsPath[MAX_PATH];
-extern TCHAR szAppCabinetsPath[MAX_PATH];
-extern TCHAR szAppPCBsPath[MAX_PATH];
-extern TCHAR szAppCheatsPath[MAX_PATH];
-extern TCHAR szAppHistoryPath[MAX_PATH];
 extern TCHAR szAppListsPath[MAX_PATH];
 extern TCHAR szAppDatListsPath[MAX_PATH];
-extern TCHAR szAppIpsPath[MAX_PATH];
-extern TCHAR szAppIconsPath[MAX_PATH];
 extern TCHAR szAppArchivesPath[MAX_PATH];

--- a/src/burner/sdl/config.cpp
+++ b/src/burner/sdl/config.cpp
@@ -3,25 +3,65 @@
 
 int nIniVersion = 0;
 
-#ifdef BUILD_SDL2
-static char* szSDLconfigPath = NULL;
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+void FixAndCreateSupportPath(TCHAR *pSupportFolderPath, TCHAR *pBaseFolderName)
+{
+	TCHAR *szSupportFolderFixedPath = NULL;
+
+	if (strstr(pSupportFolderPath, pBaseFolderName) == NULL) {
+		if (pSupportFolderPath[strlen(pSupportFolderPath) - 1] == '/') pSupportFolderPath[strlen(pSupportFolderPath) - 1] = '\0';
+		szSupportFolderFixedPath = SDL_GetPrefPath("fbneo", pSupportFolderPath);
+		_stprintf(pSupportFolderPath, _T("%s"), szSupportFolderFixedPath);
+		SDL_free(szSupportFolderFixedPath);
+	}
+}
+
+void InitSupportPaths()
+{
+	TCHAR *szBaseFolderName = NULL;
+	szBaseFolderName = SDL_GetPrefPath(NULL, "fbneo");
+	FixAndCreateSupportPath(szAppPreviewsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppTitlesPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppCheatsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppHiscorePath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppSamplesPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppHDDPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppIpsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppIconsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppBlendPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppSelectPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppVersusPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppHowtoPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppScoresPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppBossesPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppGameoverPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppFlyersPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppMarqueesPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppControlsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppCabinetsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppPCBsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppHistoryPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppEEPROMPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppListsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppDatListsPath, szBaseFolderName);
+	FixAndCreateSupportPath(szAppArchivesPath, szBaseFolderName);
+
+	TCHAR szAppPresets[MAX_PATH] = _T("config/presets/");
+	FixAndCreateSupportPath(szAppPresets, szBaseFolderName);
+
+	SDL_free(szBaseFolderName);
+}
 #endif
 
 static void CreateConfigName(char* szConfig)
 {
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-	char cfgdir[MAX_PATH] = { 0 };
-
-	if (szSDLconfigPath == NULL)
-	{
-		szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
-	}
-
-	snprintf(cfgdir, MAX_PATH, "%sfbneo.ini", szSDLconfigPath);
-	memcpy(szConfig, cfgdir, sizeof(cfgdir));
+	TCHAR *szSDLconfigPath = NULL;
+	szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
+	_stprintf(szConfig, _T("%sfbneo.ini"), szSDLconfigPath);
+	SDL_free(szSDLconfigPath);
 #else
 	_stprintf(szConfig, _T("fbneo.ini"));
-
 #endif
 
 	return;
@@ -51,9 +91,14 @@ int ConfigAppLoad()
 	char szLine[256];
 	while (fgets(szLine, sizeof(szLine), f))
 	{
-		// Get rid of the linefeed at the end
+		// Get rid of the linefeed and carriage return at the end
 		int nLen = strlen(szLine);
 		if (szLine[nLen - 1] == 10)
+		{
+			szLine[nLen - 1] = 0;
+			nLen--;
+		}
+		if (szLine[nLen - 1] == 13)
 		{
 			szLine[nLen - 1] = 0;
 			nLen--;
@@ -138,6 +183,11 @@ int ConfigAppLoad()
 // Write out the config file for the whole application
 int ConfigAppSave()
 {
+
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	InitSupportPaths();
+#endif
+
 	char  szConfig[MAX_PATH];
 	FILE* f;
 
@@ -227,6 +277,8 @@ int ConfigAppSave()
 	STR(szAppSamplesPath);
 	fprintf(f, "\n// HDD image path (include trailing slash)\n");
 	STR(szAppHDDPath);
+	fprintf(f, "\n// EEPROM save path (include trailing slash)\n");
+	STR(szAppEEPROMPath);
 	fprintf(f, "\n// UNUSED CURRENTLY (include trailing slash)\n");
 	STR(szAppIpsPath);
 	fprintf(f, "\n// UNUSED CURRENTLY (include trailing slash)\n");
@@ -257,8 +309,6 @@ int ConfigAppSave()
 	STR(szAppPCBsPath);
 	fprintf(f, "\n// UNUSED CURRENTLY (include trailing slash)\n");
 	STR(szAppHistoryPath);
-	fprintf(f, "\n// EEPROM save path (include trailing slash)\n");
-	STR(szAppEEPROMPath);
 	fprintf(f, "\n// UNUSED CURRENTLY (include trailing slash)\n");
 	STR(szAppListsPath);
 	fprintf(f, "\n// UNUSED CURRENTLY (include trailing slash)\n");

--- a/src/burner/sdl/input_sdl2.cpp
+++ b/src/burner/sdl/input_sdl2.cpp
@@ -277,6 +277,5 @@ INT32 Init_Joysticks(int p_one_use_joystick)
 			GameInpConfig(i, i, 1);
 		}
 	}
-	display_set_controls();
 	return 0;
 }

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -16,6 +16,7 @@
 #include "burner.h"
 
 INT32 Init_Joysticks(int p1_use_joystick);
+INT32 display_set_controls();
 
 int  nAppVirtualFps = 0;         // App fps * 100
 bool bRunPause = 0;
@@ -36,12 +37,6 @@ char videofiltering[3];
 bool do_reload_game = false;	// To reload game when buttons mapping changed
 #ifdef BUILD_SDL2
 SDL_Window* sdlWindow = NULL;
-
-static char* szSDLeepromPath = NULL;
-static char* szSDLhiscorePath = NULL;
-static char* szSDLHDDPath = NULL;
-static char* szSDLSamplePath = NULL;
-static char* szSDLconfigPath = NULL;
 #endif
 
 #define set_commandline_option_not_config(i,v) i = v;
@@ -119,57 +114,57 @@ void generateDats()
 	char filename[1024] = { 0 };
 
 #if defined(BUILD_SDL2)
-	printf("Creating fbneo dats in %s\n", SDL_GetPrefPath("fbneo", "dats"));
+	printf("Creating fbneo dats in %s\n", szAppDatListsPath);
 #if defined(ALT_DAT)
-	sprintf(filename, "%sFBNeo_-_ALL_SYSTEMS.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_ALL_SYSTEMS.dat"), szAppDatListsPath);
 	create_datfile(filename, -1);
 #endif
-	sprintf(filename, "%sFBNeo_-_Arcade.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Arcade.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_ARCADE_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_MegaDrive.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_MegaDrive.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_MEGADRIVE_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_PC_ENGINE.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_PC_ENGINE.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_PCENGINE_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_TurboGrafx-16.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_TurboGrafx-16.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_TG16_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_PC_Engine_SuperGrafx.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_PC_Engine_SuperGrafx.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_SGX_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Sega_SG-1000.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Sega_SG-1000.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_SG1000_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_ColecoVision.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_ColecoVision.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_COLECO_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Sega_Master_System.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Sega_Master_System.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_MASTERSYSTEM_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Sega_Game_Gear.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Sega_Game_Gear.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_GAMEGEAR_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_MSX.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_MSX.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_MSX_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Sinclair_ZX_Spectrum.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Sinclair_ZX_Spectrum.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_SPECTRUM_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Neogeo.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Neogeo.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_NEOGEO_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Nintendo_Entertainment_System.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Nintendo_Entertainment_System.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_NES_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Nintendo_Famicom_Disk_System.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Nintendo_Famicom_Disk_System.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_FDS_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Neo_Geo_Pocket.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Neo_Geo_Pocket.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_NGP_ONLY);
 
-	sprintf(filename, "%sFBNeo_-_Fairchild_Channel_F.dat", SDL_GetPrefPath("fbneo", "dats"));
+	_stprintf(filename, _T("%sFBNeo_-_Fairchild_Channel_F.dat"), szAppDatListsPath);
 	create_datfile(filename, DAT_CHANNELF_ONLY);
 
 #else
@@ -238,6 +233,7 @@ void DoGame(int gameToRun)
 		{
 			MediaInit();
 			if (usejoy) Init_Joysticks(1);	// This will ignore inputs defined in *.ini and use joysticks for all players
+			display_set_controls();
 			RunMessageLoop();
 		}
 		else
@@ -306,16 +302,6 @@ int main(int argc, char* argv[])
 
 	printf("FBNeo v%s\n", szAppBurnVer);
 
-	// create a default ini if one is not valid
-	fail = ConfigAppLoad();
-	if (fail)
-	{
-		if (bSaveconfig)
-		{
-			ConfigAppSave();
-		}
-	}
-
 	for (int i = 1; i < argc; i++)
 	{
 		if (*argv[i] != '-' && !gamefound)
@@ -327,7 +313,7 @@ int main(int argc, char* argv[])
 
 	parseSwitches(argc, argv);
 
-	if (romname == NULL)
+	if ((romname == NULL) && !usemenu && !bAlwaysMenu && !dat)
 	{
 		printf("Usage: %s [-cd] [-joy] [-menu] [-novsync] [-integerscale] [-fullscreen] [-dat] [-autosave] [-nearest] [-linear] [-best] <romname>\n", argv[0]);
 		printf("Note the -menu switch does not require a romname\n");
@@ -336,11 +322,7 @@ int main(int argc, char* argv[])
 		printf("For NeoCD games:\n");
 		printf("%s neocdz -cd path/to/ccd/filename.cue (or .ccd)\n", argv[0]);
 		printf("Usage is restricted by the license at https://raw.githubusercontent.com/finalburnneo/FBNeo/master/src/license.txt\n");
-
-		if (!usemenu && !bAlwaysMenu && !dat)
-		{
-			return 0;
-		}
+		return 0;
 	}
 
 	// Do these bits before override via ConfigAppLoad
@@ -389,34 +371,19 @@ int main(int argc, char* argv[])
 	//SDL_ShowCursor(SDL_DISABLE);
 
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-	szSDLhiscorePath = SDL_GetPrefPath("fbneo", "hiscore");
-	szSDLeepromPath = SDL_GetPrefPath("fbneo", "eeprom");
-	szSDLHDDPath = SDL_GetPrefPath("fbneo", "hdd");
-	szSDLSamplePath = SDL_GetPrefPath("fbneo", "samples");
-	_stprintf(szAppHiscorePath, _T("%s"), szSDLhiscorePath);
-	_stprintf(szAppEEPROMPath, _T("%s"), szSDLeepromPath);
-	_stprintf(szAppHDDPath, _T("%s"), szSDLHDDPath);
-	_stprintf(szAppSamplesPath, _T("%s"), szSDLSamplePath);
-
-
     // Load mapping from file if it exists
-	char gamecontrollerdbfile[MAX_PATH] = { 0 };
-	if (szSDLconfigPath == NULL) {
-		szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
-	}
-	snprintf(gamecontrollerdbfile, MAX_PATH, "%sgamecontrollerdb.txt", szSDLconfigPath);
-
+	char gamecontrollerdbfile[MAX_PATH] = _T("");
+	TCHAR *szSDLconfigPath = NULL;
+	szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
+	_stprintf(gamecontrollerdbfile, _T("%sgamecontrollerdb.txt"), szSDLconfigPath);
+	SDL_free(szSDLconfigPath);
 	if (SDL_GameControllerAddMappingsFromFile(gamecontrollerdbfile) > 0) printf("Game controller mappings loaded from: %s\n", gamecontrollerdbfile);
 #endif
 
+	// create a default ini if one is not valid
 	fail = ConfigAppLoad();
-	if (fail)
-	{
-		if (bSaveconfig)
-		{
-			ConfigAppSave();
-		}
-	}
+	if ((fail) && (bSaveconfig)) ConfigAppSave();		// for SDL2 this will also create folders in ~/.local/share/fbneo/
+
 	ComputeGammaLUT();
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
 	bprintf = AppDebugPrintf;

--- a/src/burner/sdl/run.cpp
+++ b/src/burner/sdl/run.cpp
@@ -30,7 +30,6 @@ static Uint32 starting_stick;
 extern SDL_Renderer* sdlRenderer;
 extern void ingame_gui_start(SDL_Renderer* renderer);
 /// Save States
-static char* szSDLSavePath = NULL;
 static char Windowtitle[512];
 #endif
 
@@ -42,18 +41,10 @@ int StatedAuto(int bSave)
 	static TCHAR szName[MAX_PATH] = _T("");
 	int nRet;
 
-#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)	
-	if (szSDLSavePath == NULL)
-	{
-		szSDLSavePath = SDL_GetPrefPath("fbneo", "states");
-	}
-
-	snprintf(szName, MAX_PATH, "%s%s.fs", szSDLSavePath, BurnDrvGetText(DRV_NAME));
-
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	_stprintf(szName, _T("%s%s.fs"), szAppEEPROMPath, BurnDrvGetText(DRV_NAME));
 #else
-
 	_stprintf(szName, _T("config/games/%s.fs"), BurnDrvGetText(DRV_NAME));
-
 #endif
 
 	if (bSave == 0)

--- a/src/burner/sdl/sdl2_gui.cpp
+++ b/src/burner/sdl/sdl2_gui.cpp
@@ -57,7 +57,7 @@ SDL_Texture* LoadTitleImage(SDL_Renderer* renderer, SDL_Texture* loadedTexture)
 	int currentSelected = nBurnDrvActive;
 	nBurnDrvActive = gametoplay;
 #ifndef _WIN32
-	snprintf(titlePath, MAX_PATH, "%s%s.png", szAppTitlesPath, BurnDrvGetTextA(0));
+	_stprintf(titlePath,_T("%s%s.png"), szAppTitlesPath, BurnDrvGetTextA(0));
 #else
 	snprintf(titlePath, MAX_PATH, "support\\titles\\%s.png", BurnDrvGetTextA(0));
 #endif
@@ -83,7 +83,10 @@ SDL_Texture* LoadTitleImage(SDL_Renderer* renderer, SDL_Texture* loadedTexture)
 static void CreateRomDatName(TCHAR* szRomDat)
 {
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-	_stprintf(szRomDat, _T("%s/roms.found"), SDL_GetPrefPath("fbneo", "config"));
+	TCHAR *szSDLconfigPath = NULL;
+	szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
+	_stprintf(szRomDat, _T("%s/roms.found"), szSDLconfigPath);
+	SDL_free(szSDLconfigPath);
 #else
 	_stprintf(szRomDat, _T("fbneo.dat"));
 #endif

--- a/src/burner/sdl/sdl2_gui_ingame.cpp
+++ b/src/burner/sdl/sdl2_gui_ingame.cpp
@@ -200,7 +200,6 @@ int mappedbuttons[BUTTONS_TO_MAP] = {-1,-1,-1,-1,-1,-1,-1,-1};
 
 int ControllerMenuSelected();
 extern bool do_reload_game;	// To reload game when buttons mapping changed
-static char* szSDLconfigPath = NULL;
 
 int SaveMappedButtons()
 {
@@ -216,11 +215,11 @@ int SaveMappedButtons()
 	char* pos = NULL;
 	char gamecontrollerdbpath[MAX_PATH] = { 0 };
 	char tempgamecontrollerdbpath[MAX_PATH] = { 0 };
-	if (szSDLconfigPath == NULL) {
-		szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
-	}
-	snprintf(gamecontrollerdbpath, MAX_PATH, "%sgamecontrollerdb.txt", szSDLconfigPath);
-	snprintf(tempgamecontrollerdbpath, MAX_PATH, "%sgamecontrollerdb.TEMP.txt", szSDLconfigPath);
+	TCHAR *szSDLconfigPath = NULL;
+	szSDLconfigPath = SDL_GetPrefPath("fbneo", "config");
+	_stprintf(gamecontrollerdbpath, _T("%sgamecontrollerdb.txt"), szSDLconfigPath);
+	_stprintf(tempgamecontrollerdbpath, _T("%sgamecontrollerdb.TEMP.txt"), szSDLconfigPath);
+	SDL_free(szSDLconfigPath);
 
 	for (int i = 0; i < BUTTONS_TO_MAP; i++) {
 		if (mappedbuttons[i] > -1) {
@@ -485,11 +484,15 @@ int CheatMenuSelected()
 			pCurrentCheat = pCurrentCheat->pNext;
 			i++;
 		}
-		cheatMenu[i] = (MenuItem){"DISABLE ALL CHEATS\0", DisableAllCheats, NULL};
-		i++;
-
-		cheatMenu[i] = (MenuItem){"BACK\0", MainMenuSelected, NULL};
-		cheatcount = i + 1;
+		if (i > 0) {
+			cheatMenu[i] = (MenuItem){"DISABLE ALL CHEATS\0", DisableAllCheats, NULL};
+			i++;
+			cheatMenu[i] = (MenuItem){"BACK\0", MainMenuSelected, NULL};
+			cheatcount = i + 1;
+		} else {
+			cheatMenu[i] = (MenuItem){"BACK (no cheats found)\0", MainMenuSelected, NULL};
+			cheatcount = 1;
+		}
 	}
 	return 0;
 }

--- a/src/burner/sdl/stated.cpp
+++ b/src/burner/sdl/stated.cpp
@@ -1,10 +1,5 @@
 #include "burner.h"
 
-/// Save States
-#ifdef BUILD_SDL2
-static char* szSDLSavePath = NULL;
-#endif
-
 // The automatic save
 int QuickState(int bSave)
 {
@@ -12,16 +7,9 @@ int QuickState(int bSave)
 	int nRet;
 
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-	if (szSDLSavePath == NULL)
-	{
-		szSDLSavePath = SDL_GetPrefPath("fbneo", "states");
-	}
-
-	snprintf(szName, MAX_PATH, "%squick_%s.fs", szSDLSavePath, BurnDrvGetText(DRV_NAME));
+	_stprintf(szName, _T("%squick_%s.fs"), szAppEEPROMPath, BurnDrvGetText(DRV_NAME));
 #else
-
 	_stprintf(szName, _T("config/games/quick_%s.fs"), BurnDrvGetText(DRV_NAME));
-
 #endif
 
 	if (bSave == 0)


### PR DESCRIPTION
IMPORTANT NOTE: This commit changes folders paths for <romname>.ini, *.fs, *.nv, samples and *.dat.

Some paths were not consistently defined and used. Now support paths are similar to those used in Windows.


Details about what changes:
- hiscore.dat must be placed in ~/.local/share/fbneo/support/hiscores/ (this is also where *.hi will be stored);
- samples *.zip must be placed in ~/.local/share/fbneo/support/samples/
- <romname>.ini, *.fs and *.nv are all stored in ~/.local/share/fbneo/config/games/
- when using "-dat" parameter, the *.dat files will be created in ~/.local/share/fbneo/support/lists/dat/
- all support folders are created at first launch.


Other code changes:
- main.cpp was checking fbneo.ini two times, and one of those times was too early (making highscores disabled by default when creating fbneo on first run);
- burner.h was declaring many extern variables already declared in burner.h (and it was causing issues somehow - changing values one place was not reflected elsewhere);
- when loading text files also ignore CR char, not only LF;
- only display help text if not loading a game or menu;
- always show what inputs are assigned to each player when loading a game.
