### PR TITLE
d_msx: corrunner

### DIFF
--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -32763,7 +32763,7 @@ struct BurnDriver BurnDrvMSX_circusmyst = {
 // Corridor Runner (HB)
 
 static struct BurnRomInfo MSX_corrunnerRomDesc[] = {
-	{ "Corridor Runner (2022)(Aburi Games).rom",	32768, 0xc175e20d, BRF_PRG | BRF_ESS },
+	{ "Corridor Runner (2022)(Aburi Games).rom",	32768, 0x56428423, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(MSX_corrunner, MSX_corrunner, msx_msx)

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -14877,7 +14877,7 @@ struct BurnDriver BurnDrvbrkrevext = {
 };
 
 // 19YY NGCD ADK World port to MVS
-// EKORZ October 20, 2022
+// EKORZ August 23, 2022
 
 static struct BurnRomInfo _19yyRomDesc[] = {
 	{ "19yy-p1.p1",   0x200000, 0x59374c47, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
@@ -14887,10 +14887,10 @@ static struct BurnRomInfo _19yyRomDesc[] = {
 	{ "19yy-c1.c1",   0x400000, 0x622719d5, 3 | BRF_GRA },           //  2 Sprite data
 	{ "19yy-c2.c2",   0x400000, 0x41b07be5, 3 | BRF_GRA },           //  3
 
-	{ "19yy-m1.m1",   0x020000, 0x8e05762a, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
+	{ "19yy-m1.m1",   0x020000, 0x636d8ac8, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
 
-	{ "19yy-v1.v1",   0x800000, 0x944146c2, 5 | BRF_SND },           //  7 Sound data
-	{ "19yy-v2.v2",   0x800000, 0xa4bafe45, 5 | BRF_SND },           //  8
+	{ "19yy-v1.v1",   0x400000, 0x7bb79a6a, 5 | BRF_SND },           //  7 Sound data
+	{ "19yy-v2.v2",   0x200000, 0x1908a7ce, 5 | BRF_SND },           //  8
 };
 
 STDROMPICKEXT(_19yy, _19yy, neogeo)

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -14877,7 +14877,7 @@ struct BurnDriver BurnDrvbrkrevext = {
 };
 
 // 19YY NGCD ADK World port to MVS
-// EKORZ August 23, 2022
+// Latest version, sound fixed by Elrayzeur. October 20, 2022
 
 static struct BurnRomInfo _19yyRomDesc[] = {
 	{ "19yy-p1.p1",   0x200000, 0x59374c47, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
@@ -14887,10 +14887,10 @@ static struct BurnRomInfo _19yyRomDesc[] = {
 	{ "19yy-c1.c1",   0x400000, 0x622719d5, 3 | BRF_GRA },           //  2 Sprite data
 	{ "19yy-c2.c2",   0x400000, 0x41b07be5, 3 | BRF_GRA },           //  3
 
-	{ "19yy-m1.m1",   0x020000, 0x636d8ac8, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
+	{ "19yy-m1.m1",   0x020000, 0x8e05762a, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
 
-	{ "19yy-v1.v1",   0x400000, 0x7bb79a6a, 5 | BRF_SND },           //  7 Sound data
-	{ "19yy-v2.v2",   0x200000, 0x1908a7ce, 5 | BRF_SND },           //  8
+	{ "19yy-v1.v1",   0x800000, 0x944146c2, 5 | BRF_SND },           //  7 Sound data
+	{ "19yy-v2.v2",   0x800000, 0xa4bafe45, 5 | BRF_SND },           //  8
 };
 
 STDROMPICKEXT(_19yy, _19yy, neogeo)
@@ -14900,8 +14900,38 @@ struct BurnDriver BurnDrv_19yy = {
 	"19yy", NULL, "neogeo", NULL, "2022",
 	"19YY (Neo CD conversion, ADK World)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HISCORE_SUPPORTED | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VERSHOOT, 0,
+	BDF_GAME_WORKING | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VERSHOOT, 0,
 	NULL, _19yyRomInfo, _19yyRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000,	304, 224, 4, 3
+};
+
+// 19YY NGCD ADK World port to MVS
+// EKORZ August 23, 2022
+
+static struct BurnRomInfo _19yyoRomDesc[] = {
+	{ "19yy-p1.p1",    0x200000, 0x59374c47, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+
+	{ "19yy-s1.s1",    0x020000, 0x219b6f40, 2 | BRF_GRA },           //  1 Text layer tiles
+
+	{ "19yy-c1.c1",    0x400000, 0x622719d5, 3 | BRF_GRA },           //  2 Sprite data
+	{ "19yy-c2.c2",    0x400000, 0x41b07be5, 3 | BRF_GRA },           //  3
+
+	{ "19yy-m1o.m1",   0x020000, 0x636d8ac8, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
+
+	{ "19yy-v1o.v1",   0x400000, 0x7bb79a6a, 5 | BRF_SND },           //  7 Sound data
+	{ "19yy-v2o.v2",   0x200000, 0x1908a7ce, 5 | BRF_SND },           //  8
+};
+
+STDROMPICKEXT(_19yyo, _19yyo, neogeo)
+STD_ROM_FN(_19yyo)
+
+struct BurnDriver BurnDrv_19yyo = {
+	"19yyo", "19yy", "neogeo", NULL, "2022",
+	"19YY (Neo CD conversion, ADK World)(Original release)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VERSHOOT, 0,
+	NULL, _19yyoRomInfo, _19yyoRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };


### PR DESCRIPTION
Updated to latest version found on author's repo (date from october 17, 2022).
Current version in fbneo: october 01, 2022.
.

Also, d_neogeo: 19yy
reverted to previous version as requested by taoenwen