### PR TITLE
d_neogeo: samsho2pe

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -16792,7 +16792,7 @@ struct BurnDriver BurnDrvSamsho2new = {
 // Samurai Shodown II Perfect Hack
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",   0x200000, 0x41da53ae, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p1pe.p1",   0x200000, 0xd10d5867, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "063-p2pe.p2",   0x020000, 0xe9cc1d72, 0 | BRF_ESS | BRF_PRG }, //  1
 
 	{ "063-s1.s1",     0x020000, 0x64a5cd66, 2 | BRF_GRA },           //  2 Text layer tiles


### PR DESCRIPTION
2023-04-22
Readjusted Special Moves, that don't take "life damage" in defense
- Hanzo, Galford, Earthquake:  "Fat Replica Attack"
- Haohmaru: "Rice Wine Whack"
- Sieger: "Fire Sturm"
- Jubei: "Tsunami Sabre"