### PR TITLE
win32: Add input macros for System Next State and System Previous State

### DIFF
--- a/src/burner/burner.h
+++ b/src/burner/burner.h
@@ -149,6 +149,8 @@ extern UINT8 macroSystemFFWD;
 extern UINT8 macroSystemFrame;
 extern UINT8 macroSystemSaveState;
 extern UINT8 macroSystemLoadState;
+extern UINT8 macroSystemNextState;
+extern UINT8 macroSystemPreviousState;
 extern UINT8 macroSystemUNDOState;
 extern UINT8 macroSystemRewind;
 extern UINT8 macroSystemRewindCancel;

--- a/src/burner/gami.cpp
+++ b/src/burner/gami.cpp
@@ -27,6 +27,8 @@ UINT8 macroSystemFFWD = 0;
 UINT8 macroSystemFrame = 0;
 UINT8 macroSystemSaveState = 0;
 UINT8 macroSystemLoadState = 0;
+UINT8 macroSystemNextState = 0;
+UINT8 macroSystemPreviousState = 0;
 UINT8 macroSystemUNDOState = 0;
 UINT8 macroSystemSlowMo[5] = { 0, 0, 0, 0, 0 };
 UINT8 macroSystemRewind = 0;
@@ -398,6 +400,26 @@ static void GameInpInitMacros()
 			pgi->Macro.nSysMacro = 1;
 			sprintf(pgi->Macro.szName, "System Save State");
 			pgi->Macro.pVal[0] = &macroSystemSaveState;
+			pgi->Macro.nVal[0] = 1;
+			nMacroCount++;
+			pgi++;
+
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			pgi->Macro.nSysMacro = 1;
+			sprintf(pgi->Macro.szName, "System Next State");
+			pgi->Macro.pVal[0] = &macroSystemNextState;
+			pgi->Macro.nVal[0] = 1;
+			nMacroCount++;
+			pgi++;
+
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			pgi->Macro.nSysMacro = 1;
+			sprintf(pgi->Macro.szName, "System Previous State");
+			pgi->Macro.pVal[0] = &macroSystemPreviousState;
 			pgi->Macro.nVal[0] = 1;
 			nMacroCount++;
 			pgi++;

--- a/src/burner/win32/run.cpp
+++ b/src/burner/win32/run.cpp
@@ -37,7 +37,7 @@ int nSlowMo = 0;
 static int flippy = 0; // free running RunFrame() counter
 
 // For System Macros (below)
-static int prevPause = 0, prevFFWD = 0, prevFrame = 0, prevSState = 0, prevLState = 0, prevUState = 0;
+static int prevPause = 0, prevFFWD = 0, prevFrame = 0, prevSState = 0, prevLState = 0, prevNState = 0, prevPState = 0, prevUState = 0;
 UINT32 prevPause_debounce = 0;
 
 struct lua_hotkey_handler {
@@ -134,6 +134,16 @@ static void CheckSystemMacros() // These are the Pause / FFWD macros added to th
 		PostMessage(hScrnWnd, WM_KEYDOWN, VK_F10, 0);
 	}
 	prevSState = macroSystemSaveState;
+	// Next State
+	if (macroSystemNextState && macroSystemNextState != prevNState) {
+		PostMessage(hScrnWnd, WM_KEYDOWN, VK_F11, 0);
+	}
+	prevNState = macroSystemNextState;
+	// Previous State
+	if (macroSystemPreviousState && macroSystemPreviousState != prevPState) {
+		PostMessage(hScrnWnd, WM_KEYDOWN, VK_F8, 0);
+	}
+	prevPState = macroSystemPreviousState;
 	// UNDO State
 	if (macroSystemUNDOState && macroSystemUNDOState != prevUState) {
 		scrnSSUndo();


### PR DESCRIPTION
### Description
This PR adds input macros called "System Next State" and "System Previous State" to the Win32 build of FBNeo. These macros can then be bound to inputs, in the same manner as the existing "System Save State" and "System Load State" macros. The System Next State macro triggers the F11 hotkey, which selects the next save state slot, while the System Load State macro triggers the F8 hotkey, selecting the previous save state slot.

### Motivation
I got tired of having to take my hands off of my gamepad to press F8 and F11 to switch between save state slots. I wanted to be able to bind these shortcuts to buttons on my gamepad.

### How has this been tested?
I've tested this by building the Win32 build, mapping the new macros to gamepad buttons, and verifying that they perform the expected actions while running a game. Each macro is only trigged a single time for each button press, which is how the existing System Save State and System Load State macros behave.