### PR TITLE
thready - add support for msvc

### DIFF
--- a/src/burn/devices/thready.h
+++ b/src/burn/devices/thready.h
@@ -2,15 +2,20 @@
 // thready had big dreams, this is one of them!                    - dink 2022
 
 #define THREADY_WINDOWS		1 // we're on Windows
-#define THREADY_PTHREAD		2 // anything that supports pthreads (linux, android, not apple)
-#define THREADY_PTHREADAPL	3 // apple pthreads
-#define THREADY_0THREAD		4 // neither of the above.. (no threading!)
+#define THREADY_WINDOWSVC	2 // Fix some bugs in the msvc compiler ...
+#define THREADY_PTHREAD		3 // anything that supports pthreads (linux, android, not apple)
+#define THREADY_PTHREADAPL	4 // apple pthreads
+#define THREADY_0THREAD		5 // neither of the above.. (no threading!)
 
 #define STARTUP_FRAMES 180
 #define THREADY_CHECK_CB_TIME 0
 
-#if defined(WIN32)
+#if ((defined _MSC_VER) || (defined WIN32))
+#ifndef _MSC_VER
 #define THREADY THREADY_WINDOWS
+#else
+#define THREADY THREADY_WINDOWSVC	// _MSC_VER
+#endif
 #if !defined(UNICODE) && defined(BUILD_WIN32)
 #define UNICODE
 #endif
@@ -108,7 +113,7 @@ struct threadystruct
 		startup_frame = STARTUP_FRAMES;
 	}
 
