### PR TITLE
d_neogeo: samsho2pe

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -20449,7 +20449,7 @@ struct BurnDriver BurnDrvsamsh2jq = {
 // Samurai Shodown II Perfect Hack v. 1.9 - 2024-01-21
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0x6dea7885, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p1pe.p1",	0x100000, 0xd4b8d39c, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "063-p2pe.sp2",	0x100000, 0x6c833c91, 1 | BRF_ESS | BRF_PRG }, //  1
 	{ "063-p3pe.p3",	0x020000, 0xedffbd8a, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 


### PR DESCRIPTION
.p1 bugfix: crash in pointer for Earthquake, an attempt to create a command grab.


[samsho2pe_p1_-_6dea7885_to_d4b8d39c.zip](https://github.com/finalburnneo/FBNeo/files/14018126/samsho2pe_p1_-_6dea7885_to_d4b8d39c.zip)
