### PR TITLE
v60: prevent unaligned read

### DIFF
--- a/src/cpu/v60/v60.cpp
+++ b/src/cpu/v60/v60.cpp
@@ -138,11 +138,11 @@ static UINT16 cpu_readop16(UINT32 a)
 	UINT8 *p = mem[2][a / page_size];
 
 	if (p) {
-		UINT16 *z = (UINT16*)(p + (a & page_mask));
+		UINT16 z = BURN_UNALIGNED_READ16(p + (a & page_mask));
 #ifdef LOG_MEM
-//		bprintf (0, _T("OP16: %6.6x %4.4x\n"), a, *z);
+//		bprintf (0, _T("OP16: %6.6x %4.4x\n"), a, z);
 #endif
-		return BURN_ENDIAN_SWAP_INT16(*z);
+		return z;
 	}
 
 	if (v60_read16) {
@@ -163,13 +163,13 @@ static UINT32 cpu_readop32(UINT32 a)
 	UINT8 *p = mem[2][a / page_size];
 
 	if (p) {
-		UINT32 *z = (UINT32*)(p + (a & page_mask));
+		UINT32 z = BURN_UNALIGNED_READ32(p + (a & page_mask));
 
 #ifdef LOG_MEM
-//		bprintf (0, _T("OP32: %6.6x %8.8x\n"), a, *z);
+//		bprintf (0, _T("OP32: %6.6x %8.8x\n"), a, z);
 #endif
 
-		return BURN_ENDIAN_SWAP_INT32(*z);
+		return z;
 	}
 
 	if (v60_read32) {


### PR DESCRIPTION
I have seen some weird reports about segas32 crashing, i *think* it might be due to the unaligned v60 reads i found in ubsan.

@dinkc64 this commit fixes the warnings and doesn't seem to introduce regressions, what do you think ?