### PR TITLE
SDL2: Fix fullscreen not centered or distorted

### DIFF
--- a/src/burner/sdl/run.cpp
+++ b/src/burner/sdl/run.cpp
@@ -31,6 +31,8 @@ extern SDL_Renderer* sdlRenderer;
 extern void ingame_gui_start(SDL_Renderer* renderer);
 /// Save States
 static char Windowtitle[512];
+
+extern void AdjustImageSize();		// vid_sdl2.cpp
 #endif
 
 int bDrvSaveAll = 0;
@@ -467,6 +469,7 @@ int RunMessageLoop()
 					if (event.key.keysym.mod & KMOD_ALT) 
 					{
 						SetFullscreen(!GetFullscreen());
+						AdjustImageSize();
 					}
 					break;
 #endif

--- a/src/burner/sdl/sdl2_gui_common.cpp
+++ b/src/burner/sdl/sdl2_gui_common.cpp
@@ -55,7 +55,7 @@ void SetFullscreen(int f)
 
 	if (bAppFullscreen)
 	{
-		SDL_SetWindowFullscreen(sdlWindow, SDL_WINDOW_FULLSCREEN);
+		SDL_SetWindowFullscreen(sdlWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	}
 	else
 	{


### PR DESCRIPTION
Fixed:
- image would not be centered when going from window mode to full screen;
- window would be bigger than screen when exiting full screen mode.

Also done some code cleanup (mainly avoiding repetitive if tests).