### PR TITLE
d_megadrive: umk3osc

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -45595,15 +45595,15 @@ struct BurnDriver BurnDrvmd_umk3h = {
 // Ultimate Mortal Kombat 3 OSC Hack
 
 static struct BurnRomInfo md_umk3oscRomDesc[] = {
-	{ "Ultimate Mortal Kombat 3 OSC (2022)(Bonus).bin", 5595464, 0x1eb9b657, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Ultimate Mortal Kombat 3 OSC (2022)(Bonus).bin", 5512572, 0x48374220, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_umk3osc)
 STD_ROM_FN(md_umk3osc)
 
 struct BurnDriver BurnDrvmd_umk3osc = {
-	"md_umk3osc", "md_umk3", NULL, NULL, "2022-10-03",
-	"Ultimate Mortal Kombat 3 (OSC Hack, version 27b)\0", NULL, "Bonus", "Sega Megadrive",
+	"md_umk3osc", "md_umk3", NULL, NULL, "2023-14-23",
+	"Ultimate Mortal Kombat 3 (OSC Hack, version 28)\0", NULL, "Bonus", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_umk3oscRomInfo, md_umk3oscRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,


### PR DESCRIPTION
updated to version 28 (2023-Apr-23)

Changes:
1. Added Stage in the Dead Pool arena.
2. Added Stage in the arena of Kombat Tomb. As in Mk2, if you hold "Down", then the opponent will fall from the spikes. Or it can happen randomly (with a small probability).
3. Removed the ability to strike while standing up/sitting down in a block (the so-called 7th frame).
4. Fixed a bug with auto exit options.
5. Time spent in options increased to 5 minutes.
6. Added arena Tower Mk2 (2 layers).
7. Arena Jade's Desert skipped (removed, cut).
8. Reptile - dash hit limit. Blocked after 8 hits.
9. Rain - lightning hit limit. Blocked after 7 hits.
10. Cyrex - disable the flight timer after an air throw.
11. Sindel - hitlimit for flight. Blocked after 6 hits.
12. Hitlimit on relaunches. Blocked after 7 hits.
13. Kung Lao - protection damage after HP/LP on the enemy in the air.
14. Kung Lao - divekick hit limit. Blocked after 7 hits.