### PR TITLE
d_megadrive: umk3osc

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -48457,17 +48457,17 @@ struct BurnDriver BurnDrvmd_umk3h = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Ultimate Mortal Kombat 3 OSC (Hack, v28)
+// Ultimate Mortal Kombat 3 OSC (Hack, v29) - 2024-01-28
 static struct BurnRomInfo md_umk3oscRomDesc[] = {
-	{ "Ultimate Mortal Kombat 3 OSC (2023)(Bonus).bin", 5512572, 0x48374220, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Ultimate Mortal Kombat 3 OSC v29 (2023)(Bonus).bin", 5461060, 0xeb18a625, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_umk3osc)
 STD_ROM_FN(md_umk3osc)
 
 struct BurnDriver BurnDrvmd_umk3osc = {
-	"md_umk3osc", "md_umk3", NULL, NULL, "2023",
-	"Ultimate Mortal Kombat 3 OSC (Hack, v28)\0", NULL, "Bonus", "Sega Megadrive",
+	"md_umk3osc", "md_umk3", NULL, NULL, "2024",
+	"Ultimate Mortal Kombat 3 OSC (Hack, v29)\0", NULL, "Bonus", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_umk3oscRomInfo, md_umk3oscRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,


### PR DESCRIPTION
Changes in version 29 (2024-01-28):
Some fixes are "based on" the trilogy, but there are also unique ones.

1. Kabal - the ball is blocked after 9 hits, double damage is protected after the ball.
2. Smoke – the ability to make an invitation after a harpoon has been returned.
3. Smoke – during the invisibility, a smoke animation appears.
4. Sector – the teleport is blocked after 4 hits (it was after 2), the damage is protected after the second teleport in the combo
5. Sector – you can make a regular rocket while homing.
6. Jade – in projectile technology, she runs through a clone of Sub-Zero.
7. Jade – the effect of projectile protection is increased by 1 sec.
8. The recovery after leg combos of Rain, Reptile, Jade, Kitana, Scorpio, as well as after the combo of Reptile X, X-Down-A has been reduced.
9. Added music theme for the Graveyard arena, source: MK3 prerelease version.
10. Added friendship Sub-Zero MK2. Input: Z,Y,Y, Up; distance – any.
11. The blue screen in the Animality of Liu Kang and Stryker on Shiva has been fixed.