### PR TITLE
d_neogeo: samsho2pe

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -16713,7 +16713,7 @@ struct BurnDriver BurnDrvSamsho2new = {
 // Samurai Shodown II Perfect Hack
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",   0x200000, 0x121afa44, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p1pe.p1",   0x200000, 0x6e24dad4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "063-p2pe.p2",   0x020000, 0xe9cc1d72, 0 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "063-s1.s1",     0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  2 Text layer tiles


### PR DESCRIPTION
Latest version (2023-Mar-10 22h16 utc -3).

Changes:
Charllote can now combo with Close B or AB and Splash Fount. Jubei Close AB, the 2 slashes now connects in combo. Jubei Crouch AB, the 2 slashes now connects in combo. It can also be followed with DP. Wanfu special move now has longer hitboxes and it stays active for a longer time. Cham Cham paku paku is now faster.
Nicotine super pow is now faster, connect in hit combo bug remove select 2 mizuki crashed game