### PR TITLE
SDL: Fix debug print function

### DIFF
--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -257,7 +257,7 @@ static int __cdecl AppDebugPrintf(int nStatus, TCHAR* pszFormat, ...)
 
 	va_list args;
 	va_start(args, pszFormat);
-	printf(pszFormat, args);
+	vfprintf(stderr, pszFormat, args);
 	va_end(args);
 
 	return 0;


### PR DESCRIPTION
In the SDL/SDL2 port, `AppDebugPrintf()` (and thus `bprintf()`) is completely broken:
It passes a `va_list` to `printf` (!!) (instead of `vprintf`), causing all debug prints to output garbage data & occasionally segfaults.
(In particular, i was getting crashes whenever hiscore data was written to memory, because one of the debug messages happened to trigger a segfault)