### PR TITLE
update hack games (cps1/cps2/neogeo/pgm/raiden2)

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -5134,6 +5134,19 @@ static struct BurnDIPInfo WofablaDIPList[] =
 
 STDDIPINFO(Wofabla)
 
+static struct BurnDIPInfo WofsjbQSoundDIPList[] =
+{
+	DIP_OFFSET(0x1f)
+
+	// Defaults
+	{0x00, 0xff, 0xff, 0x01, NULL                     },
+
+	// Fake Dip
+	{0   , 0xfe, 0   , 2   , "Q Sound (Must reload)"  },
+	{0x00, 0x01, 0x01, 0x00, "Off"                    },
+	{0x00, 0x01, 0x01, 0x01, "On"                     },
+};
+
 static struct BurnDIPInfo DinoQSoundDIPList[] =
 {
 	// Defaults
@@ -5144,8 +5157,6 @@ static struct BurnDIPInfo DinoQSoundDIPList[] =
 	{0x1c, 0x01, 0x01, 0x00, "Off"                    },
 	{0x1c, 0x01, 0x01, 0x01, "On"                     },
 };
-
-STDDIPINFO(DinoQSound) // For Wofsjb
 
 static struct BurnDIPInfo DinohQSoundDIPList[] =
 {
@@ -5205,6 +5216,7 @@ static struct BurnDIPInfo ffightdwDIPList[] =
 	{0x17, 0x01, 0x01, 0x01, "Original"                     },
 };
 
+STDDIPINFOEXT(WofsjbQS,   Dino,     WofsjbQSound  )
 STDDIPINFOEXT(DinoQS,     Dino,     DinoQSound    )
 STDDIPINFOEXT(DinohQS,    Dinoh,    DinohQSound   )
 STDDIPINFOEXT(PunisherQS, Punisher, PunisherQSound)
@@ -6325,28 +6337,17 @@ static struct BurnRomInfo DinopicRomDesc[] = {
 	{ "11.bin",        0x080000, 0xb7ad3394, BRF_GRA | CPS1_TILES },
 	{ "10.bin",        0x080000, 0x88847705, BRF_GRA | CPS1_TILES },
 
-	{ "cd_q.5k",       0x020000, 0x605fdb0b, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "cd-q1.1k",      0x080000, 0x60927775, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q2.2k",      0x080000, 0x770f4c47, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q3.3k",      0x080000, 0x2f273ffc, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q4.4k",      0x080000, 0x2c67821d, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "cd63b.1a",      0x000117, 0xef72e902, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",      0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",     0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",      0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",       0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",       0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",       0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",     0x000117, 0x6619c494, BRF_OPT },
-
 	/* PIC16c57 - protected, dump isn't valid */	
 	{ "pic16c57-rp",   0x002d4c, 0x5a6d393c, BRF_PRG | CPS1_PIC },
 
+	{ "cd_q.5k",       0x020000, 0x605fdb0b, BRF_PRG },
+
 	{ "1.bin",         0x080000, 0x7d921309, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "cd-q1.1k",      0x080000, 0x60927775, BRF_SND },
+	{ "cd-q2.2k",      0x080000, 0x770f4c47, BRF_SND },
+	{ "cd-q3.3k",      0x080000, 0x2f273ffc, BRF_SND },
+	{ "cd-q4.4k",      0x080000, 0x2c67821d, BRF_SND },
+
 };
 
 STD_ROM_PICK(Dinopic)
