### PR TITLE
d_neogeo: samsho2pe up to v1.8

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -20446,11 +20446,11 @@ struct BurnDriver BurnDrvsamsh2jq = {
 };
 
 
-// Samurai Shodown II Perfect Hack v. 1.7 - 2023-11-19
+// Samurai Shodown II Perfect Hack v. 1.8 - 2023-12-26
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0xffc5daeb, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "063-p2pe.sp2",	0x100000, 0x4c4b5521, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "063-p1pe.p1",	0x100000, 0xf63e163d, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.sp2",	0x100000, 0xffc16c11, 1 | BRF_ESS | BRF_PRG }, //  1
 	{ "063-p3pe.p3",	0x020000, 0xedffbd8a, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	SAMSHO2_COMPONENT
@@ -20461,8 +20461,8 @@ STD_ROM_FN(samsho2pe)
 
 struct BurnDriver BurnDrvSamsho2pe = {
 	"samsho2pe", "samsho2", "neogeo", NULL, "2023",
-	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 1.7, Hack)\0", NULL, "Bear", "Neo Geo MVS",
-	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 1.7, Hack)\0", NULL, NULL, NULL,
+	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 1.8, Hack)\0", NULL, "Bear", "Neo Geo MVS",
+	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 1.8, Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	samsh2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,


### PR DESCRIPTION
New Update Version 1.8:
-----------------------------
Hurtbox all chars rebalanced in the air for so that when they collide someone gets hit Jumps with punch weak attacks from Sieger, Nicotine, Cham Cham are now blocked by jubei in special move "Shingatou blocked counter",buff! Medium punch attack short now blocked by jubei in special move "Shingatou blocked counter", buff! Hanzo infinite combo removed, jump right + CD attack cancels on ovehead, AB front cancel in mozuto, restarts the same loop, it worked in Earthquake, Sieger, Wanfu, Nerf! Special move Tsubame Rokuren consumes damage on defense in new version, buff! All chars execute command basic Race(Run), in original to cancel and attack in average of 12 or 7 frames, now cancel in 3 frames, buff! Hit counter now predicts the char in a "Aerial Stun" and clear "hit counter" on the screen! Genjuro Remove Combo Jump Attack, Down+AB, Ouzakan, 3 rekka, big damage now the combo no longer exists, nerf! Genjuro Remove Combo Jump Attack, Down+AB, Ouzakan, "Five Flash Rip" in corner, big damage 80%, nerf! Wanfu readjusted damage project special move "Thunder Bomb", Explosion Steam Smoke in counter big damage 70% in original samsho2, rebalanced for 30% damage, nerf! Ukyo Tachibana modified special move "Tsubame Rokuren" to FHCF+AB Genjuro cancel AB stand or down with special moves in stun or block, first frames, buff!   Fixed a bug where Nakoruru had problems to hang on her "Eagle" if it was too far away allowing her to do empty cancels, This bug already exists in the original Samsho2, it made it possible to execute infinite combos, now the eagle runs at high speed along with Nakoruru so it can be used, if it retreats on the backdash the eagle also goes at high speed, only when nakoruru 2x Forward, or 2x Backward