### PR TITLE
d_neogeo: samsho2pe [Hack By Bear]

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -16669,7 +16669,7 @@ struct BurnDriver BurnDrvSamsho2new = {
 // Samurai Shodown II Perfect Hack
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",   0x200000, 0x1f44d879, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p1pe.p1",   0x200000, 0x63055581, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "063-p2pe.p2",   0x020000, 0xe9cc1d72, 0 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "063-s1.s1",     0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  2 Text layer tiles
@@ -16696,7 +16696,7 @@ STD_ROM_FN(samsho2pe)
 
 struct BurnDriver BurnDrvSamsho2pe = {
 	"samsho2pe", "samsho2", "neogeo", NULL, "2023",
-	"Samurai Shodown II Perfect (Hack)\0", NULL, "Bear", "Neo Geo MVS",
+	"Samurai Shodown II Perfect (V. 01, Hack)\0", NULL, "Bear", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -16666,6 +16666,44 @@ struct BurnDriver BurnDrvSamsho2new = {
 	0x1000, 320, 224, 4, 3
 };
 
+// Samurai Shodown II Perfect Hack
+
+static struct BurnRomInfo samsho2peRomDesc[] = {
+	{ "063-p1pe.p1",   0x200000, 0x1f44d879, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.p2",   0x020000, 0xe9cc1d72, 0 | BRF_ESS | BRF_PRG }, //  1
+
+	{ "063-s1.s1",     0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  2 Text layer tiles
+
+	{ "063-c1.c1",     0x200000, 0x86cd307c, 3 | BRF_GRA },           //  3 Sprite data
+	{ "063-c2.c2",     0x200000, 0xcdfcc4ca, 3 | BRF_GRA },           //  4
+	{ "063-c3.c3",     0x200000, 0x7a63ccc7, 3 | BRF_GRA },           //  5
+	{ "063-c4.c4",     0x200000, 0x751025ce, 3 | BRF_GRA },           //  6
+	{ "063-c5.c5",     0x200000, 0x20d3a475, 3 | BRF_GRA },           //  7
+	{ "063-c6.c6",     0x200000, 0xae4c0a88, 3 | BRF_GRA },           //  8
+	{ "063-c7.c7",     0x200000, 0x2df3cbcf, 3 | BRF_GRA },           //  9
+	{ "063-c8.c8",     0x200000, 0x1ffc6dfa, 3 | BRF_GRA },           // 10
+
+	{ "063-m1.m1",		0x020000, 0x56675098, 4 | BRF_ESS | BRF_PRG }, // 11 Z80 code
+
+	{ "063-v1.v1",		0x200000, 0x37703f91, 5 | BRF_SND },           // 12 Sound data
+	{ "063-v2.v2",		0x200000, 0x0142bde8, 5 | BRF_SND },           // 13
+	{ "063-v3.v3",		0x200000, 0xd07fa5ca, 5 | BRF_SND },           // 14
+	{ "063-v4.v4",		0x100000, 0x24aab4bb, 5 | BRF_SND },           // 15
+};
+
+STDROMPICKEXT(samsho2pe, samsho2pe, neogeo)
+STD_ROM_FN(samsho2pe)
+
+struct BurnDriver BurnDrvSamsho2pe = {
+	"samsho2pe", "samsho2", "neogeo", NULL, "2023",
+	"Samurai Shodown II Perfect (Hack)\0", NULL, "Bear", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_SAMSHO,
+	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	Samsho2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 320, 224, 4, 3
+};
+
 // Samurai Shodown IV - Amakusa's Revenge / Samurai Spirits - Amakusa Kourin (Special 2017, hack)
 // Modified by: GSC2007
 // Version number: Ver 1.0.0501


### PR DESCRIPTION
Add samsho2 perfect hack

Changes
- Genan and Earthquake can now be grabbed when they are Crouched (bug fix).
- Ninja's can't infinite the opponent with their DP + K Throw attack (bug fix).
- Players cannot force the opponent to automatically execute BC (bug fix).
- Kuroko and Mizuchi are now playable (improvement).
- All 17 characters (including bosses) were balanced to improve the gameplay (improvement).
- Added hitboxes to all Stun and Block animations, they were missing (improvement).
- All Jumps in the game were modified for a better gameplay (improvement).
- The damage of several Attacks and Throws were balanced (improvement).
- Added a random select character feature, press start to random select (improvement).
- Added a Hit counter and a Dizzy text when characters get Dizzy (improvement).
- Every time a new challenger joins the game, the other player will be able to change their character (improvement).

Rom info/layout added as requested by author.