### PR TITLE
Use CFRetain/CFRelease on IOHIDDeviceRef

### DIFF
--- a/src/dep/macos/hid/AKGamepad.m
+++ b/src/dep/macos/hid/AKGamepad.m
@@ -43,7 +43,7 @@ static void gamepadInputValueCallback(void *context, IOReturn result, void *send
         registeredForEvents = NO;
         hidDevice = device;
         
-        IOObjectRetain((io_object_t) hidDevice);
+        CFRetain(hidDevice);
         
         _vendorId = 0;
         _productId = 0;
@@ -78,7 +78,7 @@ static void gamepadInputValueCallback(void *context, IOReturn result, void *send
 {
     [self unregisterFromEvents];
     
-    IOObjectRelease((io_object_t) hidDevice);
+    CFRelease(hidDevice);
 }
 
 - (void) registerForEvents

--- a/src/dep/macos/hid/AKGamepadManager.m
+++ b/src/dep/macos/hid/AKGamepadManager.m
@@ -17,8 +17,8 @@
 
 #pragma mark - AKGamepadManager
 
-void gamepadWasAdded(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef device);
-void gamepadWasRemoved(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef device);
+static void gamepadWasAdded(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef device);
+static void gamepadWasRemoved(void *inContext, IOReturn inResult, void *inSender, IOHIDDeviceRef device);
 
 @interface AKGamepadManager ()
 


### PR DESCRIPTION
As `IOHIDDeviceRef`s are Core Foundation objects, calling `IOObjectRetain`/`IOObjectRelease` does nothing useful.