### PR TITLE
d_neogeo: kof94te

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21582,7 +21582,7 @@ struct BurnDriver BurnDrvKof94rz = {
  *************************************************************************************/
 
 static struct BurnRomInfo kof94teRomDesc[] = {
-	{ "055-p1te.p1",	0x200000, 0x9fbece14, 1 | BRF_ESS | BRF_PRG },
+	{ "055-p1te.p1",	0x200000, 0x457d9cf7, 1 | BRF_ESS | BRF_PRG },
 
 	{ "055-s1te.s1",	0x020000, 0xdcd024d2, 2 | BRF_GRA },
 
@@ -21613,7 +21613,7 @@ struct BurnDriver BurnDrvKof94te = {
 
 
 static struct BurnRomInfo kof94teaRomDesc[] = {
-	{ "055-p1tea.p1",	0x200000, 0x6619cc92, 1 | BRF_ESS | BRF_PRG },
+	{ "055-p1tea.p1",	0x200000, 0xbcda9e71, 1 | BRF_ESS | BRF_PRG },
 
 	{ "055-s1te.s1",	0x020000, 0xdcd024d2, 2 | BRF_GRA },
 


### PR DESCRIPTION
removed 'Prevent color corruption when using Rugal' patch from combination.

in https://neorh.mattgreer.dev/kof94:
_"The Rugal color corruption fix and Team Edit Edition are not compatible with each other. Sorry about that."_