### PR TITLE
only append support path in linux when config file had not been created

### DIFF
--- a/src/burner/sdl/config.cpp
+++ b/src/burner/sdl/config.cpp
@@ -183,11 +183,6 @@ int ConfigAppLoad()
 // Write out the config file for the whole application
 int ConfigAppSave()
 {
-
-#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
-	InitSupportPaths();
-#endif
-
 	char  szConfig[MAX_PATH];
 	FILE* f;
 

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -35,6 +35,8 @@ char videofiltering[3];
 bool gamefound = 0;
 const char* romname = NULL;
 
+extern void InitSupportPaths();
+
 #ifdef BUILD_SDL2
 SDL_Window* sdlWindow = NULL;
 #endif
@@ -359,8 +361,13 @@ int main(int argc, char* argv[])
 
 	// create a default ini if one is not valid
 	fail = ConfigAppLoad();
-	if (fail && bSaveconfig) ConfigAppSave();		// for SDL2 this will also create folders in ~/.local/share/fbneo/
-
+	if (fail && bSaveconfig)
+	{
+		#if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
+		InitSupportPaths();
+		#endif
+		ConfigAppSave();		// for SDL2 this will also create folders in ~/.local/share/fbneo/
+	}
 	ComputeGammaLUT();
 #if defined(BUILD_SDL2) && !defined(SDL_WINDOWS)
 	bprintf = AppDebugPrintf;


### PR DESCRIPTION
fixes https://github.com/finalburnneo/FBNeo/issues/1181 support paths should be set on config creation not and every  config save it appends paths as explained in there issue.