### PR TITLE
fix sdl windows build

### DIFF
--- a/src/burn/devices/thready.h
+++ b/src/burn/devices/thready.h
@@ -10,7 +10,7 @@
 
 #if defined(WIN32)
 #define THREADY THREADY_WINDOWS
-#if !defined(UNICODE) && !defined(__LIBRETRO__)
+#if !defined(UNICODE) && defined(BUILD_WIN32)
 #define UNICODE
 #endif
 #include "windows.h"

--- a/src/burner/sdl/sdl2_gui_ingame.cpp
+++ b/src/burner/sdl/sdl2_gui_ingame.cpp
@@ -56,6 +56,75 @@ static UINT16 current_menu = MAINMENU;
 static UINT16 current_selected_item = 0;
 UINT16 firstMenuLine = 0;
 UINT16 maxLinesMenu = 16;
+//getline is not avaiable on windows lets emulate it
+#if defined(WIN32)
+
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+
+ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream) {
+    char *cur_pos, *new_lineptr;
+    size_t new_lineptr_len;
+    int c;
+
+    if (lineptr == NULL || n == NULL || stream == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (*lineptr == NULL) {
+        *n = 128; /* init len */
+        if ((*lineptr = (char *)malloc(*n)) == NULL) {
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+
+    cur_pos = *lineptr;
+    for (;;) {
+        c = getc(stream);
+
+        if (ferror(stream) || (c == EOF && cur_pos == *lineptr))
+            return -1;
+
+        if (c == EOF)
+            break;
+
+        if ((*lineptr + *n - cur_pos) < 2) {
+            if (SSIZE_MAX / 2 < *n) {
+#ifdef EOVERFLOW
+                errno = EOVERFLOW;
+#else
+                errno = ERANGE; /* no EOVERFLOW defined */
+#endif
+                return -1;
+            }
+            new_lineptr_len = *n * 2;
+
+            if ((new_lineptr = (char *)realloc(*lineptr, new_lineptr_len)) == NULL) {
+                errno = ENOMEM;
+                return -1;
+            }
+            cur_pos = new_lineptr + (cur_pos - *lineptr);
+            *lineptr = new_lineptr;
+            *n = new_lineptr_len;
+        }
+
+        *cur_pos++ = (char)c;
+
+        if (c == delim)
+            break;
+    }
+
+    *cur_pos = '\0';
+    return (ssize_t)(cur_pos - *lineptr);
+}
+
+ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+    return getdelim(lineptr, n, '\n', stream);
+}
+#endif
 
 int MainMenuSelected()
 {


### PR DESCRIPTION
@cjom getline is posix so ive added the function for windows as its missing. The only other alternative is to use c++ getline. The other fix is to disable unicode for all windows builds accept the original fork that uses it.