### PR TITLE
d_neogeo: samsho2pe bugfix

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -17710,12 +17710,12 @@ struct BurnDriver BurnDrvSamsho2sp = {
 	0x1000, 320, 224, 4, 3
 };
 
-// Samurai Shodown II Perfect Hack - 2023-09-05
+// Samurai Shodown II Perfect Hack v. 1.3 - 2023-09-13
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0x1673aaeb, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "063-p2pe.sp2",	0x100000, 0x72584c2e, 1 | BRF_ESS | BRF_PRG }, //  1
-	{ "063-p3pe.p3",	0x020000, 0x383df825, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
+	{ "063-p1pe.p1",	0x100000, 0x206f13ed, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.sp2",	0x100000, 0xabc44174, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "063-p3pe.p3",	0x020000, 0x13047174, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	SAMSHO2_COMPONENT
 };

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -17715,7 +17715,7 @@ struct BurnDriver BurnDrvSamsho2sp = {
 static struct BurnRomInfo samsho2peRomDesc[] = {
 	{ "063-p1pe.p1",	0x100000, 0x206f13ed, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "063-p2pe.sp2",	0x100000, 0xabc44174, 1 | BRF_ESS | BRF_PRG }, //  1
-	{ "063-p3pe.p3",	0x020000, 0x13047174, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
+	{ "063-p3pe.p3",	0x020000, 0x4ceb9f16, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	SAMSHO2_COMPONENT
 };


### PR DESCRIPTION
2023-09-13:
Genjuro with a 70% damage combo that left all characters in a dizzy state, correct bug fix Galford buff 2 frames in "Mega strike dog go"
block defense medium and power, buff 1 frame, impact distance in sliding is greater, remaining in the same patterns stun! adjusted damage power attack sword all chars, reduce 2 points Sieger adjusted damage move special "Elephantglied", reduce 4 points Hanzo Buff, 6 frames in start move "fire dragon blast+AB", nerf 6 frames in recovery, move now connect in combo with medium attack
.
[movelist_png-img.zip](https://github.com/finalburnneo/FBNeo/files/12597184/movelist_png-img.zip)
