### PR TITLE
d_ssv: save NVRAM in states for games that have it mapped

### DIFF
--- a/src/burn/drv/pst90s/d_ssv.cpp
+++ b/src/burn/drv/pst90s/d_ssv.cpp
@@ -130,6 +130,8 @@ static INT32 pastelis = 0;
 static INT32 sxyreact_kludge = 0;
 static INT16 SxyGun = 0;
 
+static INT32 has_nvram = 0;
+
 // Theory of sprite buffering for this machine  -dink nov. 22, 2021
 // spriteram is delayed 1 frame, buffered once per frame
 // scroll register updates are buffered in a list, for each line they are
@@ -4015,6 +4017,15 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		BurnRandomScan(nAction);
 	}
 
+	if (has_nvram && (nAction & ACB_NVRAM)) {
+		memset(&ba, 0, sizeof(ba));
+		ba.Data		= DrvNVRAM;
+		ba.nLen		= 0x10000;
+		ba.nAddress	= 0;
+		ba.szName	= "NVRAM";
+		BurnAcb(&ba);
+	}
+
 	return 0;
 }
 
@@ -4533,6 +4544,7 @@ static INT32 Drifto94Init()
 {
 	watchdog_disable = 1;
 	use_hblank = 1;
+	has_nvram = 1;
 
 	if (DrvDips[2] & 1) {
 		BurnSetRefreshRate(60.186);
@@ -4586,6 +4598,8 @@ static void MeosismV60Map()
 
 static INT32 MeosismInit()
 {
+	has_nvram = 1;
+
 	return DrvCommonInit(MeosismV60Map, NULL, 0, -1, -1, 2, -1, 0.80);
 }
 
@@ -4634,6 +4648,8 @@ static void CairbladV60Map()
 
 static INT32 CairbladInit()
 {
+	has_nvram = 1;
+
 	return DrvCommonInit(CairbladV60Map, NULL, 1, 0, -1, -1, -1, 0.80);
 }
 
@@ -4781,6 +4797,7 @@ static void StmbladeV60Map()
 static INT32 StmbladeInit()
 {
 	watchdog_disable = 1;
+	has_nvram = 1;
 
 	return DrvCommonInit(StmbladeV60Map, NULL, 0, 0, -1, -1, -1, 1.80);
 }
@@ -5482,6 +5499,7 @@ static void SxyreactV60Map()
 static INT32 SxyreactInit()
 {
 	sxyreact_kludge = 1;
+	has_nvram = 1;
 
 	return DrvCommonInit(SxyreactV60Map, SexyreactRomLoadCallback, 1, 0, 1, 2, -1, 0.10);
 }
@@ -5609,6 +5627,8 @@ static void EaglshotV60Map()
 
 static INT32 EaglshotInit()
 {
+	has_nvram = 1;
+
 	return DrvCommonInit(EaglshotV60Map, NULL, 0, 0, 0, 0, 0, 0.80);
 }
 


### PR DESCRIPTION
Primarily to fix Change Air Blade (`cairblad`), because it does not like it if NVRAM initialization gets skipped somehow.