### PR TITLE
Update burner_macos.h

### DIFF
--- a/src/burner/macos/burner_macos.h
+++ b/src/burner/macos/burner_macos.h
@@ -75,7 +75,7 @@ int InputExit();
 int InputMake(bool bCopy);
 
 //TODO:
-#define szAppBurnVer 1
+#define szAppBurnVer "1"
 
 //stringset.cpp
 class StringSet {


### PR DESCRIPTION
Fixes -wformat warnings by making `szAppBurnVer` a string.