### PR TITLE
Port over win32 runahead fixes to SDL

### DIFF
--- a/src/burner/sdl/run.cpp
+++ b/src/burner/sdl/run.cpp
@@ -170,9 +170,7 @@ static int RunFrame(int bDraw, int bPause)
 
 				AudBlankSound();
 			}
-		}
-		else
-		{
+		} else {
 				pBurnDraw = (BurnDrvGetFlags() & BDF_RUNAHEAD_DRAWSYNC) ? pVidImage : NULL;
 				BurnDrvFrame();
 				StateRunAheadSave();
@@ -195,9 +193,7 @@ static int RunFrame(int bDraw, int bPause)
 		}
 
 		VidPaint(0);                                              // paint the screen (no need to validate)
-	}
-	else
-	{                                       // frame skipping
+	} else {                                       // frame skipping
 		pBurnDraw = NULL;                    // Make sure no image is drawn
 		BurnDrvFrame();
 	}

--- a/src/burner/sdl/run.cpp
+++ b/src/burner/sdl/run.cpp
@@ -160,17 +160,38 @@ static int RunFrame(int bDraw, int bPause)
 	{
 		nFramesRendered++;
 
-		if (!bRunAhead || bAppDoFast) {     // Run-Ahead feature 				-dink aug 02, 2021
+		if (!bRunAhead || (BurnDrvGetFlags() & BDF_RUNAHEAD_DISABLED) || bAppDoFast) {     // Run-Ahead feature 				-dink aug 02, 2021
 			if (VidFrame()) {				// Do one frame w/o RunAhead or if FFWD is pressed.
+				// VidFrame() failed, but we must run a driver frame because we have
+            	// a clocked input.  Possibly from recording or netplay(!)
+            	// Note: VidFrame() calls BurnDrvFrame() on success.
+				pBurnDraw = NULL;			// Make sure no image is drawn
+            	BurnDrvFrame();
+
 				AudBlankSound();
 			}
-		} else {
-			pBurnDraw = NULL;               // Do one frame w/RunAhead
-			BurnDrvFrame();
-			StateRunAheadSave();
-			pBurnSoundOut = NULL;
-			VidFrame();
-			StateRunAheadLoad();
+		}
+		else
+		{
+				pBurnDraw = (BurnDrvGetFlags() & BDF_RUNAHEAD_DRAWSYNC) ? pVidImage : NULL;
+				BurnDrvFrame();
+				StateRunAheadSave();
+				INT16 *pBurnSoundOut_temp = pBurnSoundOut;
+				pBurnSoundOut = NULL;
+				nCurrentFrame++;
+				bBurnRunAheadFrame = 1;
+
+				if (VidFrame()) {
+					// VidFrame() failed, but we must run a driver frame because we have
+					// an input.  Possibly from recording or netplay(!)
+					pBurnDraw = NULL;			// Make sure no image is drawn, since video failed this time 'round.
+					BurnDrvFrame();
+				}
+
+				bBurnRunAheadFrame = 0;
+				nCurrentFrame--;
+				StateRunAheadLoad();
+				pBurnSoundOut = pBurnSoundOut_temp; // restore pointer, for wav & avi writer
 		}
 
 		VidPaint(0);                                              // paint the screen (no need to validate)
@@ -346,8 +367,8 @@ int RunExit()
 #ifdef BUILD_SDL2
 void pause_game()
 {
-	AudSoundStop();	
-	
+	AudSoundStop();
+
 	if(nVidSelect) {
 		// no Text in OpenGL...
 		SDL_GL_SwapWindow(sdlWindow);
@@ -355,12 +376,12 @@ void pause_game()
 		inprint_shadowed(sdlRenderer, "PAUSE", 10, 10);
 		SDL_RenderPresent(sdlRenderer);
 	}
-	
+
     int finished = 0;
 	while (!finished)
   	{
 		starting_stick = SDL_GetTicks();
-		
+
  		SDL_Event e;
 
 		while (SDL_PollEvent(&e))
@@ -381,9 +402,9 @@ void pause_game()
 					break;
 			  }
 			}
-			if (e.type == SDL_WINDOWEVENT)  
+			if (e.type == SDL_WINDOWEVENT)
 			{ // Window Event
-				switch (e.window.event) 
+				switch (e.window.event)
 				{
 					//case SDL_WINDOWEVENT_RESTORED: // keep pause when restore window
 					case SDL_WINDOWEVENT_FOCUS_GAINED:
@@ -398,15 +419,15 @@ void pause_game()
 				}
 			}
 		}
-		
-		// limit 5 FPS (free CPU usage)		
+
+		// limit 5 FPS (free CPU usage)
 		if ( ( 1000 / 5 ) > SDL_GetTicks() - starting_stick) {
 			SDL_Delay( 1000 / 5 - ( SDL_GetTicks() - starting_stick ) );
 		}
-		
-	}	
-	
-	AudSoundPlay();	
+
+	}
+
+	AudSoundPlay();
 }
 #endif
 
@@ -421,7 +442,7 @@ int RunMessageLoop()
 
 	while (!quit)
 	{
-		
+
 		SDL_Event event;
 		while (SDL_PollEvent(&event))
 		{
@@ -433,16 +454,16 @@ int RunMessageLoop()
 
 #ifdef BUILD_SDL2
 			case SDL_WINDOWEVENT:  // Window Event
-				switch (event.window.event) 
+				switch (event.window.event)
 				{
 					case SDL_WINDOWEVENT_MINIMIZED:
 					case SDL_WINDOWEVENT_FOCUS_LOST:
 						pause_game();
 						break;
 				}
-				break;			
+				break;
 #endif
-					
+
 			case SDL_KEYDOWN:                                                // need to find a nicer way of doing this...
 				switch (event.key.keysym.sym)
 				{
@@ -474,9 +495,9 @@ int RunMessageLoop()
 						pause_game();
 					}
 					break;
-				
+
 				case SDLK_RETURN:
-					if (event.key.keysym.mod & KMOD_ALT) 
+					if (event.key.keysym.mod & KMOD_ALT)
 					{
 						SetFullscreen(!GetFullscreen());
 						AdjustImageSize();
@@ -516,7 +537,7 @@ int RunMessageLoop()
 				case SDLK_F1:
 					bAppDoFast = 0;
 					break;
-				case SDLK_F6: 
+				case SDLK_F6:
 					bscreenshot = 0;
 					break;
 				case SDLK_F12:
@@ -529,7 +550,7 @@ int RunMessageLoop()
 				break;
 			}
 		}
-		
+
 		RunIdle();
 
 	}


### PR DESCRIPTION
Just copied over the fixes from the win32 implementation of run-ahead. Tested with xmen6p and ninjak, and they seem to work as intended. Not sure if more thorough testing is needed, seeing as how it's been like this for a while. Please let me know if I'm missing anything, or if brought over anything extraneous.