-	void set_threading(INT32 value)	{
+	void set_threading(INT32 value) {
 		ok_to_thread = value;
 	}
 
@@ -163,6 +168,146 @@ static long unsigned int __stdcall ThreadyProc(void*) {
 	return 0;
 }
 #endif // THREADY_WINDOWS
+
+
+#if (THREADY == THREADY_WINDOWSVC)
+static long unsigned int __stdcall ThreadyProc(void*);
+/*
+	Because these two variables (our_event / wait_event) are not properly synchronized, the thread locks upand is hung indefinitely.
+	The vc compiler doesn't seem to be able to automatically add/unlock static variables of classes in threads when handling them,
+	as the gcc compiler does, thus ensuring the security of data in threads.
+*/
+static HANDLE our_event;
+static HANDLE wait_event;
+static INT32 end_thread;
+static void (*our_callback)();
+
+struct threadystruct
+{
+	INT32 thready_ok;
+	INT32 ok_to_thread;
+	INT32 ok_to_wait;
+	HANDLE our_thread;
+	DWORD our_threadid;
+	INT32 startup_frame;
+
+	void init(void (*thread_callback)()) {
+		thready_ok = 0;
+		ok_to_thread = 0;
+		ok_to_wait = 0;
+		startup_frame = 0;
+
+		our_callback = thread_callback;
+
+#if 0
+		SYSTEM_INFO info;
+		GetSystemInfo(&info);
+		INT32 maxproc = (info.dwNumberOfProcessors > 4) ? 4 : info.dwNumberOfProcessors;
+		INT32 thready_proc = rand() % maxproc;
+#endif
+
+		//bprintf(0, _T("Thready: processors available: %d, blitter processor: %d\n"), info.dwNumberOfProcessors, thready_proc);
+
+		end_thread = 0; // good to go!
+
+		our_event	= CreateEvent(NULL, FALSE, FALSE, NULL);
+		wait_event	= CreateEvent(NULL, FALSE, FALSE, NULL);
+		our_thread	= CreateThread(NULL, 0, ThreadyProc, NULL, 0, &our_threadid);
+		// bprintf(0, _T("Init: our_event: %d, wait_event: %d\n"), our_event, wait_event);
+
+#if 0
+		SetThreadIdealProcessor(our_thread, thready_proc);
+#endif
+
+		if (our_event && wait_event && our_thread) {
+			//bprintf(0, _T("Thready: we're gonna git 'r dun!\n"));
+			CloseHandle(our_thread); // After that, no operation of this handle is required.
+
+			thready_ok = 1;
+			ok_to_thread = 1;
+		} else {
+			//bprintf(0, _T("Thready: failure to create thread!\n"));
+		}
+	}
+
+	void exit() {
+		if (thready_ok) {
+			if (0x0101 != end_thread) {
+				end_thread = 1;
+				SetEvent(our_event);
+			} else {																// ThreadyProc has returned 0
+				if (INVALID_HANDLE_VALUE != our_event) CloseHandle(our_event);		// Close it before it becomes an invalid handle.
+				if (INVALID_HANDLE_VALUE != wait_event) CloseHandle(wait_event);	// Id.
+			}
+			do {
+				Sleep(42);					// let thread realize it's time to die
+			} while (~end_thread & 0x100);
+			thready_ok = 0;
+		}
+	}
+
+	void scan() {
+		SCAN_VAR(startup_frame);
+	}
+
+	void reset() { // only call this if using for epic12
+		startup_frame = STARTUP_FRAMES;
+	}
+
+	void set_threading(INT32 value)	{
+		ok_to_thread = value;
+	}
+
+	void notify() {
+		if (startup_frame > 0) {
+			// run in synchronous mode for startup_frame frames
+			startup_frame--;
+			our_callback();
+			return;
+		}
+		if (thready_ok && ok_to_thread) {
+			SetEvent(our_event);
+			ok_to_wait = 1;
+		} else {
+			// fallback to single-threaded mode
+			our_callback();
+		}
+	}
+	void notify_wait() {
+		if (ok_to_thread && ok_to_wait) {
+			WaitForSingleObject(wait_event, INFINITE);
+			ok_to_wait = 0;
+		}
+	}
+};
+
+static threadystruct thready;
+
+static long unsigned int __stdcall ThreadyProc(void*) {
+	do {
+		// bprintf(0, _T("Proc: our_event: %d, wait_event: %d\n"), our_event, wait_event);
+		if ((WAIT_OBJECT_0 == WaitForSingleObject(our_event, INFINITE)) && (end_thread == 0)) {
+#if THREADY_CHECK_CB_TIME
+			time_t begin_time = clock();
+#endif
+			our_callback();
+#if THREADY_CHECK_CB_TIME
+			time_t end_time = clock();
+			double duration = (double)(end_time - begin_time) / CLOCKS_PER_SEC;
+			bprintf(0, _T("thready: callback took %2.3f seconds\n"), duration);
+#endif
+			SetEvent(wait_event);
+		} else {
+			SetEvent(wait_event);
+			end_thread |= 0x100;
+			//bprintf(0, _T("Thready: thread-event thread ending..\n"));
+			return 0;
+		}
+	} while (1);
+
+	return 0;
+}
+#endif // THREADY_WINDOWSVC
 
 
 #if (THREADY == THREADY_PTHREAD)


### PR DESCRIPTION
Initially, the MSVC version did not support threading, so that the x86 binary version ran very slowly.
After adding msvc support, the following failures were found:

-------------------
*** Starting emulation of dfkbl - DoDonPachi Dai-Fukkatsu Black Label.
    Alternative title is 怒首領蜂 大復活 (2010/1/18 BLACK LABEL).
BurnSetMouseDivider() @ 1
Cheat cpu-register INIT.
Init: our_event: 1324, wait_event: 2148
Proc: our_event: 1324, wait_event: 2148
--  sh3 init @ 102400000hz
Sh3SetClockCV1k:  102400000   tmu prescale 4
CPU-registry: sh3 cpu #0 ...
*** found speedhack for dfkbl
hack_ram: c002310  hack_pc: c1d1346
Init: our_event: 1328, wait_event: 1892
Proc: our_event: 1324, wait_event: 2148  <- Static variables in structures/classes are not synchronized correctly
  * SoftFX initialised: using Plain Software Scale in 32-bit mode.
[Win7+] Sync to DWM is enabled (if available).
SuperWaitVBlankInit() on \\.\DISPLAY4
Setting CPU Clock selection.
Sh3SetClockCV1k:  102400000   tmu prescale 4
Main Clock 102400000  at 100.0%  Adjusted Clock 102400000
-------------------
[Hang up]
![Hang up](https://user-images.githubusercontent.com/67533945/218297900-aa227fa8-1a74-47c2-8927-5c3d4b0334e5.png)

Because these two variables are not properly synchronized, the thread locks up and is hung indefinitely.
The vc compiler doesn't seem to be able to automatically add/unlock static variables of classes in threads when handling them, as the gcc compiler does, thus ensuring the security of data in threads.
After tweaking & testing, it now runs well and runs at the same speed as the gcc compiled version

-------------------
*** Starting emulation of dfkbl - DoDonPachi Dai-Fukkatsu Black Label.
    Alternative title is 怒首領蜂 大復活 (2010/1/18 BLACK LABEL).
BurnSetMouseDivider() @ 1
Cheat cpu-register INIT.
Init: our_event: 1124, wait_event: 1120
Proc: our_event: 1124, wait_event: 1120
--  sh3 init @ 102400000hz
Sh3SetClockCV1k:  102400000   tmu prescale 4
CPU-registry: sh3 cpu #0 ...
*** found speedhack for dfkbl
hack_ram: c002310  hack_pc: c1d1346
Init: our_event: 2120, wait_event: 1476
Proc: our_event: 2120, wait_event: 1476
 ** Enumerating available DirectDraw drivers:
 ** Starting Direct3D7 blitter.
  * Initialising video: Total video memory minus display surface: 3072.00MB.
  * Initialisation complete: 3060.02MB video memory free.
    Displaying and rendering in 32-bit mode, emulation running in 32-bit mode.
    Running in windowed mode, using Blt() to transfer the final image.
[Win7+] Sync to DWM is enabled (if available).
SuperWaitVBlankInit() on \\.\DISPLAY4
Setting CPU Clock selection.
Sh3SetClockCV1k:  102400000   tmu prescale 4
Main Clock 102400000  at 100.0%  Adjusted Clock 102400000
Proc: our_event: 2120, wait_event: 1476
Proc: our_event: 2120, wait_event: 1476
Proc: our_event: 2120, wait_event: 1476
Proc: our_event: 2120, wait_event: 1476
...
-------------------
![OK](https://user-images.githubusercontent.com/67533945/218297910-8487cd81-7754-4571-9e05-76fd088755ed.png)