### PR TITLE
fix cross compile for sdl2

### DIFF
--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -11,10 +11,13 @@ ifeq ($(UNAME_S),Darwin)
 DARWIN=1
 endif
 
+LD=$(CC) 
+
 
 ifeq ($(OS),Windows_NT)
 WINDOWS=1
 endif
+
 
 #
 #	Flags. Uncomment any of these declarations to enable their function.

--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -100,14 +100,14 @@ endif
 
 incdir	= $(foreach dir,$(alldir),-I$(srcdir)$(dir)) -I$(objdir)dep/generated \
 		  -I/local/include -I$(srcdir)dep/sdl/include \
-		  -I$(srcdir)intf/input/sdl `sdl2-config --cflags`
+		  -I$(srcdir)intf/input/sdl `pkgconf --cflags sdl2`
 
 ifdef WINDOWS
-lib	= -lstdc++ `sdl2-config --libs` -lopengl32 -lSDL2_image -lm
+lib	= -lstdc++ `pkgconf --libs sdl2` -lopengl32 -lSDL2_image -lm
 else ifdef DARWIN
-lib	= -lstdc++ `sdl2-config --libs` -lSDL2_image -lm -lpthread
+lib	= -lstdc++ `pkgconf --libs sdl2` -lSDL2_image -lm -lpthread
 else
-lib	= -lstdc++ `sdl2-config --libs` -lGL -lSDL2_image -lm -lpthread
+lib	= -lstdc++ `pkgconf --libs sdl2` -lGL -lSDL2_image -lm -lpthread
 endif
 
 ifdef FORCE_SYSTEM_LIBPNG

--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -377,7 +377,7 @@ ifdef WINDOWS
 
 $(NAME):	$(allobj) $(objdir)drivers.o
 	@echo
-	@echo Linking executable... $(NAME)
+	@echo Linking executable... $(NAME).exe
 	@$(LD)  -mconsole $(CFLAGS) $(LDFLAGS) -o $@ $^ $(lib)
 
 else
@@ -455,7 +455,6 @@ $(a68k.o):	fba_make68k.c
 endif
 
 # Musashi
-
 $(objdir)cpu/m68k/m68kcpu.o: $(srcdir)cpu/m68k/m68kcpu.c $(objdir)dep/generated/m68kops.h $(srcdir)cpu/m68k/m68k.h $(srcdir)cpu/m68k/m68kconf.h
 	@echo Compiling Musashi MC680x0 core \(m68kcpu.c\)...
 	@$(CC) $(CFLAGS) -c $(srcdir)cpu/m68k/m68kcpu.c -o $(objdir)cpu/m68k/m68kcpu.o
@@ -465,7 +464,11 @@ $(objdir)cpu/m68k/m68kops.o: $(objdir)cpu/m68k/m68kmake $(objdir)dep/generated/m
 	@$(CC) $(CFLAGS) -c $(objdir)dep/generated/m68kops.c -o $(objdir)cpu/m68k/m68kops.o
 
 $(objdir)dep/generated/m68kops.h $(objdir)dep/generated/m68kops.c: $(objdir)cpu/m68k/m68kmake $(srcdir)cpu/m68k/m68k_in.c
+ifdef WINDOWS
+	$(objdir)cpu/m68k/m68kmake.exe $(objdir)dep/generated/ $(srcdir)cpu/m68k/m68k_in.c
+else
 	$(objdir)cpu/m68k/m68kmake $(objdir)dep/generated/ $(srcdir)cpu/m68k/m68k_in.c
+endif
 
 $(objdir)cpu/m68k/m68kmake: $(srcdir)cpu/m68k/m68kmake.c
 	@echo Compiling Musashi MC680x0 core \(m68kmake.c\)...

--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -183,7 +183,6 @@ autdrv := $(drvsrc:.cpp=.o)
 ifdef DARWIN
 	CC	= gcc
 else
-	CC	= gcc
 endif
 
 CXX	= $(CC)


### PR DESCRIPTION
Fix cross compile for mingw. Will post details of why this is needed.

```
#set env flags for mingw
. /usr/bin/mingw-env x86_64-w64-mingw32  

 [FBNeo]$ pkgconf --libs sdl2
-L/usr/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows 
[FBNeo]$ sdl2-config --libs 
-L/usr/lib -pthread -lSDL2
```
I really only have a laptop with windows on it so for testing so i need to cross compile. There is an issue with sound which doesnt happen in wine and does in windows. I will debug that later today hopefully to get all sound drivers working in sdl. Currently only direct sound is working and its forced anyway so not really a immediate must fix issue.



