### PR TITLE
fix initialization

### DIFF
--- a/src/burner/sdl/drv.cpp
+++ b/src/burner/sdl/drv.cpp
@@ -97,8 +97,10 @@ int DrvInit(int nDrvNum, bool bRestore)
 
 	{ // Init input and audio, save blitter init for later. (reduce # of mode changes, nice for emu front-ends)
 		bVidOkay = 1;
+		bAudOkay = 1;
 		MediaInit();
 		bVidOkay = 0;
+		bAudOkay = 0;
 	}
 
 	// Define nMaxPlayers early; GameInpInit() needs it (normally defined in DoLibInit()).
@@ -131,8 +133,6 @@ int DrvInit(int nDrvNum, bool bRestore)
 	ConfigCheatLoad();
 	// Reset the speed throttling code, so we don't 'jump' after the load
 	RunReset();
-	VidExit();
-	AudSoundExit();
 	return 0;
 }
 

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -232,6 +232,7 @@ void DoGame(int gameToRun)
 		if (!DrvInit(gameToRun, 0))
 		{
 			MediaInit();
+			printf("bAudOkay:%d\n",bAudOkay);
 			if (usejoy) Init_Joysticks(1);	// This will ignore inputs defined in *.ini and use joysticks for all players
 			display_set_controls();
 			RunMessageLoop();

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -232,7 +232,6 @@ void DoGame(int gameToRun)
 		if (!DrvInit(gameToRun, 0))
 		{
 			MediaInit();
-			printf("bAudOkay:%d\n",bAudOkay);
 			if (usejoy) Init_Joysticks(1);	// This will ignore inputs defined in *.ini and use joysticks for all players
 			display_set_controls();
 			RunMessageLoop();

--- a/src/burner/sdl/media.cpp
+++ b/src/burner/sdl/media.cpp
@@ -61,9 +61,7 @@ int MediaExit()
 	pBurnSoundOut = NULL;
 
 	AudSoundExit();                  // Exit sound
-	bAudOkay = 0;
 	VidExit();
-
 	InputExit();
 
 	//ScrnExit();			// Exit the Scrn Window


### PR DESCRIPTION
MediaInit() and  MediaExit() take care of bVidOkay via AudSoundExit() and INT32 AudSoundInit() .  Same foes for the video side of things. 