### PR TITLE
SDL2: fix screenshot not being saved

### DIFF
--- a/src/burner/sshot.cpp
+++ b/src/burner/sshot.cpp
@@ -5,7 +5,11 @@
 #define SSHOT_LIBPNG_ERROR 2
 #define SSHOT_OTHER_ERROR 3
 
-#define SSHOT_DIRECTORY "screenshots/"
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	TCHAR *SSHOT_DIRECTORY = NULL;
+#else
+	#define SSHOT_DIRECTORY "screenshots/"
+#endif
 
 static UINT8* pSShot = NULL;
 static UINT8* pConvertedImage = NULL;
@@ -149,8 +153,14 @@ INT32 MakeScreenShot()
     tmTime = localtime(&currentTime);
 	png_convert_from_time_t(&png_time_now, currentTime);
 
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	SSHOT_DIRECTORY = SDL_GetPrefPath("fbneo", "screenshots");
+#endif
 	// construct our filename -> "romname-mm-dd-hms.png"
     sprintf(szSShotName,"%s%s-%.2d-%.2d-%.2d%.2d%.2d.png", SSHOT_DIRECTORY, BurnDrvGetTextA(DRV_NAME), tmTime->tm_mon + 1, tmTime->tm_mday, tmTime->tm_hour, tmTime->tm_min, tmTime->tm_sec);
+#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+	SDL_free(SSHOT_DIRECTORY);
+#endif
 
 	ff = fopen(szSShotName, "wb");
 	if (ff == NULL) {


### PR DESCRIPTION
Screenshots would not be saved because the default folder was not automatically created.

Using ingame menu "Save screenshot" option will now save png files in ~/.local/share/fbneo/screenshots/