### PR TITLE
Added macros for start/select/coin, etc. Varies by hardware

### DIFF
--- a/src/burner/gami.cpp
+++ b/src/burner/gami.cpp
@@ -497,10 +497,8 @@ static void GameInpInitMacros()
 			if (bii.szName == NULL) {
 				bii.szName = "";
 			}
-			if (_stricmp(" Up", bii.szName + 2) == 0 ||
-				_stricmp(" Down", bii.szName + 2) == 0 ||
-				_stricmp(" Left", bii.szName + 2) == 0 ||
-				_stricmp(" Right", bii.szName + 2) == 0)
+			// Check if current input to be added matches player number to prevents duplicate macros
+			if ((UINT32) (bii.szName[1] - '0') == (nPlayer + 1))
 			{
 				sprintf(pgi->Macro.szName, "%s", bii.szName);
 
@@ -519,7 +517,7 @@ static void GameInpInitMacros()
 				if (_stricmp(" Right", bii.szName + 2) == 0) pArrow[3] = bii.pVal;
 
 				if ((SETS_VS) && pArrow[0] && pArrow[1] && pArrow[2] && pArrow[3]) {
-					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "¨I");
+					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "Â¨I");
 					pgi->nInput = GIT_MACRO_AUTO;
 					pgi->nType = BIT_DIGITAL;
 					pgi->Macro.nMode = 0;
@@ -530,7 +528,7 @@ static void GameInpInitMacros()
 					nMacroCount++;
 					pgi++;
 
-					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "¨J");
+					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "Â¨J");
 					pgi->nInput = GIT_MACRO_AUTO;
 					pgi->nType = BIT_DIGITAL;
 					pgi->Macro.nMode = 0;
@@ -541,7 +539,7 @@ static void GameInpInitMacros()
 					nMacroCount++;
 					pgi++;
 
-					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "¨L");
+					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "Â¨L");
 					pgi->nInput = GIT_MACRO_AUTO;
 					pgi->nType = BIT_DIGITAL;
 					pgi->Macro.nMode = 0;
@@ -552,7 +550,7 @@ static void GameInpInitMacros()
 					nMacroCount++;
 					pgi++;
 
-					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "¨K");
+					sprintf(pgi->Macro.szName, "P%d %s", nPlayer + 1, "Â¨K");
 					pgi->nInput = GIT_MACRO_AUTO;
 					pgi->nType = BIT_DIGITAL;
 					pgi->Macro.nMode = 0;


### PR DESCRIPTION
Modified line 500 for GameInpInitMacros(). Changed the conditional from checking for directional inputs, to checking if the player number was correct. This prevents the duplicate buttons from being added (ie. 2 P1 Weak Punch macros), while adding in the buttons like coin, start, and select.

Tested it out on a few games of different hardware, but I may still have missed something, since it almost seems like too simple a fix to not have been done already.