### PR TITLE
d_megadrive: umk3osc

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -48475,9 +48475,9 @@ struct BurnDriver BurnDrvmd_umk3h = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Ultimate Mortal Kombat 3 OSC (Hack, v29) - 2024-01-28
+// Ultimate Mortal Kombat 3 OSC (Hack, v29a) - 2024-03-02
 static struct BurnRomInfo md_umk3oscRomDesc[] = {
-	{ "Ultimate Mortal Kombat 3 OSC v29 (2023)(Bonus).bin", 5461060, 0xeb18a625, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Ultimate Mortal Kombat 3 OSC v29a (2024)(Bonus).bin", 5458706, 0x263cb534, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_umk3osc)
@@ -48485,7 +48485,7 @@ STD_ROM_FN(md_umk3osc)
 
 struct BurnDriver BurnDrvmd_umk3osc = {
 	"md_umk3osc", "md_umk3", NULL, NULL, "2024",
-	"Ultimate Mortal Kombat 3 OSC (Hack, v29)\0", NULL, "Bonus", "Sega Megadrive",
+	"Ultimate Mortal Kombat 3 OSC (Hack, v29a)\0", NULL, "Bonus", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_umk3oscRomInfo, md_umk3oscRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,


### PR DESCRIPTION
updated to latest version (version 29a).

Changes:
1. Shang Tsung – after morphing into Robo-Smoke and going into invisibility, smoke appears.
2. The original tracks of the Graveyard arena have been restored.
3. The attack of the jumper in 2v2 mode is even more complicated:
- the disable timer starts for the Sub-Zero mk2 puddle;
- the clone does not freeze;
- bombs disappear
4. Reptile – the recovery in the XXA combo has been increased, the ability to do relaunches has been removed.
5. Cabal – the ball is blocked after 11 hits (previously it was after 9)
6. Sector damage in combos with two TPs has been adjusted:
- damage is protected if the TP is the 2nd or later blow;
- damage protected if jap kick/punch 2nd or later hit