### PR TITLE
Optimize the input problem of neogeo when using the keyboard

### DIFF
--- a/src/burn/drv/neogeo/neo_run.cpp
+++ b/src/burn/drv/neogeo/neo_run.cpp
@@ -129,6 +129,7 @@ UINT8 NeoJoy3[8]     = { 0, 0, 0, 0, 0, 0, 0, 0 };
 UINT8 NeoJoy4[8]     = { 0, 0, 0, 0, 0, 0, 0, 0 };
 UINT16 NeoAxis[2]	 = { 0, 0 };
 UINT8 NeoInput[32]   = { 0, };
+UINT8 NeoInput_previous[32]   = { 0, };	// GSC2007
 UINT8 NeoDiag[2]	 = { 0, 0 };
 UINT8 NeoDebugDip[2] = { 0, 0 };
 UINT8 NeoReset = 0, NeoSystem = 0;
@@ -4501,14 +4502,35 @@ INT32 NeoRender()
 	return 0;
 }
 
-inline static void NeoClearOpposites(UINT8* nJoystickInputs)
+inline static void NeoClearOpposites(UINT8* nJoystickInputs,UINT8* nJoystickInputs_previous,UINT8* nJoystickInputs_previous_lr,UINT8* nJoystickInputs_previous_ud)	// GSC2007  add
 {
-	if ((*nJoystickInputs & 0x03) == 0x03) {
-		*nJoystickInputs &= ~0x03;
-	}
-	if ((*nJoystickInputs & 0x0C) == 0x0C) {
-		*nJoystickInputs &= ~0x0C;
-	}
+		if((*nJoystickInputs & 0x0C) == 0x0C)
+		{
+			 *nJoystickInputs &= *nJoystickInputs ^ *nJoystickInputs_previous_lr; //When left and right are pressed simultaneously, remove the interference items in *nJoystickInputs_previous_lr to obtain the actual required corrective input
+		} 
+		else if(*nJoystickInputs & 0x0C)
+		{
+			*nJoystickInputs_previous_lr = *nJoystickInputs & 0x0C;        //Only record the input when left and right are NOT pressed simultaneously
+		}
+		if((*nJoystickInputs & 0x03) == 0x03)
+		{
+			*nJoystickInputs &= *nJoystickInputs ^ *nJoystickInputs_previous_ud;        //Same as above
+		}
+		else if(*nJoystickInputs & 0x03)
+		{
+			*nJoystickInputs_previous_ud = *nJoystickInputs & 0x03;        //Same as above
+		}
+		
+//original code
+		if ((*nJoystickInputs & 0x03) == 0x03)		
+			*nJoystickInputs &= ~0x03;
+		if ((*nJoystickInputs & 0x0C) == 0x0C)
+			*nJoystickInputs &= ~0x0C;        
+
+		if (((*nJoystickInputs | *nJoystickInputs_previous) & 0x0C) == 0x0C)
+			*nJoystickInputs &= ~0x0C;        //When switching left and right, the first frame is mutually exclusive
+		if (((*nJoystickInputs | *nJoystickInputs_previous) & 0x03) == 0x03)
+			*nJoystickInputs &= ~0x03;        //When switching down and up, the first frame is mutually exclusive
 }
 
 static void NeoStandardInputs(INT32 nBank)
@@ -4516,6 +4538,8 @@ static void NeoStandardInputs(INT32 nBank)
 	if (nBank) {
 		NeoInput[ 8] = 0x00;					   					// Player 1
 		NeoInput[ 9] = 0x00;				   						// Player 2
+		NeoInput_previous[ 0] = NeoInput[ 8];	   					// GSC2007  add
+		NeoInput_previous[ 3] = NeoInput[ 9];	   					// GSC2007  add
 		NeoInput[10] = 0x00;				   						// Buttons
 		NeoInput[11] = 0x00;				   						//
 		for (INT32 i = 0; i < 8; i++) {
@@ -4524,8 +4548,8 @@ static void NeoStandardInputs(INT32 nBank)
 			NeoInput[10] |= (NeoButton3[i] & 1) << i;
 			NeoInput[11] |= (NeoButton4[i] & 1) << i;
 		}
-		NeoClearOpposites(&NeoInput[ 8]);
-		NeoClearOpposites(&NeoInput[ 9]);
+		NeoClearOpposites(&NeoInput[ 8],&NeoInput_previous[ 0],&NeoInput_previous[ 1],&NeoInput_previous[ 2]);// GSC2007  add
+		NeoClearOpposites(&NeoInput[ 9],&NeoInput_previous[ 3],&NeoInput_previous[ 4],&NeoInput_previous[ 5]);// GSC2007  add
 
 		if (NeoDiag[1]) {
 			NeoInput[13] |= 0x80;
@@ -4541,9 +4565,8 @@ static void NeoStandardInputs(INT32 nBank)
 			NeoInput[ 2] |= (NeoButton1[i] & 1) << i;
 			NeoInput[ 3] |= (NeoButton2[i] & 1) << i;
 		}
-		NeoClearOpposites(&NeoInput[ 0]);
-		NeoClearOpposites(&NeoInput[ 1]);
-
+		NeoClearOpposites(&NeoInput[ 0],&NeoInput_previous[ 6],&NeoInput_previous[ 7],&NeoInput_previous[ 8]);// GSC2007  add
+		NeoClearOpposites(&NeoInput[ 1],&NeoInput_previous[ 9],&NeoInput_previous[ 10],&NeoInput_previous[ 11]);// GSC2007  add
 		if (NeoDiag[0]) {
 			NeoInput[ 5] |= 0x80;
 		}


### PR DESCRIPTION
When the arcade stick input switches in two opposite directions, there is a "empty" in the middle, but when the emulator uses the keyboard to switch in two opposite directions, the switch is often instantaneous. For example, when switching left and right on an arcade joystick, the actual input is left->empty->right. That is to say, there will be an empty direction when switching to the opposite direction! But when using keyboard input, the actual input is left->right, or left->left+right->right

The problem I discovered is that some game developers deliberately added matching for the empty direction input when checking command inputs. For example, kof98 rugby charactor's 24A, 246A, 222B, 28A/C. For the last 28A/C , I found that the actual command is 2N8+A/C, that is, a total of 3 directions of detection: down, empty, up, and A/C! Once the empty direction is not detected, this command will fail, which is why it is difficult for most players to use the keyboard to do this trick!

This modification refers to the code of gsc2007 and pays tribute to him.