### PR TITLE
d_megadrive: add umk3osc

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -45592,6 +45592,25 @@ struct BurnDriver BurnDrvmd_umk3h = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Ultimate Mortal Kombat 3 OSC Hack
+
+static struct BurnRomInfo md_umk3oscRomDesc[] = {
+	{ "Ultimate Mortal Kombat 3 OSC (2022)(Bonus).bin", 5595464, 0x1eb9b657, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_umk3osc)
+STD_ROM_FN(md_umk3osc)
+
+struct BurnDriver BurnDrvmd_umk3osc = {
+	"md_umk3osc", "md_umk3", NULL, NULL, "2022-10-03",
+	"Ultimate Mortal Kombat 3 (OSC Hack, version 27b)\0", NULL, "Bonus", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_umk3oscRomInfo, md_umk3oscRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Mortal Kombat 3 Mini-Hack By Nemesis_c,r57shell
 static struct BurnRomInfo md_mk3mRomDesc[] = {
 	{ "Mortal Kombat 3 Mini-Hack.bin", 0x400000, 0xD925AA80, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },


### PR DESCRIPTION
Latest version: 27b

HISTORY OF CHANGES (translated from russian).
 
Changes in version 27b:
 
1. If the hidden character selection is activated, then when choosing, the sounds of the Stryker machine gun and Nightwolf's ax are not played;
2. In 2v2 or 3v3 combat modes, if the hidden character selection is activated, then the cursor becomes visible for the next player and returns to its original position. In this case, the hidden character selection can be activated again;
3. Hidden character selection works only for the first battle;
4. In the options, the recovery range of the win counter has been expanded to 20.
 
----------
 
Changes in version 27a:
 
1. The Alt balance and Glitch jabs sections have been removed from the options. In their place, P1 wins and P2 wins have been added to restore the account upon rehosting.
2. Any player can select and confirm the game mode (1v1, 2v2 or 3v3).
3. Added hidden character selection (X + Start).
4. Noob Saibot:
- teleport is blocked after the 6th hit (previously it was after the 5th)
- added Fatality-1 (cloud): back, back, forward, forward, Z (mid-screen distance)
- added Fatality-2 (teleport): up-up-down-Y (any distance);
- added Animality: back, forward, back, forward, Z (sweep distance);
- added Stage Fatality: Forward, Down, Forward, B ;
- added Babality: forward, forward, forward, A ;
5. Kano - the capture is taken into account in the damage from the combo, as well as in the hit counter;
6. Fixed a bug with Stage Fatality in the Scorpion's Lair arena, when the losing player flies through the lava.
 
----------
 
Changes in version 27:
 
1. Infinite with Cyrax bombs has been removed: after the 2nd hit, the bombs do not fly out;
2. In the event of a bomb explosion, damage protection is activated;
3. Removed Rain's infinite with a super-roundhouse: after the 10th hit, the enemy does not fly out from the other side of the screen;
4. Increased Noob Saibot's walking speed, now like Rain's;
5. Jade's dash kick is disabled on hit 4 (was on hit 2);
6. Returned protection damage after Mileena's roll.