@@ -6367,28 +6368,16 @@ static struct BurnRomInfo Dinopic2RomDesc[] = {
 	{ "27c4000-m12481-6.bin",	0x080000, 0xb7ad3394, BRF_GRA | CPS1_TILES },
 	{ "27c4000-m12481-5.bin",	0x080000, 0x88847705, BRF_GRA | CPS1_TILES },
 
-	{ "cd_q.5k",				0x020000, 0x605fdb0b, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "cd-q1.1k",				0x080000, 0x60927775, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q2.2k",				0x080000, 0x770f4c47, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q3.3k",				0x080000, 0x2f273ffc, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q4.4k",				0x080000, 0x2c67821d, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "cd63b.1a",				0x000117, 0xef72e902, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",				0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",				0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",				0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",				0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",				0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",				0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",				0x000117, 0x6619c494, BRF_OPT },
-
 	/* PIC16c57 - protected, dump isn't valid */
 	{ "pic16c57-xt.hex",		0x0026cc, 0xa6a5eac4, BRF_PRG | CPS1_PIC },
 
+	{ "cd_q.5k",				0x020000, 0x605fdb0b, BRF_PRG },
+
 	{ "27c4000-m12623.bin",		0x080000, 0x7d921309, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "cd-q1.1k",				0x080000, 0x60927775, BRF_SND },
+	{ "cd-q2.2k",				0x080000, 0x770f4c47, BRF_SND },
+	{ "cd-q3.3k",				0x080000, 0x2f273ffc, BRF_SND },
+	{ "cd-q4.4k",				0x080000, 0x2c67821d, BRF_SND },
 	
 	{ "gal20v8a-1.bin",			0x000157, 0xcd99ca47, BRF_OPT },
 	{ "gal20v8a-2.bin",			0x000157, 0x60d016b9, BRF_OPT },
@@ -6409,25 +6398,13 @@ static struct BurnRomInfo Dinopic3RomDesc[] = {
 	{ "tb416-02_27c160.bin",    0x200000, 0xbfd01d21, BRF_GRA | CPS1_TILES },
 	{ "tb415-01_27c160.bin",	0x200000, 0xef508ec5, BRF_GRA | CPS1_TILES },
 
-	{ "cd_q.5k",				0x020000, 0x605fdb0b, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "cd-q1.1k",				0x080000, 0x60927775, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q2.2k",				0x080000, 0x770f4c47, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q3.3k",				0x080000, 0x2f273ffc, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q4.4k",				0x080000, 0x2c67821d, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "cd63b.1a",				0x000117, 0xef72e902, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",				0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",				0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",				0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",				0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",				0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",				0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",				0x000117, 0x6619c494, BRF_OPT },
+	{ "cd_q.5k",				0x020000, 0x605fdb0b, BRF_PRG },
 
 	{ "ti-i_27c040.bin",		0x080000, 0x7d921309, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "cd-q1.1k",				0x080000, 0x60927775, BRF_SND },
+	{ "cd-q2.2k",				0x080000, 0x770f4c47, BRF_SND },
+	{ "cd-q3.3k",				0x080000, 0x2f273ffc, BRF_SND },
+	{ "cd-q4.4k",				0x080000, 0x2c67821d, BRF_SND },
 	
 	{ "1_palce20v8.bin",		0x000157, 0xcd99ca47, BRF_OPT },
 	{ "2_palce20v8.bin",		0x000157, 0x60d016b9, BRF_OPT },
@@ -6455,27 +6432,15 @@ static struct BurnRomInfo Dinopic4RomDesc[] = {
 	{ "27c4000-m15377-a-11.bin",  	0x080000, 0xb7ad3394, BRF_GRA | CPS1_TILES },
 	{ "27c4000-m15279-a-10.bin",  	0x080000, 0x88847705, BRF_GRA | CPS1_TILES },
 
-	{ "cd_q.5k",					0x020000, 0x605fdb0b, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "cd-q1.1k",					0x080000, 0x60927775, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q2.2k",					0x080000, 0x770f4c47, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q3.3k",					0x080000, 0x2f273ffc, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q4.4k",					0x080000, 0x2c67821d, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "cd63b.1a",					0x000117, 0xef72e902, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",					0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",					0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",					0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",					0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",					0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",					0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",					0x000117, 0x6619c494, BRF_OPT },
-
 	{ "pic16c57-rc.bin",			0x001030, 0x4d262eaa, BRF_PRG | CPS1_PIC },
 
+	{ "cd_q.5k",					0x020000, 0x605fdb0b, BRF_PRG },
+
 	{ "27c4000-m15388-a-1.bin",		0x080000, 0x7d921309, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "cd-q1.1k",					0x080000, 0x60927775, BRF_SND },
+	{ "cd-q2.2k",					0x080000, 0x770f4c47, BRF_SND },
+	{ "cd-q3.3k",					0x080000, 0x2f273ffc, BRF_SND },
+	{ "cd-q4.4k",					0x080000, 0x2c67821d, BRF_SND },
 	
 	{ "cat93c46p.bin",				0x000080, 0xd49fa351, BRF_OPT },
 	{ "gal20v8a-1.bin",				0x000157, 0xcd99ca47, BRF_OPT },
@@ -6533,25 +6498,13 @@ static struct BurnRomInfo Jurassic99RomDesc[] = {
 	{ "210101a_cda2.bin",	0x200000, 0x3f167412, BRF_GRA | CPS1_TILES },
 	{ "210102_cdb2.bin",	0x200000, 0x8a6920d8, BRF_GRA | CPS1_TILES },
 
-	{ "cd_q.5k",			0x020000, 0x605fdb0b, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "cd-q1.1k",			0x080000, 0x60927775, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q2.2k",			0x080000, 0x770f4c47, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q3.3k",			0x080000, 0x2f273ffc, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q4.4k",			0x080000, 0x2c67821d, BRF_SND | CPS1_QSOUND_SAMPLES },
-	
-	A_BOARD_QSOUND_PLDS
-	
-	{ "cd63b.1a",			0x000117, 0xef72e902, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",			0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",			0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",			0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",			0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",			0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",			0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",			0x000117, 0x6619c494, BRF_OPT },
+	{ "cd_q.5k",			0x020000, 0x605fdb0b, BRF_PRG },
 
 	{ "21003_u27.bin",		0x080000, 0x7d921309, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "cd-q1.1k",			0x080000, 0x60927775, BRF_SND },
+	{ "cd-q2.2k",			0x080000, 0x770f4c47, BRF_SND },
+	{ "cd-q3.3k",			0x080000, 0x2f273ffc, BRF_SND },
+	{ "cd-q4.4k",			0x080000, 0x2c67821d, BRF_SND },
 
 	{ "1_atf20v8.u25",		0x000157, 0xcd99ca47, BRF_OPT },
 	{ "2_atf16v8.u66",		0x000117, 0x48253c66, BRF_OPT },
@@ -6622,23 +6575,12 @@ static struct BurnRomInfo DinotpicRomDesc[] = {
 	{ "cd-a.160",			0x200000, 0x7e4f9fb3, BRF_GRA | CPS1_TILES },
 	{ "cd-b.160",			0x200000, 0x89532d85, BRF_GRA | CPS1_TILES },
 
-	{ "cd_q.5k",			0x020000, 0x605fdb0b, BRF_PRG | CPS1_Z80_PROGRAM },
+	{ "cd_q.5k",			0x020000, 0x605fdb0b, BRF_PRG },
 
-	{ "cd-q1.1k",			0x080000, 0x60927775, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q2.2k",			0x080000, 0x770f4c47, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q3.3k",			0x080000, 0x2f273ffc, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "cd-q4.4k",			0x080000, 0x2c67821d, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "cd63b.1a",			0x000117, 0xef72e902, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",			0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",			0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",			0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",			0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",			0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",			0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",			0x000117, 0x6619c494, BRF_OPT },
+	{ "cd-q1.1k",			0x080000, 0x60927775, BRF_SND },
+	{ "cd-q2.2k",			0x080000, 0x770f4c47, BRF_SND },
+	{ "cd-q3.3k",			0x080000, 0x2f273ffc, BRF_SND },
+	{ "cd-q4.4k",			0x080000, 0x2c67821d, BRF_SND },
 };
 
 STD_ROM_PICK(Dinotpic)
@@ -9877,27 +9819,15 @@ static struct BurnRomInfo PunipicRomDesc[] = {
 	{ "gfx11.bin",     0x080000, 0x22f2ec92, BRF_GRA | CPS1_TILES },
 	{ "gfx10.bin",     0x080000, 0x763974c9, BRF_GRA | CPS1_TILES },
 
-	{ "ps_q.5k",       0x020000, 0x49ff4446, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "ps-q1.1k",      0x080000, 0x31fd8726, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q2.2k",      0x080000, 0x980a9eef, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q3.3k",      0x080000, 0x0dd44491, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q4.4k",      0x080000, 0xbed42f03, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "ps63b.1a",      0x000117, 0x03a758b0, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",      0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",     0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",      0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",       0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",       0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",       0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",     0x000117, 0x6619c494, BRF_OPT },
-
 	{ "pic16c57",      0x004000, 0x00000000, BRF_PRG | BRF_NODUMP | CPS1_PIC },
 
+	{ "ps_q.5k",       0x020000, 0x49ff4446, BRF_PRG },
+
 	{ "sound.bin",     0x080000, 0xaeec9dc6, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "ps-q1.1k",      0x080000, 0x31fd8726, BRF_SND },
+	{ "ps-q2.2k",      0x080000, 0x980a9eef, BRF_SND },
+	{ "ps-q3.3k",      0x080000, 0x0dd44491, BRF_SND },
+	{ "ps-q4.4k",      0x080000, 0xbed42f03, BRF_SND },
 };
 
 STD_ROM_PICK(Punipic)
@@ -9912,27 +9842,15 @@ static struct BurnRomInfo Punipic2RomDesc[] = {
 	{ "pu11256.bin",   0x200000, 0x6581faea, BRF_GRA | CPS1_TILES },
 	{ "pu13478.bin",   0x200000, 0x61613de4, BRF_GRA | CPS1_TILES },
 
-	{ "ps_q.5k",       0x020000, 0x49ff4446, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "ps-q1.1k",      0x080000, 0x31fd8726, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q2.2k",      0x080000, 0x980a9eef, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q3.3k",      0x080000, 0x0dd44491, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q4.4k",      0x080000, 0xbed42f03, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "ps63b.1a",      0x000117, 0x03a758b0, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",      0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",     0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",      0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",       0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",       0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",       0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",     0x000117, 0x6619c494, BRF_OPT },
-
 	{ "pic16c57",      0x004000, 0x00000000, BRF_PRG | BRF_NODUMP | CPS1_PIC },
 
+	{ "ps_q.5k",       0x020000, 0x49ff4446, BRF_PRG },
+
 	{ "sound.bin",     0x080000, 0xaeec9dc6, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "ps-q1.1k",      0x080000, 0x31fd8726, BRF_SND },
+	{ "ps-q2.2k",      0x080000, 0x980a9eef, BRF_SND },
+	{ "ps-q3.3k",      0x080000, 0x0dd44491, BRF_SND },
+	{ "ps-q4.4k",      0x080000, 0xbed42f03, BRF_SND },
 	
 	{ "93c46.bin",     0x000080, 0x36ab4e7d, BRF_OPT },
 };
@@ -9951,23 +9869,12 @@ static struct BurnRomInfo Punipic3RomDesc[] = {
 	{ "psb-a.rom",     0x200000, 0x57f0f5e3, BRF_GRA | CPS1_TILES },
 	{ "psb-b.rom",     0x200000, 0xd9eb867e, BRF_GRA | CPS1_TILES },
 
-	{ "ps_q.5k",       0x020000, 0x49ff4446, BRF_PRG | CPS1_Z80_PROGRAM },
+	{ "ps_q.5k",       0x020000, 0x49ff4446, BRF_PRG },
 
-	{ "ps-q1.1k",      0x080000, 0x31fd8726, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q2.2k",      0x080000, 0x980a9eef, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q3.3k",      0x080000, 0x0dd44491, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "ps-q4.4k",      0x080000, 0xbed42f03, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "ps63b.1a",      0x000117, 0x03a758b0, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",      0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",     0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",      0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-	{ "d7l1.7l",       0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",       0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",       0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",     0x000117, 0x6619c494, BRF_OPT },
+	{ "ps-q1.1k",      0x080000, 0x31fd8726, BRF_SND },
+	{ "ps-q2.2k",      0x080000, 0x980a9eef, BRF_SND },
+	{ "ps-q3.3k",      0x080000, 0x0dd44491, BRF_SND },
+	{ "ps-q4.4k",      0x080000, 0xbed42f03, BRF_SND },
 
 //	{ "pic16c57",      0x004000, 0x00000000, BRF_PRG | BRF_NODUMP | CPS1_PIC },
 
@@ -14906,33 +14813,20 @@ static struct BurnRomInfo SlampicRomDesc[] = {
 	// not in dump but the game expects to read it as protection, maybe the PIC writes to the same area?
 	{ "mb_qa.5k",			0x020000, 0xe21a03c4, BRF_ESS | BRF_PRG | CPS1_Z80_PROGRAM },
 
-	{ "mb-q1.1k",		 	0x080000, 0x0630c3ce, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q2.2k",		 	0x080000, 0x354f9c21, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q3.3k",			0x080000, 0x7838487c, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q4.4k",			0x080000, 0xab66e087, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q5.1m",			0x080000, 0xc789fef2, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q6.2m",		 	0x080000, 0xecb81b61, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q7.3m",		  	0x080000, 0x041e49ba, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "mb-q8.4m",		 	0x080000, 0x59fe702a, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "mb63b.1a",		  	0x000117, 0xb8392f02, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",		  	0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",		 	0x000117, 0x31793da7, BRF_OPT },
-	{ "ioc1.ic1",		  	0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-
-	{ "d7l1.7l",		 	0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",		  	0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k2.9k",		   	0x000117, 0xcd85a156, BRF_OPT },
-	{ "d10f1.10f",			0x000117, 0x6619c494, BRF_OPT },
-
 	{ "pic16c57-xt-p.bin",	0x002000, 0xaeae5ccc, BRF_PRG | CPS1_PIC },
 #if !defined ROM_VERIFY
 	{ "pic16c57-xt-p.hex",	0x005a1e, 0x61f8607e, BRF_OPT }, // hex dump of PIC
 #endif
 
 	{ "18.bin",				0x080000, 0x73a0c11c, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "mb-q1.1k",		 	0x080000, 0x0630c3ce, BRF_SND },
+	{ "mb-q2.2k",		 	0x080000, 0x354f9c21, BRF_SND },
+	{ "mb-q3.3k",			0x080000, 0x7838487c, BRF_SND },
+	{ "mb-q4.4k",			0x080000, 0xab66e087, BRF_SND },
+	{ "mb-q5.1m",			0x080000, 0xc789fef2, BRF_SND },
+	{ "mb-q6.2m",		 	0x080000, 0xecb81b61, BRF_SND },
+	{ "mb-q7.3m",		  	0x080000, 0x041e49ba, BRF_SND },
+	{ "mb-q8.4m",		 	0x080000, 0x59fe702a, BRF_SND },
 	
 	{ "1_palce16v8.bin",	0x000117, 0xbac89609, BRF_OPT },
 	{ "2_palce16v8.bin",	0x000117, 0x680edfd5, BRF_OPT },
@@ -16043,25 +15937,12 @@ static struct BurnRomInfo WofsjbRomDesc[] = {
 	{ "tk2_gfx6.rom",  0x080000, 0x1abd14d6, BRF_GRA | CPS1_TILES },
 	{ "tk2_gfx8.rom",  0x080000, 0xb27948e3, BRF_GRA | CPS1_TILES },
 
-	{ "tk2_qa.5k",     0x020000, 0xc9183a0d, BRF_PRG | CPS1_Z80_PROGRAM },
+	{ "tk2_qa.5k",     0x020000, 0xc9183a0d, BRF_PRG },
 
-	{ "tk2-q1.1k",     0x080000, 0x611268cf, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "tk2-q2.2k",     0x080000, 0x20f55ca9, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "tk2-q3.3k",     0x080000, 0xbfcf6f52, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "tk2-q4.4k",     0x080000, 0x36642e88, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "tk263b.1a",     0x000117, 0xc4b0349b, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",      0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",     0x000117, 0x31793da7, BRF_OPT },
-
-	{ "ioc1.ic1",      0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-
-	{ "d7l1.7l",       0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",       0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k1.9k",       0x000117, 0x6c35c805, BRF_OPT },
-	{ "d10f1.10f",     0x000117, 0x6619c494, BRF_OPT },
+	{ "tk2-q1.1k",     0x080000, 0x611268cf, BRF_SND },
+	{ "tk2-q2.2k",     0x080000, 0x20f55ca9, BRF_SND },
+	{ "tk2-q3.3k",     0x080000, 0xbfcf6f52, BRF_SND },
+	{ "tk2-q4.4k",     0x080000, 0x36642e88, BRF_SND },
 
 	// using the sound roms from wofhfh or wof3js doesn't give the right result
 	// it doesn't use Q-Sound either
@@ -16131,29 +16012,15 @@ static struct BurnRomInfo WofpicRomDesc[] = {
 	{ "m12073-4",      0x080000, 0x219fd7e2, BRF_GRA | CPS1_TILES },
 	{ "m12073-3",      0x080000, 0xefc17c9a, BRF_GRA | CPS1_TILES },
 
-	{ "tk2_qa.5k",     0x020000, 0xc9183a0d, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "tk2-q1.1k",     0x080000, 0x611268cf, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "tk2-q2.2k",     0x080000, 0x20f55ca9, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "tk2-q3.3k",     0x080000, 0xbfcf6f52, BRF_SND | CPS1_QSOUND_SAMPLES },
-	{ "tk2-q4.4k",     0x080000, 0x36642e88, BRF_SND | CPS1_QSOUND_SAMPLES },
-
-	A_BOARD_QSOUND_PLDS
-
-	{ "tk263b.1a",     0x000117, 0xc4b0349b, BRF_OPT },	// b-board PLDs
-	{ "iob1.12d",      0x000117, 0x3abc0700, BRF_OPT },
-	{ "bprg1.11d",     0x000117, 0x31793da7, BRF_OPT },
-
-	{ "ioc1.ic1",      0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
-
-	{ "d7l1.7l",       0x000117, 0x27b7410d, BRF_OPT },	// d-board PLDs
-	{ "d8l1.8l",       0x000117, 0x539fc7da, BRF_OPT },
-	{ "d9k1.9k",       0x000117, 0x6c35c805, BRF_OPT },
-	{ "d10f1.10f",     0x000117, 0x6619c494, BRF_OPT },
-
 	{ "pic.bin",   	   0x001007, 0x00000000, BRF_PRG | CPS1_PIC | BRF_NODUMP},
+
+	{ "tk2_qa.5k",     0x020000, 0xc9183a0d, BRF_PRG },
 	
 	{ "ma12073.4mm",   0x080000, 0xac421276, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "tk2-q1.1k",     0x080000, 0x611268cf, BRF_SND },
+	{ "tk2-q2.2k",     0x080000, 0x20f55ca9, BRF_SND },
+	{ "tk2-q3.3k",     0x080000, 0xbfcf6f52, BRF_SND },
+	{ "tk2-q4.4k",     0x080000, 0x36642e88, BRF_SND },
 };
 
 STD_ROM_PICK(Wofpic)
@@ -16904,7 +16771,7 @@ static INT32 Cps1LoadRoms(INT32 bLoad)
 
 		if (Cps1Qs) nCpsZRomLen *= 2;
 		if (GameHasStars) nCpsGfxLen += 0x2000;
-		if (nCpsPicRomNum) Cps1DisablePSnd = 1;
+		if (nCpsPicRomNum && !Cps1Qs) Cps1DisablePSnd = 1;
 		
 #if 1 && defined FBNEO_DEBUG
 		if (nCpsRomLen) bprintf(PRINT_IMPORTANT, _T("68K Rom Length %06X, (%i roms byteswapped, %i roms not byteswapped)\n"), nCpsRomLen, nCps68KByteswapRomNum, nCps68KNoByteswapRomNum);
@@ -17482,7 +17349,7 @@ static void Jurassic99PatchCallback()
 		CpsRom[patch_fix_a[(i << 1) + 0]] = (UINT8)patch_fix_a[(i << 1) + 1];
 	}
 
-	if (Cps1QSDip & 1) {
+	if (Cps1Qs) {
 		UINT32 patch_fix_b[] = {
 			// Fix draw scroll
 			0x0006c2, 0xc0, 0x0006c3, 0xff,
@@ -17505,6 +17372,34 @@ static void Jurassic99PatchCallback()
 		for (INT32 i = 0; i < (sizeof(patch_fix_b) / sizeof(UINT32)) >> 1; i++) {
 			CpsRom[patch_fix_b[(i << 1) + 0]] = (UINT8)patch_fix_b[(i << 1) + 1];
 		}
+
+		if (0 != strcmp(BurnDrvGetTextA(DRV_NAME), "dinotpic")) {
+			// Clearing oki's samples
+			memset(CpsAd, 0, 0x080000);
+		}
+
+		INT32 nIndex = 4;
+
+		if ((0 == strcmp(BurnDrvGetTextA(DRV_NAME), "dinopic" )) ||
+			(0 == strcmp(BurnDrvGetTextA(DRV_NAME), "dinopic2")) ||
+			(0 == strcmp(BurnDrvGetTextA(DRV_NAME), "dinopic4"))) {
+			nIndex = 13;
+		}
+
+		// Loading QSound's z80
+		BurnLoadRom(CpsZRom,    nIndex, 1);
+		BurnLoadRom(CpsEncZRom, nIndex, 1);
+
+		if (0 != strcmp(BurnDrvGetTextA(DRV_NAME), "dinotpic")) {
+			nIndex += 2;
+		} else {
+			nIndex++;
+		}
+
+		// Loading QSound's samples
+		for (INT32 nNum = 0; nNum < 4; nNum++, nIndex++) {
+			BurnLoadRom((UINT8*)CpsQSam + 0x080000 * nNum, nIndex, 1);
+		}
 	}
 }
 
@@ -17526,10 +17421,21 @@ static void DinotpicPatchCallback()
 
 static INT32 DinopicInit()
 {
-	Cps1DisablePSnd = 1;
+	Cps1Qs = Cps1QSDip & 1;
+
+	if (!Cps1Qs) {
+		Cps1DisablePSnd = 1;
+	}
+	
 	CpsBootlegEEPROM = 1;
-	Cps1GfxLoadCallbackFunction = CpsLoadTilesDinopic;
-	if (Cps1QSDip & 1) {
+	if (0 == strcmp(BurnDrvGetTextA(DRV_NAME), "dinopic3")) {
+		Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160Alt;
+	} else {
+		Cps1GfxLoadCallbackFunction = CpsLoadTilesDinopic;
+	}
+	if (Cps1Qs) {
+		CRI.nCpsZRomLen = 0x020000;
+		CRI.nCpsQSamLen = 0x200000;
 		AmendProgRomCallback = Jurassic99PatchCallback;
 	} else {
 		Cps1ObjGetCallbackFunction = DinopicObjGet;
@@ -17540,7 +17446,7 @@ static INT32 DinopicInit()
 	INT32 nRet = TwelveMhzInit();
 	if (nRet) return nRet;
 
-	if (Cps1QSDip ^ 1) {
+	if (!Cps1Qs) {
 		CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
 
 		SekOpen(0);
@@ -17573,36 +17479,6 @@ static INT32 DinohInit()
 	SekSetReadByteHandler(1, DinohuntQSharedRamRead);
 	SekClose();
 
-	return nRet;
-}
-
-static INT32 Dinopic3Init()
-{
-	Cps1DisablePSnd = 1;
-	CpsBootlegEEPROM = 1;
-	Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160Alt;
-	if (Cps1QSDip & 1) {
-		AmendProgRomCallback = Jurassic99PatchCallback;
-	} else {
-		Cps1ObjGetCallbackFunction = DinopicObjGet;
-		Cps1ObjDrawCallbackFunction = FcrashObjDraw;
-	}
-	CpsMemScanCallbackFunction = CpsBootlegSpriteRamScanCallback;
-	
-	INT32 nRet = TwelveMhzInit();
-	if (nRet) return nRet;
-
-	if (Cps1QSDip ^ 1) {
-		CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
-
-		SekOpen(0);
-		SekMapMemory(CpsBootlegSpriteRam, 0x990000, 0x991fff, MAP_RAM);
-		SekMapHandler(1, 0x980000, 0x98000f, MAP_WRITE);
-		SekSetWriteWordHandler(1, DinopicScrollWrite);
-		SekMapHandler(2, 0x800200, 0x8002ff, MAP_WRITE);
-		SekSetWriteWordHandler(2, DinopicLayerWrite);
-		SekClose();
-	}
 	return nRet;
 }
 
@@ -17686,10 +17562,17 @@ static INT32 DinotInit()
 
 static INT32 DinotpicInit()
 {
-	Cps1DisablePSnd = 1;
+	Cps1Qs = Cps1QSDip & 1;
+
+	if (!Cps1Qs) {
+		Cps1DisablePSnd = 1;
+	}
+
 	CpsBootlegEEPROM = 1;
 	Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160;
-	if (Cps1QSDip & 1) {
+	if (Cps1Qs) {
+		CRI.nCpsZRomLen = 0x020000;
+		CRI.nCpsQSamLen = 0x200000;
 		AmendProgRomCallback = DinotpicPatchCallback;
 	} else {
 		Cps1ObjGetCallbackFunction = DinopicObjGet;
@@ -17700,7 +17583,7 @@ static INT32 DinotpicInit()
 	INT32 nRet = TwelveMhzInit();
 	if (nRet) return nRet;
 
-	if (Cps1QSDip ^ 1) {
+	if (!Cps1Qs) {
 		CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
 
 		SekOpen(0);
@@ -18937,21 +18820,62 @@ static void PunipicPatchCallback()
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++) {
 		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
+
+	if (0 != strcmp(BurnDrvGetTextA(DRV_NAME), "punipic3")) {
+		// Clearing oki's samples
+		memset(CpsAd, 0, 0x080000);
+	}
+
+	INT32 nIndex = 6;
+
+	if (0 == strcmp(BurnDrvGetTextA(DRV_NAME), "punipic")) {
+		nIndex = 13;
+	} else if (0 == strcmp(BurnDrvGetTextA(DRV_NAME), "punipic2")) {
+		nIndex++;
+	}
+
+	// Loading QSound's z80
+	BurnLoadRom(CpsZRom, nIndex, 1);
+	BurnLoadRom(CpsEncZRom, nIndex, 1);
+
+	if (0 != strcmp(BurnDrvGetTextA(DRV_NAME), "punipic3")) {
+		nIndex += 2;
+	} else {
+		nIndex++;
+	}
+
+	// Loading QSound's samples
+	for (INT32 nNum = 0; nNum < 4; nNum++, nIndex++) {
+		BurnLoadRom((UINT8*)CpsQSam + 0x080000 * nNum, nIndex, 1);
+	}
 }
 
 static INT32 PunipicInit()
 {
-	Cps1DisablePSnd = 1;
+	Cps1Qs = Cps1QSDip & 1;
+
+	if (!Cps1Qs) {
+		Cps1DisablePSnd = 1;
+	}
+
 	bCpsUpdatePalEveryFrame = 1;
 	CpsBootlegEEPROM = 1;
-	if (Cps1QSDip & 1) {
+	if (Cps1Qs) {
+		CRI.nCpsZRomLen = 0x020000;
+		CRI.nCpsQSamLen = 0x200000;
 		AmendProgRomCallback = PunipicPatchCallback;
 	} else {
 		Cps1OverrideLayers = 1;
 		Cps1ObjGetCallbackFunction = DinopicObjGet;
 		Cps1ObjDrawCallbackFunction = FcrashObjDraw;
 	}
-	Cps1GfxLoadCallbackFunction = CpsLoadTilesDinopic;
+	if (0 == strcmp(BurnDrvGetTextA(DRV_NAME), "punipic")) {
+		Cps1GfxLoadCallbackFunction = CpsLoadTilesDinopic;
+	} else if (0 == strcmp(BurnDrvGetTextA(DRV_NAME), "punipic2")) {
+		Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160Alt;
+	} else if (0 == strcmp(BurnDrvGetTextA(DRV_NAME), "punipic3")) {
+		Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160;
+	}
 	CpsMemScanCallbackFunction = PunipicScanCallback;
 	
 	INT32 nRet = TwelveMhzInit();
@@ -18978,74 +18902,6 @@ static INT32 PunipicExit()
 	PunipicPriorityValue = 0;
 	
 	return DrvExit();
-}
-
-static INT32 Punipic2Init()
-{
-	Cps1DisablePSnd = 1;
-	bCpsUpdatePalEveryFrame = 1;
-	CpsBootlegEEPROM = 1;
-	if (Cps1QSDip & 1) {
-		AmendProgRomCallback = PunipicPatchCallback;
-	} else {
-		Cps1OverrideLayers = 1;
-		Cps1ObjGetCallbackFunction = DinopicObjGet;
-		Cps1ObjDrawCallbackFunction = FcrashObjDraw;
-	}
-	Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160Alt;
-	CpsMemScanCallbackFunction = PunipicScanCallback;
-	
-	INT32 nRet = TwelveMhzInit();
-	if (nRet) return nRet;
-	
-	CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
-	
-	SekOpen(0);
-	SekMapMemory(CpsBootlegSpriteRam, 0x990000, 0x993fff, MAP_RAM);
-	SekMapHandler(1, 0xf18000, 0xf19fff, MAP_READ);
-	SekSetReadByteHandler(1, PunipicF18Read);
-	SekMapHandler(2, 0x980000, 0x980fff, MAP_WRITE);
-	SekSetWriteWordHandler(2, Punipic98WriteWord);
-	SekMapHandler(3, 0xff0000, 0xffffff, MAP_WRITE);
-	SekSetWriteByteHandler(3, PunipicFFWriteByte);
-	SekSetWriteWordHandler(3, PunipicFFWriteWord);
-	SekClose();
-	
-	return nRet;
-}
-
-static INT32 Punipic3Init()
-{
-	Cps1DisablePSnd = 1;
-	bCpsUpdatePalEveryFrame = 1;
-	CpsBootlegEEPROM = 1;
-	if (Cps1QSDip & 1) {
-		AmendProgRomCallback = PunipicPatchCallback;
-	} else {
-		Cps1OverrideLayers = 1;
-		Cps1ObjGetCallbackFunction = DinopicObjGet;
-		Cps1ObjDrawCallbackFunction = FcrashObjDraw;
-	}
-	Cps1GfxLoadCallbackFunction = CpsLoadTilesHack160;
-	CpsMemScanCallbackFunction = PunipicScanCallback;
-
-	INT32 nRet = TwelveMhzInit();
-	if (nRet) return nRet;
-
-	CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
-
-	SekOpen(0);
-	SekMapMemory(CpsBootlegSpriteRam, 0x990000, 0x993fff, MAP_RAM);
-	SekMapHandler(1, 0xf18000, 0xf19fff, MAP_READ);
-	SekSetReadByteHandler(1, PunipicF18Read);
-	SekMapHandler(2, 0x980000, 0x980fff, MAP_WRITE);
-	SekSetWriteWordHandler(2, Punipic98WriteWord);
-	SekMapHandler(3, 0xff0000, 0xffffff, MAP_WRITE);
-	SekSetWriteByteHandler(3, PunipicFFWriteByte);
-	SekSetWriteWordHandler(3, PunipicFFWriteWord);
-	SekClose();
-
-	return nRet;
 }
 
 static INT32 PunisherbInit()
@@ -20662,15 +20518,39 @@ static void SlampicPatchCallback()
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++) {
 		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
+
+	// Clearing oki's samples
+	memset(CpsAd, 0, 0x080000);
+
+	// Loading QSound's z80
+	BurnLoadRom(CpsEncZRom, 16, 1);
+
+	INT32 nIndex = 19;
+
+#if !defined ROM_VERIFY
+	nIndex++;
+#endif
+
+	// Loading QSound's samples
+	for (INT32 nNum = 0; nNum < 8; nNum++, nIndex++) {
+		BurnLoadRom((UINT8*)CpsQSam + 0x080000 * nNum, nIndex, 1);
+	}
 }
 
 static INT32 SlampicInit()
 {
-	Cps1DisablePSnd = 1;
+	Cps1Qs = Cps1QSDip & 1;
+
+	if (!Cps1Qs) {
+		Cps1DisablePSnd = 1;
+	}
+
 	CpsBootlegEEPROM = 1;
 	bCpsUpdatePalEveryFrame = 1;
 	Cps1GfxLoadCallbackFunction = CpsLoadTilesSlampic;
-	if (Cps1QSDip & 1) {
+	if (Cps1Qs) {
+		CRI.nCpsZRomLen = 0x010000;
+		CRI.nCpsQSamLen = 0x400000;
 		AmendProgRomCallback = SlampicPatchCallback;
 	} else {
 		Cps1ObjGetCallbackFunction = Sf2mdtObjGet;
@@ -20681,7 +20561,7 @@ static INT32 SlampicInit()
 	INT32 nRet = TwelveMhzInit();
 
 	if (!nRet) {
-		if (Cps1QSDip ^ 1) {
+		if (!Cps1Qs) {
 			for (INT32 i = 0x7fff; i >= 0; i--) {
 				CpsZRom[(i << 1) + 0] = CpsZRom[i];
 				CpsZRom[(i << 1) + 1] = 0xff;
@@ -20690,17 +20570,17 @@ static INT32 SlampicInit()
 		CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
 
 		SekOpen(0);
-		if (Cps1QSDip ^ 1)
+		if (!Cps1Qs)
 			SekMapMemory(CpsZRom, 0xf00000, 0xf0ffff, MAP_ROM);
 		SekMapMemory(CpsBootlegSpriteRam, 0x990000, 0x993fff, MAP_RAM);
 		SekMapHandler(1, 0xf18000, 0xf19fff, MAP_READ);
-		if (Cps1QSDip ^ 1)
+		if (!Cps1Qs)
 			SekSetReadByteHandler(1, SlampicF18Read);
 		SekMapHandler(2, 0xf1e000, 0xf1ffff, MAP_READ);
-		if (Cps1QSDip ^ 1)
+		if (!Cps1Qs)
 			SekSetReadByteHandler(2, SlampicF18Read);
 		SekMapHandler(3, 0x980000, 0x980fff, MAP_WRITE);
-		if (Cps1QSDip ^ 1)
+		if (!Cps1Qs)
 			SekSetWriteWordHandler(3, SlampicScrollWrite);
 		SekMapHandler(4, 0xff0000, 0xffffff, MAP_WRITE);
 		SekSetWriteByteHandler(4, SlampicFFWriteByte);
@@ -21301,6 +21181,17 @@ static void WofsjbPatchCallback()
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT16)) >> 1; i++) {
 		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
+
+	// Loading QSound's z80
+	BurnLoadRom(CpsZRom,    10, 1);
+	BurnLoadRom(CpsEncZRom, 10, 1);
+
+	INT32 nIndex = 11;
+
+	// Loading QSound's samples
+	for (INT32 nNum = 0; nNum < 4; nNum++, nIndex++) {
+		BurnLoadRom((UINT8*)CpsQSam + 0x080000 * nNum, nIndex, 1);
+	}
 }
 
 static INT32 WofsjbInit()
@@ -21309,10 +21200,15 @@ static INT32 WofsjbInit()
 	CpsLayer2XOffs = 4;
 	CpsLayer3XOffs = 8;
 
-	Cps1DisablePSnd = 1;
+	Cps1Qs = Cps1QSDip & 1;
 
-	if (Cps1QSDip & 1)
+	if (Cps1Qs) {
+		CRI.nCpsZRomLen = 0x020000;
+		CRI.nCpsQSamLen = 0x200000;
 		AmendProgRomCallback = WofsjbPatchCallback;
+	} else {
+		Cps1DisablePSnd = 1;
+	}
 
 	return TwelveMhzInit();
 }
@@ -21420,13 +21316,30 @@ static void WofpicPatchCallback()
 	for (INT32 i = 0; i < (sizeof(patch_fix) / sizeof(UINT32)) >> 1; i++) {
 		CpsRom[patch_fix[(i << 1) + 0]] = (UINT8)patch_fix[(i << 1) + 1];
 	}
+
+	// Clearing oki's samples
+	memset(CpsAd, 0, 0x080000);
+
+	// Loading QSound's z80
+	BurnLoadRom(CpsZRom,    13, 1);
+	BurnLoadRom(CpsEncZRom, 13, 1);
+
+	INT32 nIndex = 15;
+
+	// Loading QSound's samples
+	for (INT32 nNum = 0; nNum < 4; nNum++, nIndex++) {
+		BurnLoadRom((UINT8*)CpsQSam + 0x080000 * nNum, nIndex, 1);
+	}
 }
 
 static INT32 Wofr1blInit()
 {
 	bCpsUpdatePalEveryFrame = 1;
 	CpsBootlegEEPROM = 1;
-	if (Cps1QSDip & 1) {
+	Cps1Qs = Cps1QSDip & 1;
+	if (Cps1Qs) {
+		CRI.nCpsZRomLen = 0x020000;
+		CRI.nCpsQSamLen = 0x200000;
 		AmendProgRomCallback = WofpicPatchCallback;
 	} else {
 		Cps1OverrideLayers = 1;
@@ -21443,7 +21356,7 @@ static INT32 Wofr1blInit()
 	INT32 nRet = TwelveMhzInit();
 	if (nRet) return nRet;
 
-	if (Cps1QSDip ^ 1) {
+	if (!Cps1Qs) {
 		CpsBootlegSpriteRam = (UINT8*)BurnMalloc(0x4000);
 
 		SekOpen(0);
@@ -21978,7 +21891,7 @@ struct BurnDriver BurnDrvCpsDinopic3 = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 3, HARDWARE_CAPCOM_CPS1, GBF_SCRFIGHT, 0,
 	NULL, Dinopic3RomInfo, Dinopic3RomName, NULL, NULL, NULL, NULL, DinoQSInputInfo, DinoQSDIPInfo,
-	Dinopic3Init, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
+	DinopicInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
@@ -23038,7 +22951,7 @@ struct BurnDriver BurnDrvCpsPunipic2 = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_CAPCOM_CPS1, GBF_SCRFIGHT, 0,
 	NULL, Punipic2RomInfo, Punipic2RomName, NULL, NULL, NULL, NULL, PunisherQSInputInfo, PunisherQSDIPInfo,
-	Punipic2Init, PunipicExit, Cps1Frame, CpsRedraw, CpsAreaScan,
+	PunipicInit, PunipicExit, Cps1Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
@@ -23048,7 +22961,7 @@ struct BurnDriver BurnDrvCpsPunipic3 = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 2, HARDWARE_CAPCOM_CPS1, GBF_SCRFIGHT, 0,
 	NULL, Punipic3RomInfo, Punipic3RomName, NULL, NULL, NULL, NULL, PunisherQSInputInfo, PunisherQSDIPInfo,
-	Punipic3Init, PunipicExit, Cps1Frame, CpsRedraw, CpsAreaScan,
+	PunipicInit, PunipicExit, Cps1Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
@@ -24867,7 +24780,7 @@ struct BurnDriver BurnDrvCpsWofsjb = {
 	"Sangokushi II: Sheng Jian Sanguo (Chinese bootleg set 3)\0", "No sound", "bootleg", "CPS1",
 	L"\u4E09\u56FD\u5FD7 II: \u5723\u5251\u4E09\0Sangokushi II: Sheng Jian Sanguo (Chinese bootleg set 3)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_BOOTLEG, 3, HARDWARE_CAPCOM_CPS1, GBF_SCRFIGHT, 0,
-	NULL, WofsjbRomInfo, WofsjbRomName, NULL, NULL, NULL, NULL, WofsjbInputInfo, DinoQSoundDIPInfo,
+	NULL, WofsjbRomInfo, WofsjbRomName, NULL, NULL, NULL, NULL, WofsjbInputInfo, WofsjbQSDIPInfo,
 	WofsjbInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
@@ -25806,7 +25719,7 @@ struct BurnDriver BurnDrvCpsMercsc = {
 	{ "d8l1.8l",	0x000117, 0x539fc7da, BRF_OPT },						\
 	{ "d9k2.9k",	0x000117, 0xcd85a156, BRF_OPT },						\
 	{ "d10f1.10f",	0x000117, 0x6619c494, BRF_OPT },
-#define DINO_COMPONENT														\
+#define DINO_COMPONENTS														\
 	{ "cd-1m.3a",	0x080000, 0x8da4f917, BRF_GRA | CPS1_TILES },			\
 	{ "cd-3m.5a",	0x080000, 0x6c40f603, BRF_GRA | CPS1_TILES },			\
 	{ "cd-2m.4a",	0x080000, 0x09c8fc2d, BRF_GRA | CPS1_TILES },			\
@@ -25816,7 +25729,7 @@ struct BurnDriver BurnDrvCpsMercsc = {
 	{ "cd-6m.8a",	0x080000, 0xe7599ac4, BRF_GRA | CPS1_TILES },			\
 	{ "cd-8m.10a",	0x080000, 0x211b4b15, BRF_GRA | CPS1_TILES },			\
 	DINO_MISC
-#define DINOJ_COMPONENT														\
+#define DINOJ_COMPONENTS													\
 	DINOJ_TILES																\
 	DINO_MISC
 
@@ -25827,7 +25740,7 @@ struct BurnDriver BurnDrvCpsMercsc = {
 static struct BurnRomInfo DinoreRomDesc[] = {
 	{ "cde_re.10f",    0x200000, 0x7dd12d69, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(Dinore)
@@ -25853,7 +25766,7 @@ static struct BurnRomInfo dinotwRomDesc[] = {
 	{ "cdtw_21a.6f",	0x080000, 0x30f0041b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdtw_20a.5f",	0x080000, 0x418ced7e, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinotw)
@@ -25886,7 +25799,7 @@ static struct BurnRomInfo dinotjRomDesc[] = {
 	{ "cdtj_21a.6f",	0x080000, 0x26769e22, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdtj_20a.5f",	0x080000, 0x4e655871, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinotj)
@@ -25912,7 +25825,7 @@ static struct BurnRomInfo dinodsRomDesc[] = {
 	{ "cdds_21a.6f",	0x080000, 0xe361ee8d, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdds_20a.5f",	0x080000, 0x10b83994, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinods)
@@ -25937,7 +25850,7 @@ static struct BurnRomInfo dino1v3RomDesc[] = {
 	{ "cde_22a.7f",		0x080000, 0x9278aa12, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cde_21a.6f",		0x080000, 0x66d23de2, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dino1v3)
@@ -25962,7 +25875,7 @@ static struct BurnRomInfo dinodwRomDesc[] = {
 	{ "cddw_22a.7f",	0x080000, 0x0c6d3004, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cddw_21a.6f",	0x080000, 0x50378c32, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinodw)
@@ -25988,7 +25901,7 @@ static struct BurnRomInfo dinoyzRomDesc[] = {
 	{ "cdyz_21a.6f",	0x080000, 0xc6fb361b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdyz_20a.5f",	0x080000, 0x27b19848, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinoyz)
@@ -26013,7 +25926,7 @@ static struct BurnRomInfo dinosjRomDesc[] = {
 	{ "cdsj_22a.7f",	0x080000, 0x8c28ca74, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdsj_21a.6f",	0x080000, 0x2f9132a4, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinosj)
@@ -26038,7 +25951,7 @@ static struct BurnRomInfo dinolyRomDesc[] = {
 	{ "cdly_22a.7f",	0x080000, 0x273dacc8, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdly_21a.6f",	0x080000, 0x982543a0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinoly)
@@ -26063,7 +25976,7 @@ static struct BurnRomInfo dinowjRomDesc[] = {
 	{ "cdwj_22a.7f",	0x080000, 0x74f32a30, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdwj_21a.6f",	0x080000, 0x2ac06ad8, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinowj)
@@ -26088,7 +26001,7 @@ static struct BurnRomInfo dinofwRomDesc[] = {
 	{ "cdfw_22a.7f",	0x080000, 0x11df0cfb, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdfw_21a.6f",	0x080000, 0x42bae64d, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 
 	/* Framework 2022q - 20210913 */
 	{ "cdfw_23a.dif",	0x080000, 0xcd06b4b2, BRF_ESS | BRF_PRG },
@@ -26144,7 +26057,7 @@ static struct BurnRomInfo dinossRomDesc[] = {
 	{ "cdss_21a.6f",	0x080000, 0xda80ce35, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdss_20a.5f",	0x080000, 0x99019506, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinoss)
@@ -26169,7 +26082,7 @@ static struct BurnRomInfo dinojjRomDesc[] = {
 	{ "cdjj_22a.7f",	0x080000, 0xfab740a9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdjj_21a.6f",	0x080000, 0x84cfc5df, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinojj)
@@ -26195,7 +26108,7 @@ static struct BurnRomInfo dinoplusRomDesc[] = {
 	{ "cdp_21a.6f",		0x080000, 0xb2fcb323, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdp_20a.5f",		0x080000, 0xfa4cf986, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinoplus)
@@ -26221,7 +26134,7 @@ static struct BurnRomInfo dinojdRomDesc[] = {
 	{ "cdjd_21a.6f",	0x080000, 0x5685924e, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdjd_20a.5f",	0x080000, 0x7c5d66ef, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinojd)
@@ -26239,14 +26152,14 @@ struct BurnDriver BurnDrvCpsdinojd = {
 
 
 // Cadillacs and Dinosaurs (Crazy BBQ, Hack)
-// GOTVG 20240216
+// GOTVG 20240308
 
 static struct BurnRomInfo dinokrRomDesc[] = {
-	{ "cdkr_23a.8f",	0x080000, 0xa0069172, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "cdkr_22a.7f",	0x080000, 0x2169a778, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "cdkr_21a.6f",	0x080000, 0x7a6fbea7, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "cdkr_23a.8f",	0x080000, 0x4e4501a6, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "cdkr_22a.7f",	0x080000, 0xe9450be0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "cdkr_21a.6f",	0x080000, 0xc59745c8, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINO_COMPONENT
+	DINO_COMPONENTS
 };
 
 STD_ROM_PICK(dinokr)
@@ -26272,7 +26185,7 @@ static struct BurnRomInfo dinosdjRomDesc[] = {
 	{ "cdsdj_21a.6f",	0x080000, 0xebdd5897, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdsdj_20a.5f",	0x080000, 0x7432d4c7, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINOJ_COMPONENT
+	DINOJ_COMPONENTS
 };
 
 STD_ROM_PICK(dinosdj)
@@ -26297,7 +26210,7 @@ static struct BurnRomInfo dino3jRomDesc[] = {
 	{ "cd3j_22a.7f",	0x080000, 0xec4095bd, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cd3j_21a.6f",	0x080000, 0x6c325068, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINOJ_COMPONENT
+	DINOJ_COMPONENTS
 };
 
 STD_ROM_PICK(dino3j)
@@ -26323,7 +26236,7 @@ static struct BurnRomInfo dinoxzRomDesc[] = {
 	{ "cdxz_21a.6f",	0x080000, 0x3d0354e9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdxz_20a.5f",	0x080000, 0xcebe10f7, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINOJ_COMPONENT
+	DINOJ_COMPONENTS
 };
 
 STD_ROM_PICK(dinoxz)
@@ -26349,7 +26262,7 @@ static struct BurnRomInfo dinosynRomDesc[] = {
 	{ "cdsyn_21a.6f",	0x080000, 0xeb9517f3, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "cdsyn_20a.5f",	0x080000, 0xc641233a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	DINOJ_COMPONENT
+	DINOJ_COMPONENTS
 };
 
 STD_ROM_PICK(dinosyn)
@@ -26365,9 +26278,9 @@ struct BurnDriver BurnDrvCpsdinosyn = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef DINOJ_COMPONENT
+#undef DINOJ_COMPONENTS
 #undef DINOJ_TILES
-#undef DINO_COMPONENT
+#undef DINO_COMPONENTS
 #undef DINO_MISC
 
 
@@ -26385,7 +26298,7 @@ struct BurnDriver BurnDrvCpsdinosyn = {
 	{ "ccprg.11d",		0x000117, 0xe1c225c4, BRF_OPT },							\
 	{ "ioc1.ic7",		0x000104, 0xa399772d, BRF_OPT },							\
 	{ "c632.ic1",		0x000117, 0x0fbd9270, BRF_OPT },
-#define CAPTCOMM_COMPONENT															\
+#define CAPTCOMM_COMPONENTS															\
 	{ "cc-5m.3a",		0x080000, 0x7261d8ba, BRF_GRA | CPS1_TILES },				\
 	{ "cc-7m.5a",		0x080000, 0x6a60f949, BRF_GRA | CPS1_TILES },				\
 	{ "cc-1m.4a",		0x080000, 0x00637302, BRF_GRA | CPS1_TILES },				\
@@ -26438,7 +26351,7 @@ static struct BurnRomInfo captcmzsRomDesc[] = {
 	{ "cczs_24d.9e",	0x100000, 0xf3ee95be, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "cczs_28d.9f",	0x100000, 0x996e7663, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmzs)
@@ -26464,22 +26377,22 @@ struct BurnDriver BurnDrvCpscaptcmzs = {
 
 // Captain Commando (Elite Competition, Hack)
 // Modified by Jinggai
-// GOTVG 20230226
+// GOTVG 20240221
 
 static struct BurnRomInfo captcmjyRomDesc[] = {
-	{ "ccjy_23d.8f",	0x080000, 0xfd197e81, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "ccjy_23d.8f",	0x080000, 0xe1c762fd, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "ccjy_22d.7f",	0x080000, 0x3d576220, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "ccjy_24d.9e",	0x100000, 0x6c162a49, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
-	{ "ccjy_28d.9f",	0x100000, 0xd3ac68f3, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "ccjy_24d.9e",	0x100000, 0x032eb10f, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "ccjy_28d.9f",	0x100000, 0x7bf08291, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmjy)
 STD_ROM_FN(captcmjy)
 
 struct BurnDriver BurnDrvCpscaptcmjy = {
-	"captcmjy", "captcomm", NULL, NULL, "2023",
+	"captcmjy", "captcomm", NULL, NULL, "2024",
 	"Captain Commando (Elite Competition, Hack)\0", NULL, "hack", "CPS1",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 4, HARDWARE_CAPCOM_CPS1, GBF_SCRFIGHT, 0,
@@ -26499,7 +26412,7 @@ static struct BurnRomInfo captcmmyRomDesc[] = {
 	{ "ccmy_24d.9e",	0x100000, 0x73a2c165, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "ccmy_28d.9f",	0x100000, 0x87ebfc35, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmmy)
@@ -26526,7 +26439,7 @@ static struct BurnRomInfo captcmwxRomDesc[] = {
 	{ "ccwx_24d.9e",	0x100000, 0x74ce3b8b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "ccwx_28d.9f",	0x100000, 0x0b151074, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmwx)
@@ -26553,7 +26466,7 @@ static struct BurnRomInfo captcmztRomDesc[] = {
 	{ "cczt_24d.9e",	0x100000, 0x85d0f5a0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "cczt_28d.9f",	0x100000, 0x03dd2c5a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmzt)
@@ -26580,7 +26493,7 @@ static struct BurnRomInfo captcmdwRomDesc[] = {
 	{ "ccdw_24d.9e",	0x100000, 0xba97b5f6, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "ccdw_28d.9f",	0x100000, 0x980e37cf, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmdw)
@@ -26607,7 +26520,7 @@ static struct BurnRomInfo captcm2yRomDesc[] = {
 	{ "cc2y_24d.9e",	0x100000, 0xb80e4114, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "cc2y_28d.9f",	0x100000, 0x22a3f9db, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcm2y)
@@ -26634,7 +26547,7 @@ static struct BurnRomInfo captcmscRomDesc[] = {
 	{ "ccsc_24d.9e",	0x100000, 0xb7890530, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "ccsc_28d.9f",	0x100000, 0x002b6e51, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmsc)
@@ -26661,7 +26574,7 @@ static struct BurnRomInfo captcmcrRomDesc[] = {
 	{ "cccr_24d.9e",	0x100000, 0x236ab891, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "cccr_28d.9f",	0x100000, 0x3cf7dcc7, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmcr)
@@ -26688,7 +26601,7 @@ static struct BurnRomInfo captc1v4RomDesc[] = {
 	{ "cc_24d.9e",		0x020000, 0x680e543f, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "cc_28d.9f",		0x020000, 0x8820039f, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captc1v4)
@@ -26715,7 +26628,7 @@ static struct BurnRomInfo captcmshRomDesc[] = {
 	{ "ccsh_24d.9e",	0x100000, 0x85740028, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "ccsh_28d.9f",	0x100000, 0x7c666e84, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	CAPTCOMM_COMPONENT
+	CAPTCOMM_COMPONENTS
 };
 
 STD_ROM_PICK(captcmsh)
@@ -26731,7 +26644,7 @@ struct BurnDriver BurnDrvCpscaptcmsh = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef CAPTCOMM_COMPONENT
+#undef CAPTCOMM_COMPONENTS
 #undef CAPTCOMM_MISC
 
 
@@ -26971,7 +26884,7 @@ struct BurnDriver BurnDrvCpsffightdw = {
 	{ "bprg1.11d",	0x000117, 0x31793da7, BRF_OPT },							\
 	{ "ioc1.ic7",	0x000104, 0xa399772d, BRF_OPT },							\
 	{ "c632.ic1",	0x000117, 0x0fbd9270, BRF_OPT },
-#define KNIGHTS_COMPONENT														\
+#define KNIGHTS_COMPONENTS														\
 	{ "kr-5m.3a",	0x080000, 0x9e36c1a4, BRF_GRA | CPS1_TILES },				\
 	{ "kr-7m.5a",	0x080000, 0xc5832cae, BRF_GRA | CPS1_TILES },				\
 	{ "kr-1m.4a",	0x080000, 0xf095be2d, BRF_GRA | CPS1_TILES },				\
@@ -26990,7 +26903,7 @@ static struct BurnRomInfo knightspRomDesc[] = {
 	{ "kr_23p.8f",	0x080000, 0x1c73393a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "kr_22.7f",	0x080000, 0xd0b671a9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	KNIGHTS_COMPONENT
+	KNIGHTS_COMPONENTS
 };
 
 STD_ROM_PICK(knightsp)
@@ -27021,7 +26934,7 @@ static struct BurnRomInfo knightctRomDesc[] = {
 	{ "kr_23ct.8f",	0x080000, 0x98d0618b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "kr_22.7f",	0x080000, 0xd0b671a9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	KNIGHTS_COMPONENT
+	KNIGHTS_COMPONENTS
 };
 
 STD_ROM_PICK(knightct)
@@ -27071,7 +26984,7 @@ struct BurnDriver BurnDrvCpsknightsc = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef KNIGHTS_COMPONENT
+#undef KNIGHTS_COMPONENTS
 #undef KNIGHTS_MISC
 
 
@@ -27084,7 +26997,7 @@ struct BurnDriver BurnDrvCpsknightsc = {
 	{ "kdu_35.9f",		0x020000, 0x4ca6a48a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },	\
 	{ "kdu_29.10e",		0x020000, 0x0360fa72, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },	\
 	{ "kdu_36a.10f",	0x020000, 0x95a3cef8, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
-#define KOD_COMPONENT																			\
+#define KOD_COMPONENTS																			\
 	{ "kd-5m.4a",		0x080000, 0xe45b8701, BRF_GRA | CPS1_TILES },							\
 	{ "kd-7m.6a",		0x080000, 0xa7750322, BRF_GRA | CPS1_TILES },							\
 	{ "kd-1m.3a",		0x080000, 0x5f74bf78, BRF_GRA | CPS1_TILES },							\
@@ -27112,7 +27025,7 @@ static struct BurnRomInfo kod1v3RomDesc[] = {
 	{ "kdu_38b.12f",	0x020000, 0xbe8405a1, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	KODU_PRG2
 
-	KOD_COMPONENT
+	KOD_COMPONENTS
 };
 
 STD_ROM_PICK(kod1v3)
@@ -27147,7 +27060,7 @@ static struct BurnRomInfo kodbsRomDesc[] = {
 	{ "kdbs_38b.12f",	0x020000, 0x3eceba92, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	KODU_PRG2
 
-	KOD_COMPONENT
+	KOD_COMPONENTS
 };
 
 STD_ROM_PICK(kodbs)
@@ -27174,7 +27087,7 @@ static struct BurnRomInfo koddwRomDesc[] = {
 	{ "kdw_38b.12f",	0x020000, 0xfd6c6a53, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	KODU_PRG2
 
-	KOD_COMPONENT
+	KOD_COMPONENTS
 };
 
 STD_ROM_PICK(koddw)
@@ -27201,7 +27114,7 @@ static struct BurnRomInfo kodlyRomDesc[] = {
 	{ "kdly_38b.12f",	0x020000, 0xd402b86a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	KODU_PRG2
 
-	KOD_COMPONENT
+	KOD_COMPONENTS
 };
 
 STD_ROM_PICK(kodly)
@@ -27231,7 +27144,7 @@ static struct BurnRomInfo kodlysRomDesc[] = {
 	{ "kdlys_29.10e",	0x040000, 0xf8e36140, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "kdlys_36a.10f",	0x040000, 0x421e445f, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	KOD_COMPONENT
+	KOD_COMPONENTS
 };
 
 STD_ROM_PICK(kodlys)
@@ -27270,7 +27183,7 @@ static struct BurnRomInfo kodyhRomDesc[] = {
 	{ "kdyh_29.10e",	0x040000, 0x6ec796b0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 	{ "kdyh_36a.10f",	0x040000, 0x11038a97, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
 
-	KOD_COMPONENT
+	KOD_COMPONENTS
 };
 
 STD_ROM_PICK(kodyh)
@@ -27286,8 +27199,56 @@ struct BurnDriver BurnDrvCpskodyh = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef KOD_COMPONENT
+#undef KOD_COMPONENTS
 #undef KODU_PRG2
+
+// The King of Dragons (Remix Special, Hack)
+// Modified by Bonusjz
+
+static struct BurnRomInfo KodsrRomDesc[] = {
+	{ "kde_30.11e",		0x020000, 0xc7414fd4, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_37.11f",		0x020000, 0xa5bf40d2, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_31.12e",		0x020000, 0x1fffc7bd, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_38.12f",		0x020000, 0x89e57a82, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_28.9e",		0x020000, 0x9367bcd9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_35.9f",		0x020000, 0x4ca6a48a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_29.10e",		0x020000, 0x6a0ba878, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "kde_36.10f",		0x020000, 0xb509b39d, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+
+	{ "kdsr-5m.4a",		0x080000, 0x0aaa04b7, BRF_GRA | CPS1_TILES },
+	{ "kdsr-7m.6a",		0x080000, 0x28d6b2ff, BRF_GRA | CPS1_TILES },
+	{ "kdsr-1m.3a",		0x080000, 0x8707e5ac, BRF_GRA | CPS1_TILES },
+	{ "kdsr-3m.5a",		0x080000, 0xc115f6c6, BRF_GRA | CPS1_TILES },
+	{ "kdsr-6m.4c",		0x080000, 0xe8009e30, BRF_GRA | CPS1_TILES },
+	{ "kdsr-8m.6c",		0x080000, 0xc76b4156, BRF_GRA | CPS1_TILES },
+	{ "kdsr-2m.3c",		0x080000, 0x34b917e8, BRF_GRA | CPS1_TILES },
+	{ "kdsr-4m.5c",		0x080000, 0x8faba58f, BRF_GRA | CPS1_TILES },
+
+	{ "kd_9.12a",		0x010000, 0xf5514510, BRF_PRG | CPS1_Z80_PROGRAM },
+
+	{ "kd_18.11c",		0x020000, 0x69ecb2c8, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "kd_19.12c",		0x020000, 0x02d851c1, BRF_SND | CPS1_OKIM6295_SAMPLES },
+
+	A_BOARD_PLDS
+
+	{ "kd29b.1a",		0x000117, 0x6b892f82, BRF_OPT }, // b-board PLDs
+	{ "iob1.11d",		0x000117, 0x3abc0700, BRF_OPT },
+	{ "ioc1.ic7",		0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
+	{ "c632.ic1",		0x000117, 0x0fbd9270, BRF_OPT },
+};
+
+STD_ROM_PICK(Kodsr)
+STD_ROM_FN(Kodsr)
+
+struct BurnDriver BurnDrvCpsKodsr = {
+	"kodsr", "kod", NULL, NULL, "2002",
+	"The King of Dragons (Remix Special, Hack)\0", NULL, "hack", "CPS1",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 3, HARDWARE_CAPCOM_CPS1, GBF_SCRFIGHT, 0,
+	NULL, KodsrRomInfo, KodsrRomName, NULL, NULL, NULL, NULL, KodInputInfo, Kodr1DIPInfo,
+	KodInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
 
 
 // -----------------------------------------------------------------------------
@@ -27320,7 +27281,7 @@ struct BurnDriver BurnDrvCpskodyh = {
 	{ "d8l1.8l",	0x000117, 0x539fc7da, BRF_OPT },						\
 	{ "d9k1.9k",	0x000117, 0x6c35c805, BRF_OPT },						\
 	{ "d10f1.10f",	0x000117, 0x6619c494, BRF_OPT },
-#define WOFJ_COMPONENT														\
+#define WOFJ_COMPONENTS														\
 	WOFJ_TILE1																\
 	{ "tk2_05.7a",	0x080000, 0xe4a44d53, BRF_GRA | CPS1_TILES },			\
 	{ "tk2_06.8a",	0x080000, 0x58066ba8, BRF_GRA | CPS1_TILES },			\
@@ -27337,7 +27298,7 @@ static struct BurnRomInfo wofsmRomDesc[] = {
 	{ "tk2sm_23c.8f",	0x080000, 0x6dba1d2f, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2sm_22c.7f",	0x080000, 0x7630fd8a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofsm)
@@ -27368,7 +27329,7 @@ static struct BurnRomInfo wofmwsRomDesc[] = {
 	{ "tk2mws_23c.8f",	0x080000, 0x7963098e, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2mws_22c.7f",	0x080000, 0xf718e2a9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofmws)
@@ -27392,7 +27353,7 @@ static struct BurnRomInfo wofscRomDesc[] = {
 	{ "tk2sc_23c.8f",	0x080000, 0xa6f22395, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2sc_22c.7f",	0x080000, 0x11bcbbb9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofsc)
@@ -27416,7 +27377,7 @@ static struct BurnRomInfo wofzlRomDesc[] = {
 	{ "tk2zl_23c.8f",	0x080000, 0xbf93127b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2zl_22c.7f",	0x080000, 0x2bd05ebd, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofzl)
@@ -27440,7 +27401,7 @@ static struct BurnRomInfo wofwpRomDesc[] = {
 	{ "tk2wp_23c.8f",	0x080000, 0xc8b7f43c, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2wp_22c.7f",	0x080000, 0xf7c7acdb, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofwp)
@@ -27464,7 +27425,7 @@ static struct BurnRomInfo wofjwpRomDesc[] = {
 	{ "tk2wjq_23c.8f",	0x080000, 0xcdc5bed0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2wjq_22c.7f",	0x080000, 0xac2809f4, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofjwp)
@@ -27518,12 +27479,12 @@ struct BurnDriver BurnDrvCpswofdr = {
 
 
 // Tenchi wo Kurau II: Sekiheki no Tatakai (Master 2020, Hack)
-// GOTVG 20240210
+// GOTVG 20240307
 
 static struct BurnRomInfo wofdr20RomDesc[] = {
-	{ "tk2dr20_23c.8f",	0x080000, 0xd5187954, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "tk2dr20_23c.8f",	0x080000, 0x4f61f0f0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2dr_22c.7f",	0x080000, 0x16405A96, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "tk2dr20_21c.6f",	0x080000, 0x6ae37d1b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "tk2dr20_21c.6f",	0x080000, 0xb7c882f0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2dr20_20c.5f",	0x080000, 0x3a9c0284, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
 	WOFJ_TILE1
@@ -27561,7 +27522,7 @@ static struct BurnRomInfo wof1v3RomDesc[] = {
 	{ "tk21v3_23c.8f",	0x080000, 0x9fbab932, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk21v3_22c.7f",	0x080000, 0xf123a486, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wof1v3)
@@ -27585,7 +27546,7 @@ static struct BurnRomInfo wof1v3pRomDesc[] = {
 	{ "tk21v3p_23c.8f",	0x080000, 0xe6ba44f9, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk21v3p_22c.7f",	0x080000, 0x57d41693, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wof1v3p)
@@ -27609,7 +27570,7 @@ static struct BurnRomInfo wofmz1v3RomDesc[] = {
 	{ "tk2mz1v3_23c.8f",	0x080000, 0x03821862, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2mz1v3_22c.7f",	0x080000, 0x64a3f4db, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofmz1v3)
@@ -27633,7 +27594,7 @@ static struct BurnRomInfo wofkm3RomDesc[] = {
 	{ "tk2km3_23c.8f",	0x080000, 0x6f001de5, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2km3_22c.7f",	0x080000, 0x0c3bb3bc, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFJ_COMPONENT
+	WOFJ_COMPONENTS
 };
 
 STD_ROM_PICK(wofkm3)
@@ -27649,7 +27610,7 @@ struct BurnDriver BurnDrvCpswofkm3 = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef WOFJ_COMPONENT
+#undef WOFJ_COMPONENTS
 
 
 // Tenchi wo Kurau II: Sekiheki no Tatakai (T-Chi)
@@ -27694,7 +27655,7 @@ struct BurnDriver BurnDrvCpswofc = {
 };
 
 
-#define WOFCH_COMPONENT															\
+#define WOFCH_COMPONENTS														\
 	WOFA_TILE1																	\
 	{ "tk2=ch=_05.7a",	0x080000, 0xe4a44d53, BRF_GRA | CPS1_TILES },			\
 	{ "tk2=ch=_06.8a",	0x080000, 0x58066ba8, BRF_GRA | CPS1_TILES },			\
@@ -27715,7 +27676,7 @@ static struct BurnRomInfo wofchpRomDesc[] = {
 	{ "tk2=ch=eh_23.8f",	0x080000, 0x2bce786a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2=ch=eh_22.7f",	0x080000, 0xe0c80d47, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFCH_COMPONENT
+	WOFCH_COMPONENTS
 };
 
 STD_ROM_PICK(wofchp)
@@ -27746,7 +27707,7 @@ static struct BurnRomInfo WofchdxRomDesc[] = {
 	{ "tk2=ch=dx_23.8f",	0x080000, 0xa1696ca4, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "tk2=ch=dx_22.7f",	0x080000, 0x00d388c0, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	WOFCH_COMPONENT
+	WOFCH_COMPONENTS
 };
 
 STD_ROM_PICK(Wofchdx)
@@ -27762,7 +27723,7 @@ struct BurnDriver BurnDrvCpsWofchdx = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef WOFCH_COMPONENT
+#undef WOFCH_COMPONENTS
 
 #undef WOFJ_TILE1
 #undef WOFA_TILE1
@@ -27800,7 +27761,7 @@ struct BurnDriver BurnDrvCpsWofchdx = {
 	{ "d8l1.8l",	0x000117, 0x539fc7da, BRF_OPT },						\
 	{ "d9k2.9k",	0x000117, 0xcd85a156, BRF_OPT },						\
 	{ "d10f1.10f",	0x000117, 0x6619c494, BRF_OPT },
-#define PUNISHERJ_COMPONENT													\
+#define PUNISHERJ_COMPONENTS												\
 	PUNISHERJ_TILE1															\
 	{ "ps_05.7a",      0x080000, 0xc54ea839, BRF_GRA | CPS1_TILES },		\
 	{ "ps_06.8a",      0x080000, 0x04c5acbd, BRF_GRA | CPS1_TILES },		\
@@ -28002,7 +27963,7 @@ static struct BurnRomInfo punishdwRomDesc[] = {
 	{ "psdw_22.7f",		0x080000, 0x69433b02, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "psdw_21.6f",		0x080000, 0xe4e15e4a, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 
-	PUNISHERJ_COMPONENT
+	PUNISHERJ_COMPONENTS
 };
 
 STD_ROM_PICK(punishdw)
@@ -28019,7 +27980,7 @@ struct BurnDriver BurnDrvCpspunishdw = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-#undef PUNISHERJ_COMPONENT
+#undef PUNISHERJ_COMPONENTS
 #undef PUNISHERJ_TILE1
 #undef PUNISHER_TILE2
 #undef PUNISHER_MISC

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -14705,8 +14705,138 @@ struct BurnDriver BurnDrvCpsGigaman2 = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-// Dungeons & Dragons - shadow over mystara (T-Chi)
+// Dungeons & Dragons: Tower of Doom (Plus, Hack)
+// GOTVG 20160825
+
+static struct BurnRomInfo DdtoddpRomDesc[] = {
+	{ "dadedp.03c",		0x080000, 0x748d17d3, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "daded.04c",		0x080000, 0x306f14fc, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "daded.05c",		0x080000, 0x8c6b8328, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dadedp.06a",		0x080000, 0x1005b2d7, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dadd.07a",		0x080000, 0x0f0df6cc, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+
+	{ "dad.13m",		0x200000, 0xda3cb7d6, CPS2_GFX | BRF_GRA },
+	{ "dad.15m",		0x200000, 0x92b63172, CPS2_GFX | BRF_GRA },
+	{ "dad.17m",		0x200000, 0xb98757f5, CPS2_GFX | BRF_GRA },
+	{ "dad.19m",		0x200000, 0x8121ce46, CPS2_GFX | BRF_GRA },
+	{ "dad.14m",		0x100000, 0x837e6f3f, CPS2_GFX | BRF_GRA },
+	{ "dad.16m",		0x100000, 0xf0916bdb, CPS2_GFX | BRF_GRA },
+	{ "dad.18m",		0x100000, 0xcef393ef, CPS2_GFX | BRF_GRA },
+	{ "dad.20m",		0x100000, 0x8953fe9e, CPS2_GFX | BRF_GRA },
+
+	{ "dad.01",			0x020000, 0x3f5e2424, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+
+	{ "dad.11m",		0x200000, 0x0c499b67, CPS2_QSND | BRF_SND },
+	{ "dad.12m",		0x200000, 0x2f0b5a4e, CPS2_QSND | BRF_SND },
+
+	{ "phoenix.key",	0x000014, 0x2cf772b0, CPS2_ENCRYPTION_KEY },
+};
+
+STD_ROM_PICK(Ddtoddp)
+STD_ROM_FN(Ddtoddp)
+
+struct BurnDriver BurnDrvCpsDdtoddp = {
+	"ddtoddp", "ddtod", NULL, NULL, "2016",
+	"Dungeons & Dragons: Tower of Doom (Plus, Hack)\0", NULL, "hack", "CPS2",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 4, HARDWARE_CAPCOM_CPS2, GBF_SCRFIGHT, 0,
+	NULL, DdtoddpRomInfo, DdtoddpRomName, NULL, NULL, NULL, NULL, DdtodInputInfo, NULL,
+	PhoenixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
+// Dungeons & Dragons: Shadow over Mystara (Plus, Hack)
+// GOTVG 20160825
+
+static struct BurnRomInfo DdsomudpRomDesc[] = {
+	{ "dd2udp.03g",		0x080000, 0x41429cbc, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2udp.04g",		0x080000, 0x11f7496d, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2udp.05g",		0x080000, 0xc00d5fb6, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2udp.06g",		0x080000, 0x5eaf9618, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.07",			0x080000, 0x909a0b8b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.08",			0x080000, 0xe53c4d01, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.09",			0x080000, 0x5f86279f, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2udp.10",		0x080000, 0x33d55230, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+
+	{ "dd2.13m",		0x400000, 0xa46b4e6e, CPS2_GFX | BRF_GRA },
+	{ "dd2.15m",		0x400000, 0xd5fc50fc, CPS2_GFX | BRF_GRA },
+	{ "dd2.17m",		0x400000, 0x837c0867, CPS2_GFX | BRF_GRA },
+	{ "dd2.19m",		0x400000, 0xbb0ec21c, CPS2_GFX | BRF_GRA },
+	{ "dd2.14m",		0x200000, 0x6d824ce2, CPS2_GFX | BRF_GRA },
+	{ "dd2.16m",		0x200000, 0x79682ae5, CPS2_GFX | BRF_GRA },
+	{ "dd2.18m",		0x200000, 0xacddd149, CPS2_GFX | BRF_GRA },
+	{ "dd2.20m",		0x200000, 0x117fb0c0, CPS2_GFX | BRF_GRA },
+
+	{ "dd2.01",			0x020000, 0x99d657e5, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "dd2.02",			0x020000, 0x117a3824, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+
+	{ "dd2.11m",		0x200000, 0x98d0c325, CPS2_QSND | BRF_SND },
+	{ "dd2.12m",		0x200000, 0x5ea2e7fa, CPS2_QSND | BRF_SND },
+
+	{ "phoenix.key",	0x000014, 0x2cf772b0, CPS2_ENCRYPTION_KEY },
+};
+
+STD_ROM_PICK(Ddsomudp)
+STD_ROM_FN(Ddsomudp)
+
+struct BurnDriver BurnDrvCpsDdsomudp = {
+	"ddsomudp", "ddsom", NULL, NULL, "2016",
+	"Dungeons & Dragons: Shadow over Mystara (Plus, Hack)\0", NULL, "hack", "CPS2",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 4, HARDWARE_CAPCOM_CPS2, GBF_SCRFIGHT, 0,
+	NULL, DdsomudpRomInfo, DdsomudpRomName, NULL, NULL, NULL, NULL, DdsomInputInfo, NULL,
+	PhoenixInit, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
+// Dungeons & Dragons: Shadow over Mystara (1v4, Hack)
+// Modified by Pipi899
+// 20090629
+
+static struct BurnRomInfo Ddsom1v4RomDesc[] = {
+	{ "dd2a1v4.03g",	0x080000, 0xe28c61f2, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2a1v4.04g",	0x080000, 0x145efa6f, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.05g",		0x080000, 0x5eb1991c, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.06g",		0x080000, 0xc26b5e55, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.07",			0x080000, 0x909a0b8b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.08",			0x080000, 0xe53c4d01, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.09",			0x080000, 0x5f86279f, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "dd2.10",			0x080000, 0xad954c26, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+
+	{ "dd2.13m",		0x400000, 0xa46b4e6e, CPS2_GFX | BRF_GRA },
+	{ "dd2.15m",		0x400000, 0xd5fc50fc, CPS2_GFX | BRF_GRA },
+	{ "dd2.17m",		0x400000, 0x837c0867, CPS2_GFX | BRF_GRA },
+	{ "dd2.19m",		0x400000, 0xbb0ec21c, CPS2_GFX | BRF_GRA },
+	{ "dd2.14m",		0x200000, 0x6d824ce2, CPS2_GFX | BRF_GRA },
+	{ "dd2.16m",		0x200000, 0x79682ae5, CPS2_GFX | BRF_GRA },
+	{ "dd2.18m",		0x200000, 0xacddd149, CPS2_GFX | BRF_GRA },
+	{ "dd2.20m",		0x200000, 0x117fb0c0, CPS2_GFX | BRF_GRA },
+
+	{ "dd2.01",			0x020000, 0x99d657e5, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "dd2.02",			0x020000, 0x117a3824, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+
+	{ "dd2.11m",		0x200000, 0x98d0c325, CPS2_QSND | BRF_SND },
+	{ "dd2.12m",		0x200000, 0x5ea2e7fa, CPS2_QSND | BRF_SND },
+
+	{ "ddsoma.key",		0x000014, 0x8c3cc560, CPS2_ENCRYPTION_KEY },
+};
+
+STD_ROM_PICK(Ddsom1v4)
+STD_ROM_FN(Ddsom1v4)
+
+struct BurnDriver BurnDrvCpsDdsom1v4 = {
+	"ddsom1v4", "ddsom", NULL, NULL, "2009",
+	"Dungeons & Dragons: Shadow over Mystara (1v4, Hack)\0", NULL, "hack", "CPS2",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 4, HARDWARE_CAPCOM_CPS2, GBF_SCRFIGHT, 0,
+	NULL, Ddsom1v4RomInfo, Ddsom1v4RomName, NULL, NULL, NULL, NULL, DdsomInputInfo, NULL,
+	Cps2Init, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
+// Dungeons & Dragons: Shadow over Mystara (T-Chi)
 // Modified by フェニックス
+
 static struct BurnRomInfo DdsomjcRomDesc[] = {
 	{ "dd2jc.03g",		0x080000, 0xed73e646, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
 	{ "dd2jc.04g",		0x080000, 0xc5a6e4b5, CPS2_PRG_68K | BRF_ESS | BRF_PRG },

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -1304,12 +1304,12 @@ static struct BurnDIPInfo kof98cbDIPList[] = {
 
 static struct BurnDIPInfo kof98eckDIPList[] = {
 	// Fake DIPs
-	{0x06, 0xFF, 0xFF, 0x00, NULL                           },  // wo1wan
+	{0x06, 0xFF, 0xFF, 0x02, NULL                           },  // Extend
 
 	{0,    0xFE, 0,    3,    "Version change (Must reload)" },
 	{0x06, 0x01, 0x03, 0x00, "wo1wan"                       },
 	{0x06, 0x01, 0x03, 0x01, "GOTVG"                        },
-	{0x06, 0x01, 0x03, 0x02, "YZKOF"                        },
+	{0x06, 0x01, 0x03, 0x02, "Extend"                       },
 };
 
 static struct BurnDIPInfo kof98mixDIPList[] = {
@@ -16625,27 +16625,27 @@ struct BurnDriver BurnDrvwhpjq = {
 // Art of Fighting / Art of Fighting Series
 // -----------------------------------------------------------------------------
 
+#define AOF2_COMPONENTS													\
+	{ "056-s1.s1",    0x020000, 0x8b02638e, 2 | BRF_GRA },				\
+	{ "056-c1.c1",    0x200000, 0x17b9cbd2, 3 | BRF_GRA },				\
+	{ "056-c2.c2",    0x200000, 0x5fd76b67, 3 | BRF_GRA },				\
+	{ "056-c3.c3",    0x200000, 0xd2c88768, 3 | BRF_GRA },				\
+	{ "056-c4.c4",    0x200000, 0xdb39b883, 3 | BRF_GRA },				\
+	{ "056-c5.c5",    0x200000, 0xc3074137, 3 | BRF_GRA },				\
+	{ "056-c6.c6",    0x200000, 0x31de68d3, 3 | BRF_GRA },				\
+	{ "056-c7.c7",    0x200000, 0x3f36df57, 3 | BRF_GRA },				\
+	{ "056-c8.c8",    0x200000, 0xe546d7a8, 3 | BRF_GRA },				\
+	{ "056-m1.m1",    0x020000, 0xf27e9d52, 4 | BRF_ESS | BRF_PRG },	\
+	{ "056-v1.v1",    0x200000, 0x4628fde0, 5 | BRF_SND },				\
+	{ "056-v2.v2",    0x200000, 0xb710e2f2, 5 | BRF_SND },				\
+	{ "056-v3.v3",    0x100000, 0xd168c301, 5 | BRF_SND },
+
 // Art of Fighting 2 / Ryuuko no Ken 2 (Enable hidden characters V2)
 
 static struct BurnRomInfo aof2bhRomDesc[] = {
 	{ "056-p1bh.p1",  0x100000, 0x3af1e484, 1 | BRF_ESS | BRF_PRG }, //  0 68K code 		/ TC538200
 
-	{ "056-s1.s1",    0x020000, 0x8b02638e, 2 | BRF_GRA },           //  1 Text layer tiles / TC531000
-
-	{ "056-c1.c1",    0x200000, 0x17b9cbd2, 3 | BRF_GRA },           //  2 Sprite data		/ TC5316200
-	{ "056-c2.c2",    0x200000, 0x5fd76b67, 3 | BRF_GRA },           //  3 					/ TC5316200
-	{ "056-c3.c3",    0x200000, 0xd2c88768, 3 | BRF_GRA },           //  4 					/ TC5316200
-	{ "056-c4.c4",    0x200000, 0xdb39b883, 3 | BRF_GRA },           //  5 					/ TC5316200
-	{ "056-c5.c5",    0x200000, 0xc3074137, 3 | BRF_GRA },           //  6 					/ TC5316200
-	{ "056-c6.c6",    0x200000, 0x31de68d3, 3 | BRF_GRA },           //  7 					/ TC5316200
-	{ "056-c7.c7",    0x200000, 0x3f36df57, 3 | BRF_GRA },           //  8 					/ TC5316200
-	{ "056-c8.c8",    0x200000, 0xe546d7a8, 3 | BRF_GRA },           //  9 					/ TC5316200
-
-	{ "056-m1.m1",    0x020000, 0xf27e9d52, 4 | BRF_ESS | BRF_PRG }, // 10 Z80 code			/ TC531001
-
-	{ "056-v1.v1",    0x200000, 0x4628fde0, 5 | BRF_SND },           // 11 Sound data		/ TC5316200
-	{ "056-v2.v2",    0x200000, 0xb710e2f2, 5 | BRF_SND },           // 12 					/ TC5316200
-	{ "056-v3.v3",    0x100000, 0xd168c301, 5 | BRF_SND },           // 13 					/ TC538200
+	AOF2_COMPONENTS
 };
 
 STDROMPICKEXT(aof2bh, aof2bh, neogeo)
@@ -16660,6 +16660,30 @@ struct BurnDriver BurnDrvAof2bh = {
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
+
+
+// Art of Fighting 2 / Ryuuko no Ken 2 (Boss With Simple Attack Edition, Hack)
+
+static struct BurnRomInfo aof2bhsRomDesc[] = {
+	{ "056-p1bhs.p1",  0x100000, 0x89eb2c94, 1 | BRF_ESS | BRF_PRG }, //  0 68K code 		/ TC538200
+
+	AOF2_COMPONENTS
+};
+
+STDROMPICKEXT(aof2bhs, aof2bhs, neogeo)
+STD_ROM_FN(aof2bhs)
+
+struct BurnDriver BurnDrvaof2bhs = {
+	"aof2bhs", "aof2", "neogeo", NULL, "2018",
+	"Art of Fighting 2 / Ryuuko no Ken 2 (Boss With Simple Attack Edition, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	L"Art of Fighting 2\0\u9F8D\u864E\u306E\u62F3\uFF12 (Boss With Simple Attack Edition, Hack)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
+	NULL, aof2bhsRomInfo, aof2bhsRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+#undef AOF2_COMPONENTS
 
 
 // Art of Fighting 3 - The Path of the Warrior / Art of Fighting - Ryuuko no Ken Gaiden (Enable Hidden Characters V2)
@@ -16704,7 +16728,7 @@ struct BurnDriver BurnDrvAof3bh = {
 // Breakers Revenge Series
 // -----------------------------------------------------------------------------
 
-#define BREAKREV_COMPONENT											\
+#define BREAKREV_COMPONENTS											\
 	{ "245-s1.s1",	0x020000, 0xe7660a5d, 2 | BRF_GRA },			\
 	{ "245-c1.c1",	0x400000, 0x68d4ae76, 3 | BRF_GRA },			\
 	{ "245-c2.c2",	0x400000, 0xfdee05cd, 3 | BRF_GRA },			\
@@ -16722,7 +16746,7 @@ struct BurnDriver BurnDrvAof3bh = {
 static struct BurnRomInfo breakrevbhRomDesc[] = {
 	{ "245-p1bh.p1",	0x200000, 0x52c978b5, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
-	BREAKREV_COMPONENT
+	BREAKREV_COMPONENTS
 };
 
 STDROMPICKEXT(breakrevbh, breakrevbh, neogeo)
@@ -16744,7 +16768,7 @@ struct BurnDriver BurnDrvbreakrevbh = {
 static struct BurnRomInfo brkrevextRomDesc[] = {
 	{ "245-p1ext.p1",	0x200000, 0x603b47a4, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
-	BREAKREV_COMPONENT
+	BREAKREV_COMPONENTS
 };
 
 STDROMPICKEXT(brkrevext, brkrevext, neogeo)
@@ -16768,7 +16792,7 @@ static struct BurnRomInfo brkrevjqRomDesc[] = {
 	{ "245-p1jq.p1",	0x100000, 0x85779451, 1 | BRF_ESS | BRF_PRG },
 	{ "245-p2d.sp2",	0x100000, 0x615bdad6, 1 | BRF_ESS | BRF_PRG },
 
-	BREAKREV_COMPONENT
+	BREAKREV_COMPONENTS
 };
 
 STDROMPICKEXT(brkrevjq, brkrevjq, neogeo)
@@ -16784,7 +16808,7 @@ struct BurnDriver BurnDrvbrkrevjq = {
 	0x1000,	320, 224, 4, 3
 };
 
-#undef BREAKREV_COMPONENT
+#undef BREAKREV_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
@@ -16810,7 +16834,7 @@ struct BurnDriver BurnDrvbrkrevjq = {
 #define DOUBLEDR_SND										\
 	{ "082-v1.v1",	0x200000, 0xcc1128e4, 5 | BRF_SND },	\
 	{ "082-v2.v2",	0x200000, 0xc3ff5554, 5 | BRF_SND },
-#define DOUBLEDR_COMPONENT									\
+#define DOUBLEDR_COMPONENTS									\
 	DOUBLEDR_TEXT											\
 	DOUBLEDR_SPR1	DOUBLEDR_SPR2							\
 	DOUBLEDR_SPR3	DOUBLEDR_SPR4							\
@@ -16823,7 +16847,7 @@ struct BurnDriver BurnDrvbrkrevjq = {
 static struct BurnRomInfo doubledrbhRomDesc[] = {
 	{ "082-p1bh.p1",  0x200000, 0x92826c06, 1 | BRF_ESS | BRF_PRG },
 
-	DOUBLEDR_COMPONENT
+	DOUBLEDR_COMPONENTS
 };
 
 STDROMPICKEXT(doubledrbh, doubledrbh, neogeo)
@@ -16847,7 +16871,7 @@ static struct BurnRomInfo doubledpRomDesc[] = {
 	{ "082-p1p.p1",		0x100000, 0xf77b2081, 1 | BRF_ESS | BRF_PRG },
 	{ "082-p2d.sp2",	0x100000, 0x0e2616ab, 1 | BRF_ESS | BRF_PRG },
 
-	DOUBLEDR_COMPONENT
+	DOUBLEDR_COMPONENTS
 };
 
 STDROMPICKEXT(doubledp, doubledp, neogeo)
@@ -16871,7 +16895,7 @@ static struct BurnRomInfo doubledtRomDesc[] = {
 	{ "082-p1t.p1",		0x100000, 0x0f4b369e, 1 | BRF_ESS | BRF_PRG },
 	{ "082-p2d.sp2",	0x100000, 0x0e2616ab, 1 | BRF_ESS | BRF_PRG },
 
-	DOUBLEDR_COMPONENT
+	DOUBLEDR_COMPONENTS
 };
 
 STDROMPICKEXT(doubledt, doubledt, neogeo)
@@ -16960,14 +16984,14 @@ struct BurnDriver BurnDrvdoubldrsp = {
 };
 
 #undef DOUBLEDR_SOUND
-#undef DOUBLEDR_COMPONENT
+#undef DOUBLEDR_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
 // Far East of Eden - Kabuki Klash / Tengai Makyou - Shin Den Series
 // -----------------------------------------------------------------------------
 
-#define KABUKIKL_COMPONENT												\
+#define KABUKIKL_COMPONENTS												\
 	{ "092-s1.s1",	0x020000, 0xa3d68ee2, 2 | BRF_GRA },				\
 	{ "092-c1.c1",	0x400000, 0x2a9fab01, 3 | BRF_GRA },				\
 	{ "092-c2.c2",	0x400000, 0x6d2bac02, 3 | BRF_GRA },				\
@@ -16984,7 +17008,7 @@ struct BurnDriver BurnDrvdoubldrsp = {
 static struct BurnRomInfo kabukiklbRomDesc[] = {
 	{ "092-p1b.p1",   0x200000, 0x9e814a43, 1 | BRF_ESS | BRF_PRG },
 
-	KABUKIKL_COMPONENT
+	KABUKIKL_COMPONENTS
 };
 
 STDROMPICKEXT(kabukiklb, kabukiklb, neogeo)
@@ -17008,7 +17032,7 @@ static struct BurnRomInfo kabukijqRomDesc[] = {
 	{ "092-p1jq.p1",	0x100000, 0xbcc0fbec, 1 | BRF_ESS | BRF_PRG },
 	{ "092-p2d.sp2",	0x100000, 0x9e5fbe42, 1 | BRF_ESS | BRF_PRG },
 
-	KABUKIKL_COMPONENT
+	KABUKIKL_COMPONENTS
 };
 
 STDROMPICKEXT(kabukijq, kabukijq, neogeo)
@@ -17024,7 +17048,7 @@ struct BurnDriver BurnDrvkabukijq = {
 	0x1000,	320, 224, 4, 3
 };
 
-#undef KABUKIKL_COMPONENT
+#undef KABUKIKL_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
@@ -17320,7 +17344,7 @@ struct BurnDriver BurnDrvgaroujq = {
 	{ "234-v2.v2",	0x400000, 0xa0e7f6e2, 5 | BRF_SND },	\
 	{ "234-v3.v3",	0x400000, 0xa506e1e2, 5 | BRF_SND },	\
 	{ "234-v4.v4",	0x400000, 0x0e34157f, 5 | BRF_SND },
-#define LASTBLAD_COMPONENT									\
+#define LASTBLAD_COMPONENTS									\
 	LASTBLAD_TEXT											\
 	LASTBLAD_SPR1	LASTBLAD_SPR2	LASTBLAD_SPR3			\
 	LASTBLAD_Z80											\
@@ -17334,7 +17358,7 @@ static struct BurnRomInfo lastbldpRomDesc[] = {
 	{ "234-p1p.p1",		0x100000, 0x491496f0, 1 | BRF_ESS | BRF_PRG },
 	{ "234-p2p.sp2",	0x400000, 0xf80aeee8, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLAD_COMPONENT
+	LASTBLAD_COMPONENTS
 };
 
 STDROMPICKEXT(lastbldp, lastbldp, neogeo)
@@ -17357,7 +17381,7 @@ static struct BurnRomInfo lastbldiRomDesc[] = {
 	{ "234-p1i.p1",		0x100000, 0x4c21400b, 1 | BRF_ESS | BRF_PRG },
 	{ "234-p2.sp2",		0x400000, 0x0fdc289e, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLAD_COMPONENT
+	LASTBLAD_COMPONENTS
 };
 
 STDROMPICKEXT(lastbldi, lastbldi, neogeo)
@@ -17453,7 +17477,7 @@ struct BurnDriver BurnDrvlastblsp = {
 	0x1000, 320, 224, 4, 3
 };
 
-#undef LASTBLAD_COMPONENT
+#undef LASTBLAD_COMPONENTS
 #undef LASTBLAD_TEXT
 #undef LASTBLAD_SPR1
 #undef LASTBLAD_SPR2
@@ -17462,7 +17486,7 @@ struct BurnDriver BurnDrvlastblsp = {
 #undef LASTBLAD_SND
 
 
-#define LASTBLD2_COMPONENT											\
+#define LASTBLD2_COMPONENTS											\
 	{ "243-s1.s1",	0x020000, 0xc9cd2298, 2 | BRF_GRA },			\
 	{ "243-c1.c1",	0x800000, 0x5839444d, 3 | BRF_GRA },			\
 	{ "243-c2.c2",	0x800000, 0xdd087428, 3 | BRF_GRA },			\
@@ -17484,7 +17508,7 @@ static struct BurnRomInfo lastbd2eRomDesc[] = {
 	{ "243-pg1e.p1",  0x100000, 0x6c8867d2, 1 | BRF_ESS | BRF_PRG },
 	{ "243-pg2e.p2",  0x400000, 0xeef07572, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLD2_COMPONENT
+	LASTBLD2_COMPONENTS
 };
 
 STDROMPICKEXT(lastbd2e, lastbd2e, neogeo)
@@ -17510,7 +17534,7 @@ static struct BurnRomInfo lastbd2tRomDesc[] = {
 	{ "243-pg1t.p1",	0x100000, 0x8f9a24bf, 1 | BRF_ESS | BRF_PRG },
 	{ "243-pg2t.sp2",	0x400000, 0x37aaffa0, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLD2_COMPONENT
+	LASTBLD2_COMPONENTS
 };
 
 STDROMPICKEXT(lastbd2t, lastbd2t, neogeo)
@@ -17535,7 +17559,7 @@ static struct BurnRomInfo lastbd2pRomDesc[] = {
 	{ "243-pg1e.p1",	0x100000, 0xa401fe4e, 1 | BRF_ESS | BRF_PRG },
 	{ "243-pg2e.sp2",	0x400000, 0x52b3f468, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLD2_COMPONENT
+	LASTBLD2_COMPONENTS
 };
 
 STDROMPICKEXT(lastbd2p, lastbd2p, neogeo)
@@ -17559,7 +17583,7 @@ static struct BurnRomInfo lastbd2iRomDesc[] = {
 	{ "243-pg1i.p1",	0x100000, 0x9a17a53c, 1 | BRF_ESS | BRF_PRG },
 	{ "243-pg2e.sp2",	0x400000, 0x52b3f468, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLD2_COMPONENT
+	LASTBLD2_COMPONENTS
 };
 
 STDROMPICKEXT(lastbd2i, lastbd2i, neogeo)
@@ -17582,7 +17606,7 @@ static struct BurnRomInfo lastbd2bRomDesc[] = {
 	{ "243-pg1b.p1",  0x100000, 0x6e512568, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 	{ "243-pg2.sp2",  0x400000, 0xadd4a30b, 1 | BRF_ESS | BRF_PRG },
 
-	LASTBLD2_COMPONENT
+	LASTBLD2_COMPONENTS
 };
 
 STDROMPICKEXT(lastbd2b, lastbd2b, neogeo)
@@ -17598,14 +17622,14 @@ struct BurnDriver BurnDrvlastbd2b = {
 	0x1000, 320, 224, 4, 3
 };
 
-#undef LASTBLD2_COMPONENT
+#undef LASTBLD2_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
 // Magical Drop III Series
 // -----------------------------------------------------------------------------
 
-#define MAGDROP3_COMPONENT												\
+#define MAGDROP3_COMPONENTS												\
 	{ "233-s1.s1",	0x020000, 0x7399e68a, 2 | BRF_GRA },				\
 	{ "233-c1.c1",	0x400000, 0x65e3f4c4, 3 | BRF_GRA },				\
 	{ "233-c2.c2",	0x400000, 0x35dea6c9, 3 | BRF_GRA },				\
@@ -17621,7 +17645,7 @@ struct BurnDriver BurnDrvlastbd2b = {
 static struct BurnRomInfo magdrop3bhRomDesc[] = {
 	{ "233-p1bh.p1",	0x100000, 0x80bfe2a9, 1 | BRF_ESS | BRF_PRG },
 
-	MAGDROP3_COMPONENT
+	MAGDROP3_COMPONENTS
 };
 
 STDROMPICKEXT(magdrop3bh, magdrop3bh, neogeo)
@@ -17651,7 +17675,7 @@ struct BurnDriver BurnDrvmagdrop3bh = {
 static struct BurnRomInfo magdrop3teRomDesc[] = {
 	{ "233-p1te.p1",	0x100000, 0xe2068d05, 1 | BRF_ESS | BRF_PRG },
 
-	MAGDROP3_COMPONENT
+	MAGDROP3_COMPONENTS
 };
 
 STDROMPICKEXT(magdrop3te, magdrop3te, neogeo)
@@ -17667,14 +17691,14 @@ struct BurnDriver BurnDrvmagdrop3te = {
 	0x1000,	304, 224, 4, 3
 };
 
-#undef MAGDROP3_COMPONENT
+#undef MAGDROP3_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
 // Metal Slug Series
 // -----------------------------------------------------------------------------
 
-#define MSLUG_COMPONENT													\
+#define MSLUG_COMPONENTS												\
 	{ "201-s1.s1",		0x020000, 0x2f55958d, 2 | BRF_GRA },			\
 	{ "201-c1.c1",		0x400000, 0x72813676, 3 | BRF_GRA },			\
 	{ "201-c2.c2",		0x400000, 0x96f62574, 3 | BRF_GRA },			\
@@ -17690,7 +17714,7 @@ struct BurnDriver BurnDrvmagdrop3te = {
 static struct BurnRomInfo mslugunityRomDesc[] = {
 	{ "201-p1uni.p1",	0x200000, 0xa3186dfd, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslugunity, mslugunity, neogeo)
@@ -17715,7 +17739,7 @@ static struct BurnRomInfo mslugdgRomDesc[] = {
 	{ "201-p1dg.p1",	0x100000, 0x7f66b97f, 1 | BRF_ESS | BRF_PRG },
 	{ "201-p2dg.sp2",	0x100000, 0xc3cb544c, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslugdg, mslugdg, neogeo)
@@ -17740,7 +17764,7 @@ static struct BurnRomInfo mslug1v2RomDesc[] = {
 	{ "201-p11v2.p1",	0x100000, 0x18301e60, 1 | BRF_ESS | BRF_PRG },
 	{ "201-p2d.sp2",	0x100000, 0xc4d10926, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslug1v2, mslug1v2, neogeo)
@@ -17765,7 +17789,7 @@ static struct BurnRomInfo mslugqyRomDesc[] = {
 	{ "201-p1qy.p1",	0x100000, 0xa054f7ba, 1 | BRF_ESS | BRF_PRG },
 	{ "201-p2dg.sp2",	0x100000, 0xc3cb544c, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslugqy, mslugqy, neogeo)
@@ -17790,7 +17814,7 @@ static struct BurnRomInfo mslugfc1RomDesc[] = {
 	{ "201-p1fc1.p1",	0x100000, 0xdb8f7d81, 1 | BRF_ESS | BRF_PRG },
 	{ "201-p2fc1.sp2",	0x100000, 0xf3d34029, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslugfc1, mslugfc1, neogeo)
@@ -17815,7 +17839,7 @@ static struct BurnRomInfo mslugfc2RomDesc[] = {
 	{ "201-p1fc2.p1",	0x100000, 0xb079dd40, 1 | BRF_ESS | BRF_PRG },
 	{ "201-p2fc2.sp2",	0x100000, 0x8211a964, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslugfc2, mslugfc2, neogeo)
@@ -17839,7 +17863,7 @@ static struct BurnRomInfo mslugfsRomDesc[] = {
 	{ "201-p1fs.p1",	0x100000, 0xaa1c9f84, 1 | BRF_ESS | BRF_PRG },
 	{ "201-p2fs.sp2",	0x100000, 0x057962bd, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG_COMPONENT
+	MSLUG_COMPONENTS
 };
 
 STDROMPICKEXT(mslugfs, mslugfs, neogeo)
@@ -17855,7 +17879,7 @@ struct BurnDriver BurnDrvmslugfs = {
 	0x1000,	304, 224, 4, 3
 };
 
-#undef MSLUG_COMPONENT
+#undef MSLUG_COMPONENTS
 
 
 #define MSLUG2_TEXT												\
@@ -17871,7 +17895,7 @@ struct BurnDriver BurnDrvmslugfs = {
 #define MSLUG2_SND												\
 	{ "241-v1.v1",		0x400000, 0x99ec20e8, 5 | BRF_SND },	\
 	{ "241-v2.v2",		0x400000, 0xecb16799, 5 | BRF_SND },
-#define MSLUG2_COMPONENT										\
+#define MSLUG2_COMPONENTS										\
 	MSLUG2_TEXT													\
 	MSLUG2_SPR1	MSLUG2_SPR2										\
 	MSLUG2_Z80													\
@@ -17885,7 +17909,7 @@ static struct BurnRomInfo mslug2unityRomDesc[] = {
 	{ "241-p1uni.p1",	0x100000, 0x1562cf23, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2.sp2",		0x200000, 0x38883f44, 1 | BRF_ESS | BRF_PRG }, 
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(mslug2unity, mslug2unity, neogeo)
@@ -17910,7 +17934,7 @@ static struct BurnRomInfo mslug2fmRomDesc[] = {
 	{ "241-p1fm.p1",	0x100000, 0x487173f6, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2fm.sp2",	0x200000, 0x37a118fc, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(mslug2fm, mslug2fm, neogeo)
@@ -17968,7 +17992,7 @@ static struct BurnRomInfo mslug2dgRomDesc[] = {
 	{ "241-p1dg.p1",	0x100000, 0x00c455e7, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2dg.sp2",	0x200000, 0x1bf6b12a, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(mslug2dg, mslug2dg, neogeo)
@@ -17994,7 +18018,7 @@ static struct BurnRomInfo mslug2ctRomDesc[] = {
 	{ "241-p1ct.p1",	0x100000, 0x78ad6864, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2ct.sp2",	0x200000, 0xfe36f353, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(mslug2ct, mslug2ct, neogeo)
@@ -18019,7 +18043,7 @@ static struct BurnRomInfo mslug2rRomDesc[] = {
 	{ "241-p1r.p1",		0x100000, 0xf882d50d, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2.sp2",		0x200000, 0x38883f44, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(mslug2r, mslug2r, neogeo)
@@ -18044,7 +18068,7 @@ static struct BurnRomInfo mslug2pRomDesc[] = {
 	{ "241-p1p.p1",		0x100000, 0xfe803784, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2.sp2",		0x200000, 0x38883f44, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(mslug2p, mslug2p, neogeo)
@@ -18069,7 +18093,7 @@ static struct BurnRomInfo ms21v2RomDesc[] = {
 	{ "241-p11v2.p1",	0x100000, 0xc3efed6c, 1 | BRF_ESS | BRF_PRG },
 	{ "241-p2.sp2",		0x200000, 0x38883f44, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG2_COMPONENT
+	MSLUG2_COMPONENTS
 };
 
 STDROMPICKEXT(ms21v2, ms21v2, neogeo)
@@ -18119,7 +18143,7 @@ struct BurnDriver BurnDrvmslug2eg = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef MSLUG2_COMPONENT
+#undef MSLUG2_COMPONENTS
 #undef MSLUG2_TEXT
 #undef MSLUG2_SPR1
 #undef MSLUG2_SPR2
@@ -18144,7 +18168,7 @@ struct BurnDriver BurnDrvmslug2eg = {
 	{ "250-v1.v1",	0x400000, 0xc79ede73, 5 | BRF_SND },	\
 	{ "250-v2.v2",	0x400000, 0xea9aabe1, 5 | BRF_SND },	\
 	{ "250-v3.v3",	0x200000, 0x2ca65102, 5 | BRF_SND },
-#define MSLUGX_COMPONENT									\
+#define MSLUGX_COMPONENTS									\
 	MSLUGX_TEXT												\
 	MSLUGX_SPR1	MSLUGX_SPR2	MSLUGX_SPR3						\
 	MSLUGX_Z80												\
@@ -18157,7 +18181,7 @@ static struct BurnRomInfo mslugxunityRomDesc[] = {
 	{ "250-p1uni.p1",	0x100000, 0x36102d34, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2.ep1",		0x400000, 0x1fda2e12, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxunity, mslugxunity, neogeo)
@@ -18182,7 +18206,7 @@ static struct BurnRomInfo mslugxc1RomDesc[] = {
 	{ "250-p1c1.p1",	0x100000, 0xe74f36c2, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2c1.ep1",	0x400000, 0xe954b8aa, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxc1, mslugxc1, neogeo)
@@ -18207,7 +18231,7 @@ static struct BurnRomInfo mslugxc2RomDesc[] = {
 	{ "250-p1.p1",		0x100000, 0x81f1f60b, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2c2.ep1",	0x400000, 0x5d1c52cd, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxc2, mslugxc2, neogeo)
@@ -18232,7 +18256,7 @@ static struct BurnRomInfo mslugxifRomDesc[] = {
 	{ "250-p1if.p1",	0x100000, 0xa507546f, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2if.ep1",	0x400000, 0x9cf91e0f, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxif, mslugxif, neogeo)
@@ -18257,7 +18281,7 @@ static struct BurnRomInfo mslugx2rRomDesc[] = {
 	{ "250-p12r.p1",	0x100000, 0x721f11aa, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p22r.ep1",	0x400000, 0x4f875278, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugx2r, mslugx2r, neogeo)
@@ -18282,7 +18306,7 @@ static struct BurnRomInfo mslugxebRomDesc[] = {
 	{ "250-p1eb.p1",	0x100000, 0x764d1bb1, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2eb.ep1",	0x400000, 0xa51363d1, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxeb, mslugxeb, neogeo)
@@ -18307,7 +18331,7 @@ static struct BurnRomInfo msxsrfRomDesc[] = {
 	{ "250-p1srf.p1",	0x100000, 0xaed327fe, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2srf.ep1",	0x400000, 0x4389f47d, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(msxsrf, msxsrf, neogeo)
@@ -18332,7 +18356,7 @@ static struct BurnRomInfo msx2rebRomDesc[] = {
 	{ "250-p12reb.p1",	0x100000, 0xdba3f1a1, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p22reb.ep1",	0x400000, 0x3866eb68, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(msx2reb, msx2reb, neogeo)
@@ -18357,7 +18381,7 @@ static struct BurnRomInfo msx2r1v2RomDesc[] = {
 	{ "250-p12r1v2.p1",		0x100000, 0xd13fd368, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p22r1v2.ep1",	0x400000, 0x730e94a2, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(msx2r1v2, msx2r1v2, neogeo)
@@ -18382,7 +18406,7 @@ static struct BurnRomInfo mslugxxrRomDesc[] = {
 	{ "250-p1xr.p1",	0x100000, 0xbea1f7e5, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2xr.ep1",	0x400000, 0x0efc5d67, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxxr, mslugxxr, neogeo)
@@ -18407,7 +18431,7 @@ static struct BurnRomInfo mslugxsvRomDesc[] = {
 	{ "250-p1sv.p1",	0x100000, 0x1b213460, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2sv.ep1",	0x400000, 0x718d6d66, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxsv, mslugxsv, neogeo)
@@ -18460,19 +18484,19 @@ struct BurnDriver BurnDrvmslugxsc = {
 
 // Metal Slug X - Super Vehicle-001 (Legend, Hack)
 // Modified by 合金弹头爱克斯
-// GOTVG 20240201
+// GOTVG 20240308
 
 static struct BurnRomInfo mslugxcqRomDesc[] = {
-	{ "250-p1cq.p1",	0x100000, 0x52120338, 1 | BRF_ESS | BRF_PRG },
-	{ "250-p2cq.ep1",	0x400000, 0x006cc14b, 1 | BRF_ESS | BRF_PRG },
+	{ "250-p1cq.p1",	0x100000, 0x950c4021, 1 | BRF_ESS | BRF_PRG },
+	{ "250-p2cq.ep1",	0x400000, 0xd4b8511b, 1 | BRF_ESS | BRF_PRG },
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },
 
 	MSLUGX_SPR1
 	{ "250-c3cq.c3",	0x800000, 0x917f95c5, 3 | BRF_GRA },
 	{ "250-c4cq.c4",	0x800000, 0x93290f81, 3 | BRF_GRA },
-	{ "250-c5cq.c5",	0x800000, 0x5fd01617, 3 | BRF_GRA },
-	{ "250-c6cq.c6",	0x800000, 0x30ff06cc, 3 | BRF_GRA },
+	{ "250-c5cq.c5",	0x800000, 0xa3b56ab4, 3 | BRF_GRA },
+	{ "250-c6cq.c6",	0x800000, 0xac06c7bb, 3 | BRF_GRA },
 
 	MSLUGX_Z80
 
@@ -18495,18 +18519,18 @@ struct BurnDriver BurnDrvmslugxcq = {
 
 // Metal Slug X - Super Vehicle-001 (Firepower Showdown, Hack)
 // Modified by 合金弹头爱克斯
-// GOTVG 20240131
+// GOTVG 20240308
 
 static struct BurnRomInfo mslugxfsRomDesc[] = {
-	{ "250-p1fs.p1",	0x100000, 0x7c1a7ea0, 1 | BRF_ESS | BRF_PRG },
-	{ "250-p2fs.ep1",	0x400000, 0xc1ea9688, 1 | BRF_ESS | BRF_PRG },
+	{ "250-p1fs.p1",	0x100000, 0x86f79976, 1 | BRF_ESS | BRF_PRG },
+	{ "250-p2fs.ep1",	0x400000, 0x77475ced, 1 | BRF_ESS | BRF_PRG },
 
 	{ "250-s1sc.s1",	0x020000, 0x03bce893, 2 | BRF_GRA },
 
 	MSLUGX_SPR1
 	MSLUGX_SPR2
-	{ "250-c5fs.c5",	0x800000, 0x43d90430, 3 | BRF_GRA },
-	{ "250-c6fs.c6",	0x800000, 0x97e6a580, 3 | BRF_GRA },
+	{ "250-c5fs.c5",	0x800000, 0xedef3d1d, 3 | BRF_GRA },
+	{ "250-c6fs.c6",	0x800000, 0x7e06b834, 3 | BRF_GRA },
 
 	MSLUGX_Z80
 
@@ -18535,7 +18559,7 @@ static struct BurnRomInfo mslugxdgRomDesc[] = {
 	{ "250-p1dg.p1",	0x100000, 0xf86ea146, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2dg.ep1",	0x400000, 0xef0c263f, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(mslugxdg, mslugxdg, neogeo)
@@ -18560,7 +18584,7 @@ static struct BurnRomInfo msx1v2RomDesc[] = {
 	{ "250-p11v2.p1",	0x100000, 0x0cf1f95b, 1 | BRF_ESS | BRF_PRG },
 	{ "250-p2.ep1",		0x400000, 0x1fda2e12, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUGX_COMPONENT
+	MSLUGX_COMPONENTS
 };
 
 STDROMPICKEXT(msx1v2, msx1v2, neogeo)
@@ -18644,7 +18668,7 @@ struct BurnDriver BurnDrvmslugxlb = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef MSLUGX_COMPONENT
+#undef MSLUGX_COMPONENTS
 #undef MSLUGX_TEXT
 #undef MSLUGX_SPR1
 #undef MSLUGX_SPR2
@@ -18660,7 +18684,7 @@ struct BurnDriver BurnDrvmslugxlb = {
 	{ "256-v2.v2",	0x400000, 0x7e2a10bd, 5 | BRF_SND },	\
 	{ "256-v3.v3",	0x400000, 0x0eaec17c, 5 | BRF_SND },	\
 	{ "256-v4.v4",	0x400000, 0x9b4b22d4, 5 | BRF_SND },
-#define MSLUG3_ENCRYPTION_COMPONENT							\
+#define MSLUG3_ENCRYPTION_COMPONENTS						\
 	{ "256-c1.c1",	0x800000, 0x5a79c34e, 3 | BRF_GRA },	\
 	{ "256-c2.c2",	0x800000, 0x944c362c, 3 | BRF_GRA },	\
 	{ "256-c3.c3",	0x800000, 0x6e69d36f, 3 | BRF_GRA },	\
@@ -18683,7 +18707,7 @@ static struct BurnRomInfo mslug3unityRomDesc[] = {
 
 	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
 	/* Encrypted */
-	MSLUG3_ENCRYPTION_COMPONENT
+	MSLUG3_ENCRYPTION_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3unity, mslug3unity, neogeo)
@@ -18712,7 +18736,7 @@ static struct BurnRomInfo mslug3iRomDesc[] = {
 
 	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
 	/* Encrypted */
-	MSLUG3_ENCRYPTION_COMPONENT
+	MSLUG3_ENCRYPTION_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3i, mslug3i, neogeo)
@@ -18741,7 +18765,7 @@ static struct BurnRomInfo ms31v2RomDesc[] = {
 
 	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
 	/* Encrypted */
-	MSLUG3_ENCRYPTION_COMPONENT
+	MSLUG3_ENCRYPTION_COMPONENTS
 };
 
 STDROMPICKEXT(ms31v2, ms31v2, neogeo)
@@ -18770,7 +18794,7 @@ static struct BurnRomInfo mslug3ebRomDesc[] = {
 
 	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
 	/* Encrypted */
-	MSLUG3_ENCRYPTION_COMPONENT
+	MSLUG3_ENCRYPTION_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3eb, mslug3eb, neogeo)
@@ -18786,7 +18810,7 @@ struct BurnDriver BurnDrvmslug3eb = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef MSLUG3_ENCRYPTION_COMPONENT
+#undef MSLUG3_ENCRYPTION_COMPONENTS
 
 
 #define MSLUG3_DECRYPTED_TEXT								\
@@ -18803,7 +18827,7 @@ struct BurnDriver BurnDrvmslug3eb = {
 #define MSLUG3_DECRYPTED_SPR4								\
 	{ "256-c7d.c7",	0x800000, 0x9395b809, 3 | BRF_GRA },	\
 	{ "256-c8d.c8",	0x800000, 0xa369f9d4, 3 | BRF_GRA },
-#define MSLUG3_DECRYPTED_COMPONENT							\
+#define MSLUG3_DECRYPTED_COMPONENTS							\
 	MSLUG3_DECRYPTED_TEXT									\
 	MSLUG3_DECRYPTED_SPR1									\
 	MSLUG3_DECRYPTED_SPR2									\
@@ -18818,7 +18842,7 @@ static struct BurnRomInfo mslug3fdRomDesc[] = {
 	{ "256-ph1.p1",		0x100000, 0x9c42ca85, 1 | BRF_ESS | BRF_PRG },
 	{ "256-ph2.sp2",	0x400000, 0x1f3d8ce8, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3fd, mslug3fd, neogeo)
@@ -18842,7 +18866,7 @@ static struct BurnRomInfo mslug3vRomDesc[] = {
 	{ "256-pg1v.p1",	0x100000, 0x47f9aeea, 1 | BRF_ESS | BRF_PRG },
 	{ "256-ph2.sp2",	0x400000, 0x1f3d8ce8, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3v, mslug3v, neogeo)
@@ -18937,7 +18961,7 @@ static struct BurnRomInfo mslug3cRomDesc[] = {
 	{ "256-p1c.p1",		0x100000, 0x05c99714, 1 | BRF_ESS | BRF_PRG },
 	{ "256-p2c.sp2",	0x400000, 0xb948a472, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3c, mslug3c, neogeo)
@@ -18961,7 +18985,7 @@ static struct BurnRomInfo mslug3seRomDesc[] = {
 	{ "256-p1se.p1",	0x100000, 0x46330db5, 1 | BRF_ESS | BRF_PRG },
 	{ "256-ph2.sp2",	0x400000, 0x1f3d8ce8, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3se, mslug3se, neogeo)
@@ -19024,7 +19048,7 @@ static struct BurnRomInfo mslug3lwRomDesc[] = {
 	{ "256-plw.p1",		0x100000, 0x94527837, 1 | BRF_ESS | BRF_PRG },
 	{ "256-p2ps.sp2",	0x400000, 0x08ee1fe3, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3lw, mslug3lw, neogeo)
@@ -19049,7 +19073,7 @@ static struct BurnRomInfo mslug3sdRomDesc[] = {
 	{ "256-p1sd.p1",	0x100000, 0xe1e21cc4, 1 | BRF_ESS | BRF_PRG },
 	{ "256-p2sd.sp2",	0x400000, 0x7343335b, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3sd, mslug3sd, neogeo)
@@ -19105,19 +19129,19 @@ struct BurnDriver BurnDrvmslug3gw = {
 
 // Metal Slug 3 (Legend, Hack)
 // Modified by 合金弹头爱克斯
-// GOTVG 20240131
+// GOTVG 20240308
 
 static struct BurnRomInfo mslug3cqRomDesc[] = {
-	{ "256-p1cq.p1",	0x100000, 0x44ac1146, 1 | BRF_ESS | BRF_PRG },
-	{ "256-p2cq.sp2",	0x400000, 0xe99d3a3a, 1 | BRF_ESS | BRF_PRG },
+	{ "256-p1cq.p1",	0x100000, 0x745d11d3, 1 | BRF_ESS | BRF_PRG },
+	{ "256-p2cq.sp2",	0x400000, 0x4010956b, 1 | BRF_ESS | BRF_PRG },
 
 	MSLUG3_DECRYPTED_TEXT
 
 	MSLUG3_DECRYPTED_SPR1
 	MSLUG3_DECRYPTED_SPR2
 	MSLUG3_DECRYPTED_SPR3
-	{ "256-c7cq.c7",	0x800000, 0x4ee4c193, 3 | BRF_GRA },
-	{ "256-c8cq.c8",	0x800000, 0x87645c1f, 3 | BRF_GRA },
+	{ "256-c7cq.c7",	0x800000, 0x2d54bf3c, 3 | BRF_GRA },
+	{ "256-c8cq.c8",	0x800000, 0xe7f00844, 3 | BRF_GRA },
 
 	MSLUG3_Z80
 
@@ -19140,19 +19164,19 @@ struct BurnDriver BurnDrvmslug3cq = {
 
 // Metal Slug 3 (Firepower Showdown, Hack)
 // Modified by 合金弹头爱克斯
-// GOTVG 20240131
+// GOTVG 20240308
 
 static struct BurnRomInfo mslug3fsRomDesc[] = {
-	{ "256-p1fs.p1",	0x100000, 0x2520f83d, 1 | BRF_ESS | BRF_PRG },
-	{ "256-p2fs.sp2",	0x400000, 0x0e41d294, 1 | BRF_ESS | BRF_PRG },
+	{ "256-p1fs.p1",	0x100000, 0x532c9268, 1 | BRF_ESS | BRF_PRG },
+	{ "256-p2fs.sp2",	0x400000, 0x2471b0b1, 1 | BRF_ESS | BRF_PRG },
 
 	MSLUG3_DECRYPTED_TEXT
 
 	MSLUG3_DECRYPTED_SPR1
 	MSLUG3_DECRYPTED_SPR2
 	MSLUG3_DECRYPTED_SPR3
-	{ "256-c7fs.c7",	0x800000, 0xd713c05c, 3 | BRF_GRA },
-	{ "256-c8fs.c8",	0x800000, 0x13c7afda, 3 | BRF_GRA },
+	{ "256-c7fs.c7",	0x800000, 0xdbac6c74, 3 | BRF_GRA },
+	{ "256-c8fs.c8",	0x800000, 0x65b13e42, 3 | BRF_GRA },
 
 	MSLUG3_Z80
 
@@ -19216,7 +19240,7 @@ static struct BurnRomInfo mslug3zhRomDesc[] = {
 	{ "256-p1zh.p1",	0x100000, 0x257fa6b9, 1 | BRF_ESS | BRF_PRG },
 	{ "256-p2zh.sp2",	0x400000, 0xbadc753c, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG3_DECRYPTED_COMPONENT
+	MSLUG3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug3zh, mslug3zh, neogeo)
@@ -19267,7 +19291,7 @@ struct BurnDriver BurnDrvmslug3g = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef MSLUG3_DECRYPTED_COMPONENT
+#undef MSLUG3_DECRYPTED_COMPONENTS
 #undef MSLUG3_DECRYPTED_TEXT
 #undef MSLUG3_DECRYPTED_SPR1
 #undef MSLUG3_DECRYPTED_SPR2
@@ -19277,7 +19301,7 @@ struct BurnDriver BurnDrvmslug3g = {
 #undef MSLUG3_SND
 
 
-#define MSLUG4_ENCRYPTION_COMPONENT										\
+#define MSLUG4_ENCRYPTION_COMPONENTS									\
 	{ "263-c1.c1",    0x800000, 0x84865f8a, 3 | BRF_GRA },				\
 	{ "263-c2.c2",    0x800000, 0x81df97f2, 3 | BRF_GRA },				\
 	{ "263-c3.c3",    0x800000, 0x1a343323, 3 | BRF_GRA },				\
@@ -19297,7 +19321,7 @@ static struct BurnRomInfo mslug4unityRomDesc[] = {
 
 	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
 	/* Encrypted */
-	MSLUG4_ENCRYPTION_COMPONENT
+	MSLUG4_ENCRYPTION_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4unity, mslug4unity, neogeo)
@@ -19313,7 +19337,7 @@ struct BurnDriver BurnDrvmslug4unity = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef MSLUG4_ENCRYPTION_COMPONENT
+#undef MSLUG4_ENCRYPTION_COMPONENTS
 
 
 #define MSLUG4_DECRYPTED_TEXT								\
@@ -19334,7 +19358,7 @@ struct BurnDriver BurnDrvmslug4unity = {
 	{ "263-v2d.v2",	0x400000, 0x94217b1e, 5 | BRF_SND },	\
 	{ "263-v3d.v3",	0x400000, 0x7616fcec, 5 | BRF_SND },	\
 	{ "263-v4d.v4",	0x400000, 0xc5967f91, 5 | BRF_SND },
-#define MSLUG4_DECRYPTED_COMPONENT							\
+#define MSLUG4_DECRYPTED_COMPONENTS							\
 	MSLUG4_DECRYPTED_TEXT									\
 	MSLUG4_DECRYPTED_SPR1	MSLUG4_DECRYPTED_SPR2			\
 	MSLUG4_DECRYPTED_SPR3									\
@@ -19347,7 +19371,7 @@ static struct BurnRomInfo mslug4fdRomDesc[] = {
 	{ "263-p1.p1",		0x100000, 0x27e4def3, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2.sp2",		0x400000, 0xfdb7aed8, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4fd, mslug4fd, neogeo)
@@ -19448,7 +19472,7 @@ static struct BurnRomInfo mslug4arRomDesc[] = {
 	{ "263-p1ar.p1",	0x100000, 0x21b68d31, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2lq.sp2",	0x500000, 0x7deba8eb, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4ar, mslug4ar, neogeo)
@@ -19473,7 +19497,7 @@ static struct BurnRomInfo mslug4aRomDesc[] = {
 	{ "263-p1a.p1",		0x100000, 0x0f2b0fc2, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2a.sp2",	0x400000, 0x87dc01b9, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4a, mslug4a, neogeo)
@@ -19498,7 +19522,7 @@ static struct BurnRomInfo mslug4qRomDesc[] = {
 	{ "263-p1q.p1",		0x100000, 0x1b5121b6, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2q.sp2",	0x400000, 0xf132898f, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4q, mslug4q, neogeo)
@@ -19591,7 +19615,7 @@ static struct BurnRomInfo mslug4dgRomDesc[] = {
 	{ "263-p1dg.p1",	0x100000, 0x36dfa877, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2dg.sp2",	0x400000, 0xcf6feb75, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4dg, mslug4dg, neogeo)
@@ -19616,7 +19640,7 @@ static struct BurnRomInfo ms41v2RomDesc[] = {
 	{ "263-p11v2.p1",	0x100000, 0xdddca463, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2.sp2",		0x400000, 0xfdb7aed8, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(ms41v2, ms41v2, neogeo)
@@ -19641,7 +19665,7 @@ static struct BurnRomInfo mslug4cRomDesc[] = {
 	{ "263-p1c.p1",		0x100000, 0x81fd4ae9, 1 | BRF_ESS | BRF_PRG },
 	{ "263-p2.sp2",		0x400000, 0xfdb7aed8, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG4_DECRYPTED_COMPONENT
+	MSLUG4_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug4c, mslug4c, neogeo)
@@ -19657,7 +19681,7 @@ struct BurnDriver BurnDrvmslug4c = {
 	0x1000,	304, 224, 4, 3
 };
 
-#undef MSLUG4_DECRYPTED_COMPONENT
+#undef MSLUG4_DECRYPTED_COMPONENTS
 #undef MSLUG4_DECRYPTED_TEXT
 #undef MSLUG4_DECRYPTED_SPR1
 #undef MSLUG4_DECRYPTED_SPR2
@@ -19666,7 +19690,7 @@ struct BurnDriver BurnDrvmslug4c = {
 #undef MSLUG4_DECRYPTED_SND
 
 
-#define MSLUG5_ENCRYPTION_COMPONENT										\
+#define MSLUG5_ENCRYPTION_COMPONENTS									\
 	{ "268-c1c.c1",    0x800000, 0xab7c389a, 3 | BRF_GRA },				\
 	{ "268-c2c.c2",    0x800000, 0x3560881b, 3 | BRF_GRA },				\
 	{ "268-c3c.c3",    0x800000, 0x3af955ea, 3 | BRF_GRA },				\
@@ -19689,7 +19713,7 @@ static struct BurnRomInfo mslug5unityRomDesc[] = {
 
 	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
 	/* Encrypted */
-	MSLUG5_ENCRYPTION_COMPONENT
+	MSLUG5_ENCRYPTION_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5unity, mslug5unity, neogeo)
@@ -19705,7 +19729,7 @@ struct BurnDriver BurnDrvmslug5unity = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef MSLUG5_ENCRYPTION_COMPONENT
+#undef MSLUG5_ENCRYPTION_COMPONENTS
 
 
 #define MSLUG5_DECRYPTED_TEXT									\
@@ -19727,7 +19751,7 @@ struct BurnDriver BurnDrvmslug5unity = {
 #define MSLUG5_DECRYPTED_SND									\
 	{ "268-v1d.v1",		0x800000, 0x7ff6ca47, 5 | BRF_SND },	\
 	{ "268-v2d.v2",		0x800000, 0x696cce3b, 5 | BRF_SND },
-#define MSLUG5_DECRYPTED_COMPONENT								\
+#define MSLUG5_DECRYPTED_COMPONENTS								\
 	MSLUG5_DECRYPTED_TEXT										\
 	MSLUG5_DECRYPTED_SPR1	MSLUG5_DECRYPTED_SPR2				\
 	MSLUG5_DECRYPTED_SPR3	MSLUG5_DECRYPTED_SPR4				\
@@ -19740,7 +19764,7 @@ static struct BurnRomInfo mslug5fdRomDesc[] = {
 	{ "268-p1d.p1",		0x100000, 0x24ae2e4d, 1 | BRF_ESS | BRF_PRG },
 	{ "268-p2d.sp2",	0x400000, 0x768ee64a, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5fd, mslug5fd, neogeo)
@@ -19762,7 +19786,7 @@ struct BurnDriver BurnDrvmslug5fd = {
 static struct BurnRomInfo mslug5ndRomDesc[] = {
 	{ "268-p1n.p1",		0x600000, 0x975eb06a, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5nd, mslug5nd, neogeo)
@@ -19820,7 +19844,7 @@ struct BurnDriver BurnDrvms5plush = {
 static struct BurnRomInfo mslug5exRomDesc[] = {
 	{ "268-p1ex.p1",	0x600000, 0x7ff5364b, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5ex, mslug5ex, neogeo)
@@ -19844,7 +19868,7 @@ struct BurnDriver BurnDrvmslug5ex = {
 static struct BurnRomInfo mslug5esRomDesc[] = {
 	{ "268-p1es.p1",	0x600000, 0xfc309b3d, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5es, mslug5es, neogeo)
@@ -19868,7 +19892,7 @@ struct BurnDriver BurnDrvmslug5es = {
 static struct BurnRomInfo ms5esrRomDesc[] = {
 	{ "268-p1esr.p1",	0x600000, 0x8f8327a1, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(ms5esr, ms5esr, neogeo)
@@ -19966,7 +19990,7 @@ struct BurnDriver BurnDrvmslug5f = {
 static struct BurnRomInfo mslug5sgRomDesc[] = {
 	{ "268-p1sg.p1",	0x600000, 0x1b6a6163, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5sg, mslug5sg, neogeo)
@@ -20024,7 +20048,7 @@ struct BurnDriver BurnDrvmslug5sc = {
 static struct BurnRomInfo mslug5bsRomDesc[] = {
 	{ "268-p1bs.p1",	0x600000, 0x3ec95964, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5bs, mslug5bs, neogeo)
@@ -20048,7 +20072,7 @@ struct BurnDriver BurnDrvmslug5bs = {
 static struct BurnRomInfo mslug5zhRomDesc[] = {
 	{ "268-p1zh.p1",	0x600000, 0xdc057a7a, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5zh, mslug5zh, neogeo)
@@ -20072,7 +20096,7 @@ struct BurnDriver BurnDrvmslug5zh = {
 static struct BurnRomInfo ms51v2RomDesc[] = {
 	{ "268-p11v2.p1",	0x600000, 0x953d6e11, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(ms51v2, ms51v2, neogeo)
@@ -20096,7 +20120,7 @@ struct BurnDriver BurnDrvms51v2 = {
 static struct BurnRomInfo mslug5dgRomDesc[] = {
 	{ "268-p1dg.p1",	0x600000, 0x3be747ab, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5dg, mslug5dg, neogeo)
@@ -20119,7 +20143,7 @@ struct BurnDriver BurnDrvmslug5dg = {
 static struct BurnRomInfo ms5sgfRomDesc[] = {
 	{ "268-p1sgf.p1",	0x600000, 0xb1fbb850, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(ms5sgf, ms5sgf, neogeo)
@@ -20143,7 +20167,7 @@ struct BurnDriver BurnDrvms5sgf = {
 static struct BurnRomInfo mslug5cRomDesc[] = {
 	{ "268-p1c.p1",		0x600000, 0xe876d1e7, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5c, mslug5c, neogeo)
@@ -20167,7 +20191,7 @@ struct BurnDriver BurnDrvmslug5c = {
 static struct BurnRomInfo mslug5mgRomDesc[] = {
 	{ "268-p1mg.p1",	0x600000, 0x1fc7de70, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5mg, mslug5mg, neogeo)
@@ -20191,7 +20215,7 @@ struct BurnDriver BurnDrvmslug5mg = {
 static struct BurnRomInfo mslug5xRomDesc[] = {
 	{ "268-p1x.p1",		0x600000, 0xafffcd5b, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5x, mslug5x, neogeo)
@@ -20215,7 +20239,7 @@ struct BurnDriver BurnDrvmslug5x = {
 static struct BurnRomInfo mslug5dbRomDesc[] = {
 	{ "268-p1db.p1",	0x600000, 0x1527c4dd, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5db, mslug5db, neogeo)
@@ -20239,7 +20263,7 @@ struct BurnDriver BurnDrvmslug5db = {
 static struct BurnRomInfo mslug5ddRomDesc[] = {
 	{ "268-p1dd.p1",	0x600000, 0x40917fba, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5dd, mslug5dd, neogeo)
@@ -20263,7 +20287,7 @@ struct BurnDriver BurnDrvmslug5dd = {
 static struct BurnRomInfo mslug5kiRomDesc[] = {
 	{ "268-p1ki.p1",	0x600000, 0x846bc220, 1 | BRF_ESS | BRF_PRG },
 
-	MSLUG5_DECRYPTED_COMPONENT
+	MSLUG5_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(mslug5ki, mslug5ki, neogeo)
@@ -20279,7 +20303,7 @@ struct BurnDriver BurnDrvmslug5ki = {
 	0x1000,	304, 224, 4, 3
 };
 
-#undef MSLUG5_DECRYPTED_COMPONENT
+#undef MSLUG5_DECRYPTED_COMPONENTS
 #undef MSLUG5_DECRYPTED_TEXT
 #undef MSLUG5_DECRYPTED_SPR1
 #undef MSLUG5_DECRYPTED_SPR2
@@ -20350,7 +20374,7 @@ struct BurnDriver BurnDrvsamshobs = {
 	{ "063-v2.v2",	0x200000, 0x0142bde8, 5 | BRF_SND },	\
 	{ "063-v3.v3",	0x200000, 0xd07fa5ca, 5 | BRF_SND },	\
 	{ "063-v4.v4",	0x100000, 0x24aab4bb, 5 | BRF_SND },
-#define SAMSHO2_COMPONENT									\
+#define SAMSHO2_COMPONENTS									\
 	SAMSHO2_TEXT											\
 	SAMSHO2_SPR1	SAMSHO2_SPR2							\
 	SAMSHO2_SPR3	SAMSHO2_SPR4							\
@@ -20482,7 +20506,7 @@ static struct BurnRomInfo samsho2peRomDesc[] = {
 	{ "063-p2pe.sp2",	0x100000, 0x6c833c91, 1 | BRF_ESS | BRF_PRG }, //  1
 	{ "063-p3pe.p3",	0x020000, 0xedffbd8a, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
-	SAMSHO2_COMPONENT
+	SAMSHO2_COMPONENTS
 };
 
 STDROMPICKEXT(samsho2pe, samsho2pe, neogeo)
@@ -20498,7 +20522,7 @@ struct BurnDriver BurnDrvSamsho2pe = {
 	0x1000, 320, 224, 4, 3
 };
 
-#undef SAMSHO2_COMPONENT
+#undef SAMSHO2_COMPONENTS
 #undef SAMSHO2_TEXT
 #undef SAMSHO2_SPR1
 #undef SAMSHO2_SPR2
@@ -20663,7 +20687,7 @@ struct BurnDriver BurnDrvsamsh4sp = {
 #define SAMSHO5_SND											\
 	{ "270-v1d.v1",	0x800000, 0x809c7617, 5 | BRF_SND },	\
 	{ "270-v2d.v2",	0x800000, 0x42671607, 5 | BRF_SND },
-#define SAMSH5_COMPONENT									\
+#define SAMSH5_COMPONENTS									\
 	SAMSHO5_TEXT											\
 	SAMSHO5_SPR1	SAMSHO5_SPR2							\
 	SAMSHO5_SPR3	SAMSHO5_SPR4							\
@@ -20676,7 +20700,7 @@ static struct BurnRomInfo samsh5fdRomDesc[] = {
 	{ "270-p1d.p1",		0x400000, 0x4f8f86bd, 1 | BRF_ESS | BRF_PRG },
 	{ "270-p2d.sp2",	0x400000, 0x91979dee, 1 | BRF_ESS | BRF_PRG },
 
-	SAMSH5_COMPONENT
+	SAMSH5_COMPONENTS
 };
 
 STDROMPICKEXT(samsh5fd, samsh5fd, neogeo)
@@ -20876,7 +20900,7 @@ struct BurnDriver BurnDrvsamsh5fe = {
 // Savage Reign / Fu'un Mokushiroku - Kakutou Sousei Series
 // -----------------------------------------------------------------------------
 
-#define SAVAGERE_COMPONENT											\
+#define SAVAGERE_COMPONENTS											\
 	{ "059-s1.s1",	0x020000, 0xe08978ca, 2 | BRF_GRA },			\
 	{ "059-c1.c1",	0x200000, 0x763ba611, 3 | BRF_GRA },			\
 	{ "059-c2.c2",	0x200000, 0xe05e8ca6, 3 | BRF_GRA },			\
@@ -20896,7 +20920,7 @@ struct BurnDriver BurnDrvsamsh5fe = {
 static struct BurnRomInfo savagerebRomDesc[] = {
 	{ "059-p1b.p1",		0x200000, 0x3a7fbff0, 1 | BRF_ESS | BRF_PRG },
 
-	SAVAGERE_COMPONENT
+	SAVAGERE_COMPONENTS
 };
 
 STDROMPICKEXT(savagereb, savagereb, neogeo)
@@ -20920,7 +20944,7 @@ static struct BurnRomInfo savagerpRomDesc[] = {
 	{ "059-p1p.p1",		0x100000, 0xd8598aa0, 1 | BRF_ESS | BRF_PRG },
 	{ "059-p2d.sp2",	0x100000, 0x58a9af72, 1 | BRF_ESS | BRF_PRG },
 
-	SAVAGERE_COMPONENT
+	SAVAGERE_COMPONENTS
 };
 
 STDROMPICKEXT(savagerp, savagerp, neogeo)
@@ -20936,14 +20960,14 @@ struct BurnDriver BurnDrvsavagerp = {
 	0x1000, 304, 224, 4, 3
 };
 
-#undef SAVAGERE_COMPONENT
+#undef SAVAGERE_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
 // Sengoku 3 / Sengoku Densho 2001 Series
 // -----------------------------------------------------------------------------
 
-#define SENGOKU3_DECRYPTED_COMPONENT								\
+#define SENGOKU3_DECRYPTED_COMPONENTS								\
 	{ "261-s1d.s1",	0x020000, 0xc1e27cc7, 2 | BRF_GRA },			\
 	{ "261-c1d.c1",	0x800000, 0x9af7cbca, 3 | BRF_GRA },			\
 	{ "261-c2d.c2",	0x800000, 0x2a1f874d, 3 | BRF_GRA },			\
@@ -20961,7 +20985,7 @@ static struct BurnRomInfo sengk3fdRomDesc[] = {
 	{ "261-ph1d.p1",	0x100000, 0x9295cc2c, 1 | BRF_ESS | BRF_PRG },
 	{ "261-p2d.sp2",	0x100000, 0xc74e374c, 1 | BRF_ESS | BRF_PRG },
 
-	SENGOKU3_DECRYPTED_COMPONENT
+	SENGOKU3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(sengk3fd, sengk3fd, neogeo)
@@ -20984,7 +21008,7 @@ static struct BurnRomInfo sengoku3sRomDesc[] = {
 	{ "261-p1s.p1",		0x100000, 0x20b15bb5, 1 | BRF_ESS | BRF_PRG },
 	{ "261-p2d.sp2",	0x100000, 0xc74e374c, 1 | BRF_ESS | BRF_PRG },
 
-	SENGOKU3_DECRYPTED_COMPONENT
+	SENGOKU3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(sengoku3s, sengoku3s, neogeo)
@@ -21009,7 +21033,7 @@ static struct BurnRomInfo sengk3fsRomDesc[] = {
 	{ "261-p1fs.p1",	0x100000, 0x60038a12, 1 | BRF_ESS | BRF_PRG },
 	{ "261-p2d.sp2",	0x100000, 0xc74e374c, 1 | BRF_ESS | BRF_PRG },
 
-	SENGOKU3_DECRYPTED_COMPONENT
+	SENGOKU3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(sengk3fs, sengk3fs, neogeo)
@@ -21032,7 +21056,7 @@ static struct BurnRomInfo sengok3iRomDesc[] = {
 	{ "261-p1i.p1",		0x100000, 0xa2a750cd, 1 | BRF_ESS | BRF_PRG },
 	{ "261-p2d.sp2",	0x100000, 0xc74e374c, 1 | BRF_ESS | BRF_PRG },
 
-	SENGOKU3_DECRYPTED_COMPONENT
+	SENGOKU3_DECRYPTED_COMPONENTS
 };
 
 STDROMPICKEXT(sengok3i, sengok3i, neogeo)
@@ -21057,7 +21081,7 @@ static struct BurnRomInfo sengk3ebRomDesc[] = {
 	{ "261-p1eb.p1",	0x100000, 0xf05a0ab3, 1 | BRF_ESS | BRF_PRG },
 	{ "261-p2d.sp2",	0x100000, 0xc74e374c, 1 | BRF_ESS | BRF_PRG },
 
-	SENGOKU3_DECRYPTED_COMPONENT
+	SENGOKU3_DECRYPTED_COMPONENTS
 
 	/* Green Blue earlier - 2010531 */
 	{ "261-p1eb.dif",	0x100000, 0xa285ce0d, 0 | BRF_ESS | BRF_PRG },
@@ -21099,7 +21123,7 @@ struct BurnDriver BurnDrvsengk3eb = {
 	0x1000, 320, 224, 4, 3
 };
 
-#undef SENGOKU3_DECRYPTED_COMPONENT
+#undef SENGOKU3_DECRYPTED_COMPONENTS
 
 
 // -----------------------------------------------------------------------------
@@ -21231,6 +21255,28 @@ struct BurnDriver BurnDrvkof94bs = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof94bsRomInfo, kof94bsRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+
+// The King of Fighters '94 (New Remix 2018 Rev.2, Hack)
+
+static struct BurnRomInfo kof94nr2RomDesc[] = {
+	{ "055-p1nr2.p1",	0x200000, 0xf4c60559, 1 | BRF_ESS | BRF_PRG },
+
+	KOF94_COMPONENTS
+};
+
+STDROMPICKEXT(kof94nr2, kof94nr2, neogeo)
+STD_ROM_FN(kof94nr2)
+
+struct BurnDriver BurnDrvkof94nr2 = {
+	"kof94nr2", "kof94", "neogeo", NULL, "2018",
+	"The King of Fighters '94 (New Remix 2018 Rev.2, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof94nr2RomInfo, kof94nr2RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -21481,6 +21527,28 @@ struct BurnDriver BurnDrvkof95b = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof95bRomInfo, kof95bRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+
+// The King of Fighters '95 (Super Remix V3, Hack)
+
+static struct BurnRomInfo kof95sr3RomDesc[] = {
+	{ "084-p1sr3.p1",   0x200000, 0x2b85571b, 1 | BRF_ESS | BRF_PRG },
+
+	KOF95_COMPONENTS
+};
+
+STDROMPICKEXT(kof95sr3, kof95sr3, neogeo)
+STD_ROM_FN(kof95sr3)
+
+struct BurnDriver BurnDrvkof95sr3 = {
+	"kof95sr3", "kof95", "neogeo", NULL, "2018",
+	"The King of Fighters '95 (Super Remix V3, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPP, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof95sr3RomInfo, kof95sr3RomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000, 304, 224, 4, 3
 };
@@ -22348,6 +22416,40 @@ struct BurnDriver BurnDrvkof97st = {
 };
 
 
+// The King of Fighters '97 (Randomized, Hack)
+// 20220718
+
+static struct BurnRomInfo kof97rmRomDesc[] = {
+	{ "232-p1rm.p1",	0x100000, 0x4c597fda, 1 | BRF_ESS | BRF_PRG },
+	{ "232-p2rm.sp2",	0x400000, 0x0410b42e, 1 | BRF_ESS | BRF_PRG },
+
+	{ "232-s1rm.s1",	0x020000, 0x53b57ce2, 2 | BRF_GRA },
+
+	{ "232-c1st.c1",	0x800000, 0x57633aca, 3 | BRF_GRA },
+	{ "232-c2st.c2",	0x800000, 0x831ec266, 3 | BRF_GRA },
+	{ "232-c3st.c3",	0x800000, 0xb092e64f, 3 | BRF_GRA },
+	{ "232-c4st.c4",	0x800000, 0xd25e8a04, 3 | BRF_GRA },
+	KOF97_SPR3
+
+	KOF97_Z80
+
+	KOF97_SND
+};
+
+STDROMPICKEXT(kof97rm, kof97rm, neogeo)
+STD_ROM_FN(kof97rm)
+
+struct BurnDriver BurnDrvkof97rm = {
+	"kof97rm", "kof97", "neogeo", NULL, "2022",
+	"The King of Fighters '97 (Randomized, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof97rmRomInfo, kof97rmRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
+
 // The King of Fighters '97 (Anniversary, Hack)
 // Modified by AndyChan, Ice Flame Fantasy
 
@@ -22680,6 +22782,31 @@ struct BurnDriver BurnDrvkof97bt = {
 	NULL, kof97btRomInfo, kof97btRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
+};
+
+
+// The King of Fighters '97 (Champion  Edition, Hack)
+// Modified by GSC2007
+// GOTVG 20240208
+
+static struct BurnRomInfo kof97ceRomDesc[] = {
+	{ "232-p1ce.p1",	0x100000, 0xe1808b39, 1 | BRF_ESS | BRF_PRG },
+	{ "232-p2.sp2",		0x400000, 0x158b23f6, 1 | BRF_ESS | BRF_PRG },
+
+	KOF97_COMPONENTS
+};
+
+STDROMPICKEXT(kof97ce, kof97ce, neogeo)
+STD_ROM_FN(kof97ce)
+
+struct BurnDriver BurnDrvkof97ce = {
+	"kof97ce", "kof97", "neogeo", NULL, "2024",
+	"The King of Fighters '97 (Champion  Edition, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof97ceRomInfo, kof97ceRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
 };
 
 #undef KOF97_COMPONENTS
@@ -23333,16 +23460,27 @@ static struct BurnRomInfo kof98eckRomDesc[] = {
 	{ "242-v3eg.dif",	0x400000, 0x78097adb, 0 | BRF_SND },
 	{ "242-v4eg.dif",	0x400000, 0x57aa42a5, 0 | BRF_SND },
 
-	/* YZKOF Version - 20220906 */
-	{ "242-p1ey.dif",	0x100000, 0xbb9f7c93, 0 | BRF_ESS | BRF_PRG }, // 32 68K code
-	{ "242-p2ey.dif",	0x400000, 0xc3494165, 0 | BRF_ESS | BRF_PRG },
+	/* Extend Version - 20240218 */
+	{ "242-p1ex.dif",	0x100000, 0x8da31321, 0 | BRF_ESS | BRF_PRG }, // 32 68K code
+	{ "242-p2ex.dif",	0x400000, 0xf6bc5fd2, 0 | BRF_ESS | BRF_PRG },
 
-	{ "242-s1ey.dif",	0x020000, 0xa8495dda, 0 | BRF_GRA },           // 34 Text layer tiles
+	{ "242-s1ex.dif",	0x020000, 0xc1adc149, 0 | BRF_GRA },           // 34 Text layer tiles
 
-	{ "242-c1ey.dif",	0x800000, 0x6c7626ae, 0 | BRF_GRA },           // 35 Sprite data
-	{ "242-c2ey.dif",	0x800000, 0x81971225, 0 | BRF_GRA },
-	{ "242-c7ey.dif",	0x800000, 0xdc6b96cd, 0 | BRF_GRA },
-	{ "242-c8ey.dif",	0x800000, 0xa8de7f8f, 0 | BRF_GRA },
+	{ "242-c1ex.dif",	0x800000, 0xe98b5c8a, 0 | BRF_GRA },           // 35 Sprite data
+	{ "242-c2ex.dif",	0x800000, 0xa779434e, 0 | BRF_GRA },
+	{ "242-c3ex.dif",	0x800000, 0xa747eb36, 0 | BRF_GRA },
+	{ "242-c4ex.dif",	0x800000, 0x0d7c33c9, 0 | BRF_GRA },
+	{ "242-c7ex.dif",	0x800000, 0x7deedae9, 0 | BRF_GRA },
+	{ "242-c8ex.dif",	0x800000, 0xf27a725c, 0 | BRF_GRA },
+	{ "242-c9ex.c9",	0x800000, 0x5a8f8d88, 0 | BRF_GRA },
+	{ "242-c10ex.c10",	0x800000, 0xdc7a6504, 0 | BRF_GRA },
+
+	{ "242-m1ex.dif",	0x040000, 0x0e1b3ef0, 0 | BRF_ESS | BRF_PRG }, // 43 Z80 code
+
+	{ "242-v1ex.dif",	0x400000, 0xda8f39fe, 0 | BRF_SND },           // 44 Sound data
+	{ "242-v2ex.dif",	0x400000, 0xd2d03f2a, 0 | BRF_SND },
+	{ "242-v3ex.dif",	0x400000, 0x7b339d40, 0 | BRF_SND },
+	{ "242-v4ex.dif",	0x400000, 0x07450c5d, 0 | BRF_SND },
 };
 
 STDROMPICKEXT(kof98eck, kof98eck, neogeo)
@@ -23350,21 +23488,28 @@ STD_ROM_FN(kof98eck)
 
 static void kof98eckCallback()
 {
-	INT32 nIndex = 32, nEnd = 37, nAdd = 0x3000000;
+	INT32 nIndex = (0x01 == nBurnDrvSubActive) ? 16 : 32;
 
-	if (VerSwitcher & 0x01) {
-		nIndex = 16; nEnd = 25; nAdd = 0x1000000;
-		RomDiffPatch(NeoZ80ROMActive, 27, 0x040000, 1);
-	}
-
-	RomDiffPatch(Neo68KROMActive + 0x000000, nIndex + 0, 0x100000, 1);
+	RomDiffPatch(Neo68KROMActive + 0x000000, nIndex + 0, 0x100000, 1); // 68K code
 	RomDiffPatch(Neo68KROMActive + 0x100000, nIndex + 1, 0x400000, 1);
-	RomDiffPatch(NeoTextROM[nNeoActiveSlot], nIndex + 2, 0x020000, 1);
+	RomDiffPatch(NeoTextROM[nNeoActiveSlot], nIndex + 2, 0x020000, 1); // Text layer tiles
 
-	for (INT32 i = nIndex + 3, nOffset = 0; i <= nEnd; i += 2, nOffset += nAdd) {
-		RomDiffPatch(NeoSpriteROM[nNeoActiveSlot] + nOffset, i, 0x1000000, 2);
+	nIndex += 3;
+
+	if (0x01 == nBurnDrvSubActive) {
+		for (INT32 nGroup = 0; nGroup < 4; nGroup++, nIndex += 2) {
+			RomDiffPatch(NeoSpriteROM[nNeoActiveSlot] + 0x01000000 * nGroup, nIndex, 0x01000000, 2);
+		}
+	} else {
+		RomDiffPatch(NeoSpriteROM[nNeoActiveSlot] + 0x00000000, nIndex + 0, 0x01000000, 2);
+		RomDiffPatch(NeoSpriteROM[nNeoActiveSlot] + 0x01000000, nIndex + 2, 0x01000000, 2);
+		RomDiffPatch(NeoSpriteROM[nNeoActiveSlot] + 0x03000000, nIndex + 4, 0x01000000, 2);
+		RomDiffPatch(NeoSpriteROM[nNeoActiveSlot] + 0x04000000, nIndex + 6, 0x00000000, 2);
 	}
 
+	nIndex = (0x01 == nBurnDrvSubActive) ? 27 : 43;
+
+	RomDiffPatch(NeoZ80ROMActive + 0x000000, nIndex + 0, 0x040000, 1); // Z80 code
 }
 
 static INT32 kof98eckInit()
@@ -23381,7 +23526,8 @@ static INT32 kof98eckInit()
 		break;
 
 	case 0x02:
-		pszCustomNameA = "The King of Fighters '98 - The Slugfest / King of Fighters '98 - Dream Match Never Ends (YZKOF Easy Combo King, Hack)\0";
+		pNRI->nSpriteSize = 0x1000000;
+		pszCustomNameA = "The King of Fighters '98 - The Slugfest / King of Fighters '98 - Dream Match Never Ends (Easy Combo King Extend, Hack)\0";
 		break;
 	}
 
@@ -23391,9 +23537,11 @@ static INT32 kof98eckInit()
 
 	INT32 nRet = NeoInit();
 
-	if ((0 == nRet) && (0x01 == nBurnDrvSubActive)) {
-		for (INT32 nIndex = 28, nOffset = 0; nIndex <= 31; nIndex++, nOffset += 0x400000) {
-			RomDiffPatch(YM2610ADPCMAROM[nNeoActiveSlot] + nOffset, nIndex, 0x400000, 1);
+	if ((0 == nRet) && (nBurnDrvSubActive)) {
+		INT32 nIndex = (0x01 == nBurnDrvSubActive) ? 28 : 44;
+
+		for (INT32 nNum = 0; nNum < 4; nNum++, nIndex++) {
+			RomDiffPatch(YM2610ADPCMAROM[nNeoActiveSlot] + 0x400000 * nNum, nIndex, 0x400000, 1);
 		}
 	}
 
@@ -23401,7 +23549,7 @@ static INT32 kof98eckInit()
 }
 
 struct BurnDriver BurnDrvkof98eckg = {
-	"kof98eck", "kof98", "neogeo", NULL, "2019-2023",
+	"kof98eck", "kof98", "neogeo", NULL, "2019-2024",
 	"The King of Fighters '98 - The Slugfest / King of Fighters '98 - Dream Match Never Ends (Easy Combo King, Hack)\0", "Other versions are selected in the dipswitch", "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
@@ -23528,7 +23676,7 @@ struct BurnDriver BurnDrvkof99fd = {
 };
 
 
-// The King of Fighters '99 - Millennium Battle (Plus, Hack)
+// The King of Fighters '99 - Millennium Battle (Optimized, Hack)
 
 static struct BurnRomInfo kof99tRomDesc[] = {
 	// GOTVG - GSC2007 20140829
@@ -23557,11 +23705,11 @@ static INT32 kof99tInit()
 
 	switch (nBurnDrvSubActive) {
 	case 0x00:
-		pszCustomNameA = "The King of Fighters '99 - Millennium Battle (GOTVG Plus, Hack)\0";
+		pszCustomNameA = "The King of Fighters '99 - Millennium Battle (GOTVG Optimized, Hack)\0";
 		break;
 
 	case 0x01:
-		pszCustomNameA = "The King of Fighters '99 - Millennium Battle (YZKOF Plus, Hack)\0";
+		pszCustomNameA = "The King of Fighters '99 - Millennium Battle (YZKOF Optimized, Hack)\0";
 		NeoCallbackActive->pInitialise = kof99tCallback;
 		break;
 	}
@@ -23571,7 +23719,7 @@ static INT32 kof99tInit()
 
 struct BurnDriver BurnDrvkof99t = {
 	"kof99t", "kof99", "neogeo", NULL, "2014-2024",
-	"The King of Fighters '99 - Millennium Battle (Plus, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	"The King of Fighters '99 - Millennium Battle (Optimized, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
 	NULL, kof99tRomInfo, kof99tRomName, NULL, NULL, NULL, NULL, neoverswInputInfo, kf2k23rdDIPInfo,
@@ -23911,6 +24059,40 @@ struct BurnDriver BurnDrvkof99ae = {
 	0x1000, 304, 224, 4, 3
 };
 
+
+// The King of Fighters '99 - Millennium Battle (Plus, Hack)
+
+static struct BurnRomInfo kof99plsRomDesc[] = {
+	{ "152-p1pls.p1",	0x100000, 0xdcba09c6, 1 | BRF_ESS | BRF_PRG },
+	{ "152-p2pls.p2",	0x400000, 0x4fde8e58, 1 | BRF_ESS | BRF_PRG },
+
+	KOF99_DECRYPTED_TEXT
+
+	{ "251-c1pls.c1",	0x800000, 0x598cc558, 3 | BRF_GRA },
+	{ "251-c2pls.c2",	0x800000, 0x5b4c297b, 3 | BRF_GRA },
+	KOF99_DECRYPTED_SPR2
+	KOF99_DECRYPTED_SPR3
+	{ "251-c7pls.c7",	0x800000, 0x3ac342ad, 3 | BRF_GRA },
+	{ "251-c8pls.c8",	0x800000, 0x500aea52, 3 | BRF_GRA },
+
+	KOF99_Z80
+
+	KOF99_SND
+};
+
+STDROMPICKEXT(kof99pls, kof99pls, neogeo)
+STD_ROM_FN(kof99pls)
+
+struct BurnDriver BurnDrvkof99pls = {
+	"kof99pls", "kof99", "neogeo", NULL, "2024",
+	"The King of Fighters '99 - Millennium Battle (Plus, Hack)\0", NULL, "hack", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof99plsRomInfo, kof99plsRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
 #undef KOF99_DECRYPTED_COMPONENTS
 #undef KOF99_DECRYPTED_TEXT
 #undef KOF99_DECRYPTED_SPR1
@@ -23996,11 +24178,11 @@ struct BurnDriver BurnDrvkof2000t = {
 
 
 // The King of Fighters 2000 (Special, Hack)
-// Modified by GSC2007
-// GOTVG 20210304
+// Modified by GSC2007 & EGCG
+// GOTVG 20230306
 
 static struct BurnRomInfo kof2kspRomDesc[] = {
-	{ "257-p1sp.p1",	0x100000, 0xd31861a2, 1 | BRF_ESS | BRF_PRG },
+	{ "257-p1sp.p1",	0x100000, 0xa9742061, 1 | BRF_ESS | BRF_PRG },
 	{ "257-p2sp.sp2",	0x400000, 0x48a1a381, 1 | BRF_ESS | BRF_PRG },
 
 	KOF2000_DECRYPTED_SPR1
@@ -24018,7 +24200,7 @@ STDROMPICKEXT(kof2ksp, kof2ksp, neogeo)
 STD_ROM_FN(kof2ksp)
 
 struct BurnDriver BurnDrvkof2ksp = {
-	"kof2ksp", "kof2000", "neogeo", NULL, "2021",
+	"kof2ksp", "kof2000", "neogeo", NULL, "2023",
 	"The King of Fighters 2000 (Special, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_ALTERNATE_TEXT, GBF_VSFIGHT, FBF_KOF,
@@ -24450,11 +24632,11 @@ struct BurnDriver BurnDrvkf2k1pkz = {
 
 
 // The King of Fighters 2001 (Ultimate, Hack)
-// GOTVG 20240208
+// GOTVG 20240302
 
 static struct BurnRomInfo kf2k1ultRomDesc[] = {
-	{ "262-p1ult.p1",		0x100000, 0x8e659ab2, 1 | BRF_ESS | BRF_PRG },
-	{ "262-p2ult.sp2",		0x500000, 0x48e3b5a4, 1 | BRF_ESS | BRF_PRG },
+	{ "262-p1ult.p1",		0x100000, 0x30a082d1, 1 | BRF_ESS | BRF_PRG },
+	{ "262-p2ult.sp2",		0x500000, 0x569e8cee, 1 | BRF_ESS | BRF_PRG },
 
 	{ "262-s1ult.s1",		0x020000, 0xe8cb20be, 2 | BRF_GRA },
 
@@ -25504,7 +25686,7 @@ struct BurnDriver BurnDrvkf2k3p2s = {
 };
 
 
-#define WAKUWAK7_COMPONENT											\
+#define WAKUWAK7_COMPONENTS											\
 	{ "225-s1.s1",	0x020000, 0x71c4b4b5, 2 | BRF_GRA },			\
 	{ "225-c1.c1",	0x400000, 0xee4fea54, 3 | BRF_GRA },			\
 	{ "225-c2.c2",	0x400000, 0x0c549e2d, 3 | BRF_GRA },			\
@@ -25523,7 +25705,7 @@ static struct BurnRomInfo wakuwak7bhRomDesc[] = {
 	{ "225-p1bh.p1",	0x100000, 0x0b7a3776, 1 | BRF_ESS | BRF_PRG },
 	{ "225-p2.sp2",		0x200000, 0xfe190665, 1 | BRF_ESS | BRF_PRG },
 
-	WAKUWAK7_COMPONENT
+	WAKUWAK7_COMPONENTS
 };
 
 STDROMPICKEXT(wakuwak7bh, wakuwak7bh, neogeo)
@@ -25547,7 +25729,7 @@ static struct BurnRomInfo wakuw7jqRomDesc[] = {
 	{ "225-p1jq.p1",  0x100000, 0x680b0912, 1 | BRF_ESS | BRF_PRG },
 	{ "225-p2.sp2",   0x200000, 0xfe190665, 1 | BRF_ESS | BRF_PRG },
 
-	WAKUWAK7_COMPONENT
+	WAKUWAK7_COMPONENTS
 };
 
 STDROMPICKEXT(wakuw7jq, wakuw7jq, neogeo)
@@ -25563,7 +25745,7 @@ struct BurnDriver BurnDrvwakuw7jq = {
 	0x1000,	304, 224, 4, 3
 };
 
-#undef WAKUWAK7_COMPONENT
+#undef WAKUWAK7_COMPONENTS
 
 
 // -----------------------------------------------------------------------------

--- a/src/burn/drv/pgm/d_pgm.cpp
+++ b/src/burn/drv/pgm/d_pgm.cpp
@@ -122,55 +122,55 @@ static struct BurnDIPInfo jammaDIPList[] = {
 STDDIPINFO(jamma)
 
 static struct BurnDIPInfo pgmhDIPList[] = {
-	{0x2D, 0xFF, 0xFF, 0x00, NULL                                    },
-	{0x2F, 0xFF, 0x01, 0x01, NULL                                    },
-	{0x30, 0xFF, 0x01, 0x01, NULL                                    },
+	{0x2D, 0xFF, 0xFF, 0x00, NULL                               },
+	{0x2F, 0xFF, 0x01, 0x01, NULL                               },
+	{0x30, 0xFF, 0x01, 0x01, NULL                               },
 
-	{0,    0xFE, 0,    2,    "Test mode"                             },
-	{0x2D, 0x01, 0x01, 0x00, "Off"                                   },
-	{0x2D, 0x01, 0x01, 0x01, "On"                                    },
+	{0,    0xFE, 0,    2,    "Test mode"                        },
+	{0x2D, 0x01, 0x01, 0x00, "Off"                              },
+	{0x2D, 0x01, 0x01, 0x01, "On"                               },
 
-	{0,    0xFE, 0,    2,    "Music"                                 },
-	{0x2D, 0x01, 0x02, 0x02, "Off"                                   },
-	{0x2D, 0x01, 0x02, 0x00, "On"                                    },
+	{0,    0xFE, 0,    2,    "Music"                            },
+	{0x2D, 0x01, 0x02, 0x02, "Off"                              },
+	{0x2D, 0x01, 0x02, 0x00, "On"                               },
 
-	{0,    0xFE, 0,    2,    "Voice"                                 },
-	{0x2D, 0x01, 0x04, 0x04, "Off"                                   },
-	{0x2D, 0x01, 0x04, 0x00, "On"                                    },
+	{0,    0xFE, 0,    2,    "Voice"                            },
+	{0x2D, 0x01, 0x04, 0x04, "Off"                              },
+	{0x2D, 0x01, 0x04, 0x00, "On"                               },
 
-	{0,    0xFE, 0,    2,    "Free play"                             },
-	{0x2D, 0x01, 0x08, 0x00, "Off"                                   },
-	{0x2D, 0x01, 0x08, 0x08, "On"                                    },
+	{0,    0xFE, 0,    2,    "Free play"                        },
+	{0x2D, 0x01, 0x08, 0x00, "Off"                              },
+	{0x2D, 0x01, 0x08, 0x08, "On"                               },
 
-	{0,    0xFE, 0,    2,    "Stop mode"                             },
-	{0x2D, 0x01, 0x10, 0x00, "Off"                                   },
-	{0x2D, 0x01, 0x10, 0x10, "On"                                    },
+	{0,    0xFE, 0,    2,    "Stop mode"                        },
+	{0x2D, 0x01, 0x10, 0x00, "Off"                              },
+	{0x2D, 0x01, 0x10, 0x10, "On"                               },
 
-	{0,    0xFE, 0,    4,    "Bios select (Fake)"                    },
-	{0x2F, 0x01, 0x0f, 0x00, "Older"                                 },
-	{0x2F, 0x01, 0x0f, 0x01, "Newer"                                 },
-	{0x2F, 0x01, 0x0f, 0x02, "Newer (no intro, calendar)"            },
-	{0x2F, 0x01, 0x0f, 0x03, "Newer (no intro)"                      },
+	{0,    0xFE, 0,    4,    "Bios select (Fake)"               },
+	{0x2F, 0x01, 0x0f, 0x00, "Older"                            },
+	{0x2F, 0x01, 0x0f, 0x01, "Newer"                            },
+	{0x2F, 0x01, 0x0f, 0x02, "Newer (no intro, calendar)"       },
+	{0x2F, 0x01, 0x0f, 0x03, "Newer (no intro)"                 },
 
 	// Fake Dip
-	{0,    0xFE, 0,    2,    "Code select (Effective when reloaded)" },
-	{0x30, 0x01, 0x01, 0x00, "Real hardware"                         },
-	{0x30, 0x01, 0x01, 0x01, "Non-real hardware"                     },
+	{0,    0xFE, 0,    2,    "Code select (Must reload)"        },
+	{0x30, 0x01, 0x01, 0x00, "Real hardware"                    },
+	{0x30, 0x01, 0x01, 0x01, "Non-real hardware"                },
 };
 
 static struct BurnDIPInfo jammahDIPList[] = {
-	{0x2D, 0xFF, 0xFF, 0x00, NULL                                    },
-	{0x2F, 0xFF, 0x01, 0x00, NULL                                    },
-	{0x30, 0xFF, 0x01, 0x01, NULL                                    },
+	{0x2D, 0xFF, 0xFF, 0x00, NULL                               },
+	{0x2F, 0xFF, 0x01, 0x00, NULL                               },
+	{0x30, 0xFF, 0x01, 0x01, NULL                               },
 
-	{0,    0xFE, 0,    2,    "Test mode"                             },
-	{0x2D, 0x01, 0x01, 0x00, "Off"                                   },
-	{0x2D, 0x01, 0x01, 0x01, "On"                                    },
+	{0,    0xFE, 0,    2,    "Test mode"                        },
+	{0x2D, 0x01, 0x01, 0x00, "Off"                              },
+	{0x2D, 0x01, 0x01, 0x01, "On"                               },
 
 	// Fake Dip
-	{0,    0xFE, 0,    2,    "Code select (Effective when reloaded)" },
-	{0x30, 0x01, 0x01, 0x00, "Real hardware"                         },
-	{0x30, 0x01, 0x01, 0x01, "Non-real hardware"                     },
+	{0,    0xFE, 0,    2,    "Code select (Must reload)"        },
+	{0x30, 0x01, 0x01, 0x00, "Real hardware"                    },
+	{0x30, 0x01, 0x01, 0x01, "Non-real hardware"                },
 };
 
 static struct BurnDIPInfo orlegendDIPList[] = {
@@ -348,7 +348,7 @@ static struct BurnDIPInfo oldsplusnrDIPList[] = {
 	{0x2E, 0xFF, 0xFF, 0x01, NULL                                       },
 	{0x31, 0xFF, 0xFF, 0x00, NULL                                       },
 
-	{0,    0xFE, 0,    2,    "Version change (Effective when reloaded)" },
+	{0,    0xFE, 0,    2,    "Version change (Must reload)"             },
 	{0x31, 0x01, 0x01, 0x00, "v211"                                     },
 	{0x31, 0x01, 0x01, 0x01, "v208"                                     },
 };
@@ -808,6 +808,37 @@ STDDIPINFOEXT(oldschs,		pgmh,		olds100		)
 STDDIPINFOEXT(oldsplusnr,	pgmh,		oldsplusnr	) 
 STDDIPINFOEXT(kovchs,		pgmh,		kovassg		)
 STDDIPINFOEXT(kov2dzxx,		jammah,		kov2dzxx	) // The selection of [Region] and [BIOS] is shielded
+
+// ----------------------------------------------------------------------------
+// Loading incremental roms
+
+static void RomDiffPatch(UINT8* pSrc, INT32 nIndex, INT32 nLen)
+{
+	if (nLen > 0x2000000) return;
+	if (nLen < 0) nLen = 0;
+
+	UINT8* pTemp = NULL;
+
+	if (0 != nLen)
+		pTemp = BurnMalloc(0x2000000);
+
+	if (((NULL != pTemp) && (nLen > 0)) || (0 == nLen)) {
+		if (0 == nLen) pTemp = pSrc;
+
+		BurnLoadRom(pTemp, nIndex + 0, 1);
+
+		// pTemp = BurnMalloc(0x2000000);
+		// Don't use ips patch in diff mode anymore!
+		if (0 != nLen) {
+			for (INT32 i = 0; i < nLen; i++) {
+				// 0 when same, xor when different
+				if ((UINT8)0 != pTemp[i]) pSrc[i] ^= pTemp[i];
+			}
+
+			BurnFree(pTemp);
+		}
+	}
+}
 
 // -----------------------------------------------------------------------------
 // BIOS
@@ -7879,19 +7910,18 @@ static struct BurnRomInfo oldsplusnrRomDesc[] = {
 	{ "oldsplus_igs027a.bin",	0x0004000, 0x00000000, 7 | BRF_PRG | BRF_ESS | BRF_NODUMP }, //  9 Internal ARM7 Rom
 
 	/* v208 - 20200705 */
-	{ "v-208cn.u10",			0x0400000, 0xce6893ae, 0 | BRF_PRG | BRF_ESS },              // 10 68K Code
+	{ "v-208cn.dif",			0x0400000, 0x56ef7c1b, 0 | BRF_PRG | BRF_ESS },              
 
-	{ "igs_t05301w064.u2",		0x0800000, 0x8257bbb0, 0 | BRF_GRA },                        // 11 Tile data
+	{ "igs_t05301w064.dif",		0x0800000, 0x27b8be4b, 0 | BRF_GRA },                        // 11 Tile data
 
-	{ "igs_a05301nw064.u3",		0x0800000, 0x3d3125ff, 0 | BRF_GRA },                        // 12 Sprite Color Data
-//	{ "igs_a05302nw064.u4",		0x0800000, 0x4ed9028c, 0 | BRF_GRA },
-	{ "igs_a05303w064.u6",		0x0800000, 0x13475d85, 0 | BRF_GRA },                        // 13
-	{ "igs_a05304w064.u8",		0x0800000, 0xf03ef7a6, 0 | BRF_GRA },                        // 14
+	{ "igs_a05301nw064.dif",	0x0800000, 0x28a6f9f3, 0 | BRF_GRA },                        // 12 Sprite Color Data
+	{ "igs_a05303w064.dif",		0x0800000, 0x56e00d62, 0 | BRF_GRA },
+	{ "igs_a05304w064.dif",		0x0800000, 0x560f9b68, 0 | BRF_GRA },
 
-	{ "igs_b05301nw064.u9",		0x0800000, 0x13702bbf, 0 | BRF_GRA },                        // 15 Sprite Masks & Color Indexes
-	{ "igs_b05302nw064.u11",	0x0800000, 0xb9f75120, 0 | BRF_GRA },                        // 16
+	{ "igs_b05301nw064.dif",	0x0800000, 0x1565554b, 0 | BRF_GRA },                        // 15 Sprite Masks & Color Indexes
+	{ "igs_b05302nw064.dif",	0x0800000, 0x86924573, 0 | BRF_GRA },
 
-	{ "igs_w05301b032.u5",		0x0400000, 0x86ec83bc, 0 | BRF_SND },                        // 17 Samples
+	{ "igs_w05301b032.dif",		0x0400000, 0x20eb7bc6, 0 | BRF_SND },                        // 17 Samples
 };
 
 STDROMPICKEXT(oldsplusnr, oldsplusnr, pgm)
@@ -7901,29 +7931,28 @@ static void oldsplusnrLoadSPRColCallback(UINT8* gfx, INT32)
 {
 	// gfx is a pointer to the temporary memory where the Sprite Color Data roms are loaded
 	// v208
-	if (VerSwitcher & 1) {
-		BurnLoadRom(gfx + 0x0000000, 12, 1);
-		/* igs_a05302nw064.u4 Same as v211 */
-		BurnLoadRom(gfx + 0x1000000, 13, 1);
-		BurnLoadRom(gfx + 0x1800000, 14, 1);
+	if (nBurnDrvSubActive) {
+		RomDiffPatch(gfx + 0x00000000, 12, 0x800000); // Sprite Color Data
+		RomDiffPatch(gfx + 0x01000000, 13, 0x800000);
+		RomDiffPatch(gfx + 0x01800000, 14, 0x800000);
 	}
 }
 
 static void oldsplusnrLoadTileCallback(UINT8* gfx, INT32)
 {
-	// gfx is a pointer to the (PGMTileROM + 0x0180000)
+	// gfx is a pointer to the (PGMTileROM + 0x180000)
 	// v208
-	if (VerSwitcher & 1) BurnLoadRom(gfx, 11, 1);
+	if (nBurnDrvSubActive) RomDiffPatch(gfx, 11, 0x800000); // Tile data
 }
 
 static void oldsplusnrLoadRomsCallback()
 {
 	// v208
-	if (VerSwitcher & 1) {
-		BurnLoadRom(PGM68KROM,                 10, 1);
-		BurnLoadRom(PGMSPRMaskROM + 0x0000000, 15, 1);
-		BurnLoadRom(PGMSPRMaskROM + 0x0800000, 16, 1);
-		BurnLoadRom(ICSSNDROM     + 0x0400000, 17, 1);
+	if (nBurnDrvSubActive) {
+		RomDiffPatch(PGM68KROM     + 0x000000, 10, 0x400000); // 68K Code
+		RomDiffPatch(PGMSPRMaskROM + 0x000000, 15, 0x800000); // Sprite Masks & Color Indexes
+		RomDiffPatch(PGMSPRMaskROM + 0x800000, 16, 0x800000);
+		RomDiffPatch(ICSSNDROM     + 0x400000, 17, 0x400000); // Samples
 	}
 
 	// Decrypt 68k rom
@@ -7932,6 +7961,18 @@ static void oldsplusnrLoadRomsCallback()
 
 static INT32 oldsplusnrInit()
 {
+	nBurnDrvSubActive = (VerSwitcher & 0x01);
+
+	switch (nBurnDrvSubActive) {
+		case 0x00:
+			pszCustomNameA = "Xi You Shi E Zhuan - Xin Qun Mo Luan Wu (v211, Hack)\0";
+			break;
+
+		case 0x01:
+			pszCustomNameA = "Xi You Shi E Zhuan - Xin Qun Mo Luan Wu (v208, Hack)\0";
+			break;
+	}
+
 	pPgmColorDataDecryptcallback	= oldsplusnrLoadSPRColCallback;
 	pPgmTileDecryptCallback			= oldsplusnrLoadTileCallback;
 	pPgmInitCallback				= oldsplusnrLoadRomsCallback;
@@ -7942,7 +7983,7 @@ static INT32 oldsplusnrInit()
 
 struct BurnDriver BurnDrvoldsplusnr = {
 	"oldsplusnr", "oldsplus", "pgm", NULL, "2020-2024",
-	"Xi You Shi E Zhuan - Xin Qun Mo Luan Wu (Hack)\0", "Switchable v208 / v211", "hack", "PolyGameMaster",
+	"Xi You Shi E Zhuan - Xin Qun Mo Luan Wu (Hack)\0", "Switchable v211 / v208", "hack", "PolyGameMaster",
 	L"Xi You Shi E Zhuan - Xin Qun Mo Luan Wu (Hack)\0\u897f\u6e38\u91ca\u5384\u4f20 - \u65b0\u7fa4\u9b54\u4e71\u821e (\u4fee\u6539\u7248)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 4, HARDWARE_IGS_PGM/* | HARDWARE_IGS_USE_ARM_CPU*/, GBF_SCRFIGHT, 0,
 	NULL, oldsplusnrRomInfo, oldsplusnrRomName, NULL, NULL, NULL, NULL, oldsplusnrInputInfo, oldsplusnrDIPInfo,
@@ -8310,7 +8351,7 @@ static struct BurnRomInfo kovytzywscwRomDesc[] = {
 STDROMPICKEXT(kovytzywscw, kovytzywscw, pgm)
 STD_ROM_FN(kovytzywscw)
 
-static INT32 kovytzywscwInit()
+static INT32 kovshpsprhackInit()
 {
 	nPGMSpriteBufferHack = 1;
 
@@ -8323,7 +8364,7 @@ struct BurnDriver BurnDrvkovytzywscw = {
 	L"Yi Tong Zhong Yuan - Warriors\0\u4e00\u7edf\u4e2d\u539f - \u65e0\u53cc\u7248\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 4, HARDWARE_IGS_PGM | HARDWARE_IGS_USE_ARM_CPU, GBF_SCRFIGHT, 0,
 	NULL, kovytzywscwRomInfo, kovytzywscwRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
-	kovytzywscwInit, pgmExit, pgmFrame, pgmDraw, pgmScan, &nPgmPalRecalc, 0x900,
+	kovshpsprhackInit, pgmExit, pgmFrame, pgmDraw, pgmScan, &nPgmPalRecalc, 0x900,
 	448, 224, 4, 3
 };
 
@@ -8971,13 +9012,6 @@ static struct BurnRomInfo kovqxzbwsRomDesc[] = {
 STDROMPICKEXT(kovqxzbws, kovqxzbws, pgm)
 STD_ROM_FN(kovqxzbws)
 
-static INT32 kovshpsprhackInit()
-{
-	nPGMSpriteBufferHack = 1;
-	
-	return kovshpInit();
-}
-
 struct BurnDriver BurnDrvkovqxzbws = {
 	"kovqxzbws", "kovshp", "pgm", NULL, "2022",
 	"San Guo Zhan Ji - Qun Xiong Zheng Ba Feng Yun Zai Qi (Hack, ver. 2022-07-31)\0", "hack", "IGS", "PolyGameMaster",
@@ -8991,7 +9025,7 @@ struct BurnDriver BurnDrvkovqxzbws = {
 
 // San Guo Zhan Ji - Heng Sao Qian Jun (Hack)
 
-static struct BurnRomInfo kovplushsqjRomDesc[] = {
+static struct BurnRomInfo kovphsqjRomDesc[] = {
 	{ "hsqj_p0603_119.u1",	0x0600000, 0x476f2ae3, 1 | BRF_PRG | BRF_ESS },              //  0 68K Code
 
 	{ "hsqj_t0600.u11",		0x0800000, 0xec2357a0, 2 | BRF_GRA },                        //  1 Tile data
@@ -9012,8 +9046,8 @@ static struct BurnRomInfo kovplushsqjRomDesc[] = {
 	{ "kov_igs027a.bin",	0x0004000, 0x00000000, 7 | BRF_PRG | BRF_ESS | BRF_NODUMP }, // 12 Internal ARM7 Rom
 };
 
-STDROMPICKEXT(kovplushsqj, kovplushsqj, pgm)
-STD_ROM_FN(kovplushsqj)
+STDROMPICKEXT(kovphsqj, kovphsqj, pgm)
+STD_ROM_FN(kovphsqj)
 
 static INT32 kovsprhackInit()
 {
@@ -9022,12 +9056,12 @@ static INT32 kovsprhackInit()
 	return kovInit();
 }
 
-struct BurnDriver BurnDrvkovplushsqj = {
-	"kovplushsqj", "kovplus", "pgm", NULL, "2023",
+struct BurnDriver BurnDrvKovphsqj = {
+	"kovphsqj", "kovplus", "pgm", NULL, "2023",
 	"San Guo Zhan Ji - Heng Sao Qian Jun (Hack)\0", NULL, "hack", "PolyGameMaster",
-	L"San Guo Zhan Ji - Heng Sao Qian Jun\0\u4e09\u56fd\u6218\u7eaa - \u6a2a\u626b\u5343\u519b\0", NULL, NULL, NULL,
+	L"San Guo Zhan Ji - Heng Sao Qian Jun\0\u4e09\u570b\u6230\u7d00 - \u6a6b\u6383\u5343\u8ecd (Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 4, HARDWARE_IGS_PGM, GBF_SCRFIGHT, 0,
-	NULL, kovplushsqjRomInfo, kovplushsqjRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
+	NULL, kovphsqjRomInfo, kovphsqjRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
 	kovsprhackInit, pgmExit, pgmFrame, pgmDraw, pgmScan, &nPgmPalRecalc, 0x900,
 	448, 224, 4, 3
 };
@@ -9035,7 +9069,7 @@ struct BurnDriver BurnDrvkovplushsqj = {
 
 // San Guo Zhan Ji - Zhen Tun Shi Tian Di (Hack)
 
-static struct BurnRomInfo kovpluststdRomDesc[] = {
+static struct BurnRomInfo kovptstdRomDesc[] = {
 	{ "tstd_p0603_119.u1",	0x0600000, 0xc83ca4de, 1 | BRF_PRG | BRF_ESS },              //  0 68K Code
 
 	{ "tstd_t0600.u11",		0x0800000, 0xc13c78c3, 2 | BRF_GRA },                        //  1 Tile data
@@ -9054,16 +9088,83 @@ static struct BurnRomInfo kovpluststdRomDesc[] = {
 	{ "kov_igs027a.bin",	0x0004000, 0x00000000, 7 | BRF_PRG | BRF_ESS | BRF_NODUMP }, // 10 Internal ARM7 Rom
 };
 
-STDROMPICKEXT(kovpluststd, kovpluststd, pgm)
-STD_ROM_FN(kovpluststd)
+STDROMPICKEXT(kovptstd, kovptstd, pgm)
+STD_ROM_FN(kovptstd)
 
-struct BurnDriver BurnDrvkovpluststd = {
-	"kovpluststd", "kovplus", "pgm", NULL, "2023",
+struct BurnDriver BurnDrvKovptstd = {
+	"kovptstd", "kovplus", "pgm", NULL, "2023",
 	"San Guo Zhan Ji - Zhen Tun Shi Tian Di (Hack)\0", NULL, "hack", "PolyGameMaster",
-	L"San Guo Zhan Ji - Zhen Tun Shi Tian Di\0\u4e09\u56fd\u6218\u7eaa - \u771f\u00b7\u541e\u98df\u5929\u5730\0", NULL, NULL, NULL,
+	L"San Guo Zhan Ji - Zhen Tun Shi Tian Di\0\u4e09\u570b\u6230\u7d00 - \u771f\u00b7\u541e\u98df\u5929\u5730 (Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 4, HARDWARE_IGS_PGM, GBF_SCRFIGHT, 0,
-	NULL, kovpluststdRomInfo, kovpluststdRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
+	NULL, kovptstdRomInfo, kovptstdRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
 	kovInit, pgmExit, pgmFrame, pgmDraw, pgmScan, &nPgmPalRecalc, 0x900,
 	448, 224, 4, 3
 };
 
+
+// San Guo Zhan Ji - Xiao Bing Zheng Ba (Ver.A, Hack)
+
+static struct BurnRomInfo kovpxbaRomDesc[] = {
+	{ "xba_p0603_v119.u1",	0x0400000, 0xf8cd3baa, 1 | BRF_PRG | BRF_ESS },
+
+	{ "pgm_t0600.u11",		0x0800000, 0x4acc1ad6, 2 | BRF_GRA },
+
+	{ "pgm_a0600.u2",		0x0800000, 0xd8167834, 3 | BRF_GRA },
+	{ "pgm_a0601.u4",		0x0800000, 0xff7a4373, 3 | BRF_GRA },
+	{ "pgm_a0602.u6",		0x0800000, 0xe7a32959, 3 | BRF_GRA },
+	{ "pgm_a0603.u9",		0x0400000, 0xec31abda, 3 | BRF_GRA },
+
+	{ "pgm_b0600.u5",		0x0800000, 0x7d3cd059, 4 | BRF_GRA },
+	{ "pgm_b0601.u7",		0x0400000, 0xa0bb1c2f, 4 | BRF_GRA },
+
+	{ "pgm_m0600.u3",		0x0400000, 0x3ada4fd6, 5 | BRF_SND },
+
+	{ "kov_igs027a.bin",	0x0004000, 0x00000000, 7 | BRF_PRG | BRF_ESS | BRF_NODUMP },
+};
+
+STDROMPICKEXT(kovpxba, kovpxba, pgm)
+STD_ROM_FN(kovpxba)
+
+struct BurnDriver BurnDrvKovpxba = {
+	"kovpxba", "kovplus", "pgm", NULL, "2018",
+	"San Guo Zhan Ji - Xiao Bing Zheng Ba (Ver.A, Hack)\0", NULL, "hack", "PolyGameMaster",
+	L"San Guo Zhan Ji - Xiao Bing Zheng Ba\0\u4e09\u570b\u6230\u7d00 - \u5c0f\u5175\u722d\u9738 (Ver.A, Hack)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 4, HARDWARE_IGS_PGM/* | HARDWARE_IGS_USE_ARM_CPU*/, GBF_SCRFIGHT, 0,
+	NULL, kovpxbaRomInfo, kovpxbaRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
+	kovInit, pgmExit, pgmFrame, pgmDraw, pgmScan, &nPgmPalRecalc, 0x900,
+	448, 224, 4, 3
+};
+
+
+// San Guo Zhan Ji - Xiao Bing Zheng Ba (Ver.B, Hack)
+
+static struct BurnRomInfo kovpxbbRomDesc[] = {
+	{ "xbb_p0603_v119.u1",	0x0400000, 0xc94d20b9, 1 | BRF_PRG | BRF_ESS },
+
+	{ "pgm_t0600.u11",		0x0800000, 0x4acc1ad6, 2 | BRF_GRA },
+
+	{ "pgm_a0600.u2",		0x0800000, 0xd8167834, 3 | BRF_GRA },
+	{ "pgm_a0601.u4",		0x0800000, 0xff7a4373, 3 | BRF_GRA },
+	{ "pgm_a0602.u6",		0x0800000, 0xe7a32959, 3 | BRF_GRA },
+	{ "pgm_a0603.u9",		0x0400000, 0xec31abda, 3 | BRF_GRA },
+
+	{ "pgm_b0600.u5",		0x0800000, 0x7d3cd059, 4 | BRF_GRA },
+	{ "pgm_b0601.u7",		0x0400000, 0xa0bb1c2f, 4 | BRF_GRA },
+
+	{ "pgm_m0600.u3",		0x0400000, 0x3ada4fd6, 5 | BRF_SND },
+
+	{ "kov_igs027a.bin",	0x0004000, 0x00000000, 7 | BRF_PRG | BRF_ESS | BRF_NODUMP },
+};
+
+STDROMPICKEXT(kovpxbb, kovpxbb, pgm)
+STD_ROM_FN(kovpxbb)
+
+struct BurnDriver BurnDrvKovpxbb = {
+	"kovpxbb", "kovplus", "pgm", NULL, "2018",
+	"San Guo Zhan Ji - Xiao Bing Zheng Ba (Ver.B, Hack)\0", NULL, "hack", "PolyGameMaster",
+	L"San Guo Zhan Ji - Xiao Bing Zheng Ba\0\u4e09\u570b\u6230\u7d00 - \u5c0f\u5175\u722d\u9738 (Ver.B, Hack)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 4, HARDWARE_IGS_PGM/* | HARDWARE_IGS_USE_ARM_CPU*/, GBF_SCRFIGHT, 0,
+	NULL, kovpxbbRomInfo, kovpxbbRomName, NULL, NULL, NULL, NULL, pgmhInputInfo, kovchsDIPInfo,
+	kovInit, pgmExit, pgmFrame, pgmDraw, pgmScan, &nPgmPalRecalc, 0x900,
+	448, 224, 4, 3
+};

--- a/src/burn/drv/pst90s/d_raiden2.cpp
+++ b/src/burn/drv/pst90s/d_raiden2.cpp
@@ -5631,13 +5631,13 @@ struct BurnDriver BurnDrvZerotm2k = {
 
 // Zero Team USA (Incubus, Hack)
 // Modified by YanYan
-// GOTVG 20240114
+// GOTVG 20240229
 
 static struct BurnRomInfo zteammmRomDesc[] = {
-	{ "ztmm__1.u024.5k",	0x040000, 0x0a3cef0d, 1 | BRF_PRG | BRF_ESS }, //  0 V30 Code
-	{ "ztmm__3.u023.6k",	0x040000, 0x7f752b91, 1 | BRF_PRG | BRF_ESS }, //  1
-	{ "ztmm__2.u025.6l",	0x040000, 0x89a18871, 1 | BRF_PRG | BRF_ESS }, //  2
-	{ "ztmm__4.u026.5l",	0x040000, 0xc0c8eefb, 1 | BRF_PRG | BRF_ESS }, //  3
+	{ "ztmm__1.u024.5k",	0x040000, 0xc8bec908, 1 | BRF_PRG | BRF_ESS }, //  0 V30 Code
+	{ "ztmm__3.u023.6k",	0x040000, 0xb96f3a32, 1 | BRF_PRG | BRF_ESS }, //  1
+	{ "ztmm__2.u025.6l",	0x040000, 0x6fdfdf1c, 1 | BRF_PRG | BRF_ESS }, //  2
+	{ "ztmm__4.u026.5l",	0x040000, 0x5dae1177, 1 | BRF_PRG | BRF_ESS }, //  3
 
 	ZEROTEAM_COMPONENTS
 };
@@ -5818,13 +5818,13 @@ struct BurnDriver BurnDrvZteamym = {
 
 // Zero Team USA (God, Hack)
 // Modified by YanYan
-// GOTVG 20240214
+// GOTVG 20240227
 
 static struct BurnRomInfo zteamysRomDesc[] = {
-	{ "ztys__1.u024.5k",	0x040000, 0xd795a957, 1 | BRF_PRG | BRF_ESS }, //  0 V30 Code
-	{ "ztys__3.u023.6k",	0x040000, 0xfffa1699, 1 | BRF_PRG | BRF_ESS }, //  1
-	{ "ztys__2.u025.6l",	0x040000, 0x046a4d7e, 1 | BRF_PRG | BRF_ESS }, //  2
-	{ "ztys__4.u026.5l",	0x040000, 0x24beeac9, 1 | BRF_PRG | BRF_ESS }, //  3
+	{ "ztys__1.u024.5k",	0x040000, 0xb18507f8, 1 | BRF_PRG | BRF_ESS }, //  0 V30 Code
+	{ "ztys__3.u023.6k",	0x040000, 0x085be47f, 1 | BRF_PRG | BRF_ESS }, //  1
+	{ "ztys__2.u025.6l",	0x040000, 0x40483d13, 1 | BRF_PRG | BRF_ESS }, //  2
+	{ "ztys__4.u026.5l",	0x040000, 0x28237717, 1 | BRF_PRG | BRF_ESS }, //  3
 
 	ZEROTEAM_COMPONENTS
 };


### PR DESCRIPTION
d_cps1: wofdr20/kodsr/dinokr/captcmjy/bootlegs's QSound rebuilt drivers
d_cps2: ddsom1v4/ddsomudp/ddtoddp
d_pgm: kovphsqj/kovptstd/kovpxba/kovpxbb/oldsplusnr
d_neogeo: kof2ksp/kof97ce/mslugxcq/mslugxfs/mslug3cq/mslug3fs/kof95sr3/kof94nr2/aof2bhs/kof98eck/kof99pls/kof97rm/kf2k1ult
d_raiden2: zteammm/zteamys

https://github.com/finalburnneo/FBNeo/issues/1701
https://github.com/finalburnneo/FBNeo/issues/1690

test: https://drive.google.com/drive/folders/1qqk2cNlE5ecb6wMGjJmAqTef2xVgshyJ?usp=drive_link