### PR TITLE
extend the functionality of ips

### DIFF
--- a/src/burn/burn.h
+++ b/src/burn/burn.h
@@ -399,7 +399,7 @@ void Reinitialise();
 // ---------------------------------------------------------------------------
 // IPS Control
 
-#define IPS_USE_PROTECT		(1 <<  0)	// Control protection.
+#define IPS_NOT_PROTECT		(1 <<  0)	// Control protection.
 
 #define IPS_NEOP3_20000		(1 <<  1)	// Extra Rom
 #define IPS_NEOP3_40000		(1 <<  2)

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -1520,7 +1520,7 @@ static INT32 NeoSMAInit(void (*pInitCallback)(), pSekWriteWordHandler pBankswitc
 	NeoCallbackActive->pInitialise = pInitCallback;
 
 	// Control SMA protection in ips environment.
-	if (!bDoIpsPatch || (GetIpsDrvDefine() & IPS_USE_PROTECT)) {
+	if (!bDoIpsPatch || !(GetIpsDrvDefine() & IPS_NOT_PROTECT)) {
 		NeoCallbackActive->pInstallHandlers = NeoSMAInstallHanders;
 		NeoCallbackActive->pBankswitch = NeoSMABankswitch;
 		NeoCallbackActive->pScan = NeoSMAScan;
@@ -1706,7 +1706,7 @@ static void NeoPVCInstallHandlers()
 static INT32 NeoPVCInit()
 {
 	// Control PVC protection in ips environment.
-	if (!bDoIpsPatch || (GetIpsDrvDefine() & IPS_USE_PROTECT)) {
+	if (!bDoIpsPatch || !(GetIpsDrvDefine() & IPS_NOT_PROTECT)) {
 		PVCRAM = (UINT8*)BurnMalloc(0x2000);
 		if (!PVCRAM) return 1;
 


### PR DESCRIPTION
Allow ips patches for single files larger than 16M (offset mode). Adjust the default neogeo's sma & pvc protection switch in ips mode