### PR TITLE
Some changes in nes/pre90s

### DIFF
--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -41622,7 +41622,7 @@ struct BurnDriver BurnDrvnes_ghostbustersii = {
 
 // Ghosts'n Goblins (USA)(Hack, Easy Mode v2.0)
 static struct BurnRomInfo nes_ghostsngoblinshRomDesc[] = {
-	{ "Ghosts'n Goblins (USA)(Hack, Very Easy Mode v2.0).nes",          131088, 0x66751cad, BRF_ESS | BRF_PRG },
+	{ "Ghosts'n Goblins (USA)(Hack, Very Easy Mode v2.0).nes",          131088, 0x79a599d9, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_ghostsngoblinsh)
@@ -41640,7 +41640,7 @@ struct BurnDriver BurnDrvnes_ghostsngoblinsh = {
 
 // Ghosts'n Goblins (USA)
 static struct BurnRomInfo nes_ghostsngoblinsRomDesc[] = {
-	{ "Ghosts'n Goblins (USA).nes",          131088, 0x983dd1de, BRF_ESS | BRF_PRG },
+	{ "Ghosts'n Goblins (USA).nes",          131088, 0x87ed54aa, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_ghostsngoblins)

--- a/src/burn/drv/pre90s/d_pacman.cpp
+++ b/src/burn/drv/pre90s/d_pacman.cpp
@@ -4970,7 +4970,7 @@ static struct BurnRomInfo mspacmane2RomDesc[] = {
 	{ "mpe3.6h", 	0x1000, 0x1821ee0b, 1 | BRF_ESS | BRF_PRG },	//  2
 	{ "mpe4.6j", 	0x1000, 0xd5e5d2aa, 1 | BRF_ESS | BRF_PRG },	//  3
 	{ "mpe5.6l", 	0x1000, 0x8c3e6de6, 1 | BRF_ESS | BRF_PRG },	//  4
-	{ "mpe6.6m", 	0x0800, 0x375f0693, 1 | BRF_ESS | BRF_PRG },	//  5
+	{ "mpe6.6m", 	0x1000, 0x375f0693, 1 | BRF_ESS | BRF_PRG },	//  5
 
 	{ "mpe7.5e",   	0x0800, 0x93933d1d, 2 | BRF_GRA },				//  6 Graphics
 	{ "mpe9.5h",   	0x0800, 0x7409fbec, 2 | BRF_GRA },				//  7 / BAD DUMP

--- a/src/burn/drv/pre90s/d_tsamurai.cpp
+++ b/src/burn/drv/pre90s/d_tsamurai.cpp
@@ -1885,10 +1885,10 @@ STD_ROM_PICK(alphaxz)
 STD_ROM_FN(alphaxz)
 
 struct BurnDriver BurnDrvAlphaxz = {
-	"alphaxz", "m660", NULL, NULL, "1986",
+	"alphaxz", NULL, NULL, NULL, "1986",
 	"The Alphax Z (Japan)\0", NULL, "Ed Co., Ltd. (Wood Place Co., Ltd. license)", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_ORIENTATION_VERTICAL | BDF_ORIENTATION_FLIPPED | BDF_HISCORE_SUPPORTED, 2, HARDWARE_MISC_PRE90S, GBF_VERSHOOT, 0,
+	BDF_GAME_WORKING | BDF_ORIENTATION_VERTICAL | BDF_ORIENTATION_FLIPPED | BDF_HISCORE_SUPPORTED, 2, HARDWARE_MISC_PRE90S, GBF_VERSHOOT, 0,
 	NULL, alphaxzRomInfo, alphaxzRomName, NULL, NULL, NULL, NULL, TsamuraiInputInfo, M660DIPInfo,
 	m660Init, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x100,
 	224, 256, 3, 4


### PR DESCRIPTION
nes
d_nes - ghostsngoblins / ghostsngoblinsh: removed "NI 1.3" from header.
"NI 1.3 is the watermark of an old tool called NES Image converter." (by noone).

pre90s
d_pacman - mspacmane2: correct size for 'mpe6.6m' (checked in fbneo and rom manager).
d_tsamurai - alphaxz: changed "m660" to NULL, coz alphaxz is a parent ROM.