### PR TITLE
some changes in MD / MSX / N3S / SN3S...

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -47830,6 +47830,26 @@ struct BurnDriver BurnDrvmd_btomatog = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)
+// https://romhackplaza.org/romhacks/bishoujo-super-street-fighter-ii-glamor-queen-genesis/
+
+static struct BurnRomInfo md_bssf2gqRomDesc[] = {
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.6 (2024)(Yoni Arousement).bin", 0x500000, 0x87a6c750, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_bssf2gq)
+STD_ROM_FN(md_bssf2gq)
+
+struct BurnDriver BurnDrvmd_bssf2gq = {
+	"md_bssf2gq", "md_ssf2", NULL, NULL, "2024",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Cadash (Hack, Arcade Colors)
 // http://www.romhacking.net/hacks/3905/
 static struct BurnRomInfo md_cadashacRomDesc[] = {
@@ -52547,18 +52567,18 @@ struct BurnDriver BurnDrvmd_mkae = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Mortal Kombat Arcade Edition (Hack)
-// https://www.romhacking.net/reviews/9714/
+// Mortal Kombat Arcade Edition (Hack, v2.1)
+// https://romhackplaza.org/romhacks/mortal-kombat-arcade-edition-enhanced-genesis-2/
 static struct BurnRomInfo md_mkaeeRomDesc[] = {
-	{ "Mortal Kombat Arcade Edition Enhanced v1.5 (2022)(Rael G.C.).bin", 4194304, 0xb884890b, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Mortal Kombat Arcade Edition Enhanced v2.1 (2024)(Rael G.C.).bin", 4194304, 0x486979c5, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_mkaee)
 STD_ROM_FN(md_mkaee)
 
 struct BurnDriver BurnDrvmd_mkaee = {
-	"md_mkaee", "md_mk", NULL, NULL, "2022",
-	"Mortal Kombat Arcade Edition Enhanced (Hack, v1.5)\0", NULL, "Rael G.C.", "Sega Megadrive",
+	"md_mkaee", "md_mk", NULL, NULL, "2024",
+	"Mortal Kombat Arcade Edition Enhanced (Hack, v2.1)\0", NULL, "Rael G.C.", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_mkaeeRomInfo, md_mkaeeRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -14132,7 +14132,7 @@ struct BurnDriver BurnDrvMSX_gundamk = {
 // Mokari Makka? Bochibochi Denna! (Japan)
 
 static struct BurnRomInfo MSX_mokarimaRomDesc[] = {
-	{ "Mokari Makka? Bochibochi Denna! (Japan)(1986)(Leben Pro).rom",	0x08000, 0xd40f481d, BRF_PRG | BRF_ESS },
+	{ "Mokari Makka Bochibochi Denna! (Japan)(1986)(Leben Pro).rom",	0x08000, 0xd40f481d, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(MSX_mokarima, MSX_mokarima, msx_msx)

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -28056,10 +28056,10 @@ struct BurnDriver BurnDrvnes_marioadventure = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
-// Mario Adventure 3 (Hack, v1.9.8)
+// Mario Adventure 3 (Hack, v1.9.9)
 // https://marioadventure3.com/
 static struct BurnRomInfo nes_marioadventure3RomDesc[] = {
-	{ "Mario Adventure 3 v1.9.8 (2024)(ScarlettVixen).nes",          786448, 0x494115ef, BRF_ESS | BRF_PRG },
+	{ "Mario Adventure 3 v1.9.9 (2024)(ScarlettVixen).nes",          786448, 0x0bf1b61c, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_marioadventure3)
@@ -28067,7 +28067,7 @@ STD_ROM_FN(nes_marioadventure3)
 
 struct BurnDriver BurnDrvnes_marioadventure3 = {
 	"nes_marioadventure3", "nes_smb3", NULL, NULL, "2024",
-	"Mario Adventure 3 (Hack, v1.9.8)\0", NULL, "ScarlettVixen", "Miscellaneous",
+	"Mario Adventure 3 (Hack, v1.9.9)\0", NULL, "ScarlettVixen", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_NES, GBF_PLATFORM, 0,
 	NESGetZipName, nes_marioadventure3RomInfo, nes_marioadventure3RomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
@@ -28800,9 +28800,9 @@ struct BurnDriver BurnDrvnes_multidudee = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
-// Murder in the Maze (HB)
+// Murder in the Maze (HB, v1.01)
 static struct BurnRomInfo nes_murdmazeRomDesc[] = {
-	{ "Murder in the Maze (2024)(T1LT).nes",          524304, 0xbaac5e32, BRF_ESS | BRF_PRG },
+	{ "Murder in the Maze v1.01 (2024)(T1LT).nes",          524304, 0xbaac5e32, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(nes_murdmaze)
@@ -28810,7 +28810,7 @@ STD_ROM_FN(nes_murdmaze)
 
 struct BurnDriver BurnDrvnes_murdmaze = {
 	"nes_murdmaze", NULL, NULL, NULL, "2024",
-	"Murder in the Maze (HB)\0", NULL, "T1LT", "Miscellaneous",
+	"Murder in the Maze (HB, v1.01)\0", NULL, "T1LT", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_NES, GBF_ADV | GBF_MINIGAMES, 0,
 	NESGetZipName, nes_murdmazeRomInfo, nes_murdmazeRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,

--- a/src/burn/drv/snes/d_snes.cpp
+++ b/src/burn/drv/snes/d_snes.cpp
@@ -2729,10 +2729,10 @@ struct BurnDriver BurnDrvsnes_Bahalagoonte = {
 	512, 448, 4, 3
 };
 
-// Bahamut Lagoon (Hack, Spanish v1.03a)
+// Bahamut Lagoon (Hack, Spanish v1.03c)
 // https://crackowia.com/bahamuts.html
 static struct BurnRomInfo snes_BahalagoontsRomDesc[] = {
-	{ "Bahamut Lagoon T-Spa v1.03a (2022)(Rod Merida).sfc", 8388608, 0x04a290fa, BRF_ESS | BRF_PRG },
+	{ "Bahamut Lagoon T-Spa v1.03c (2022)(Rod Merida).sfc", 8388608, 0xf24350ec, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(snes_Bahalagoonts)
@@ -2740,7 +2740,7 @@ STD_ROM_FN(snes_Bahalagoonts)
 
 struct BurnDriver BurnDrvsnes_Bahalagoonts = {
 	"snes_bahalagoonts", "snes_bahalagoonte", NULL, NULL, "2022",
-	"Bahamut Lagoon (Hack, Spanish v1.03a)\0", NULL, "Rod Merida", "Nintendo",
+	"Bahamut Lagoon (Hack, Spanish v1.03c)\0", NULL, "Rod Merida", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_SNES, GBF_RPG | GBF_STRATEGY, 0,
 	SNESGetZipName, snes_BahalagoontsRomInfo, snes_BahalagoontsRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
@@ -6475,7 +6475,7 @@ struct BurnDriver BurnDrvsnes_Dezaemonj = {
 // Dezaemon (Hack, English)
 // https://www.romhacking.net/translations/3749/
 static struct BurnRomInfo snes_DezaemonteRomDesc[] = {
-	{ "Dezaemon T-Eng (2018)(Aeon Genesis)..sfc", 524288, 0x32f9c958, BRF_ESS | BRF_PRG },
+	{ "Dezaemon T-Eng (2018)(Aeon Genesis).sfc", 524288, 0x32f9c958, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(snes_Dezaemonte)
@@ -30135,10 +30135,10 @@ struct BurnDriver BurnDrvsnes_Ff5rte = {
 	512, 448, 4, 3
 };
 
-// Final Fantasy VI Reimagined (Hack)
+// Final Fantasy VI Reimagined (Hack) - 2024-10-30
 // https://www.ff6hacking.com/forums/thread-4416.html
 static struct BurnRomInfo snes_Ff6rmdRomDesc[] = {
-	{ "Final Fantasy VI Reimagined (2024)(DrakeyC).sfc", 4194304, 0xb1148ddf, BRF_ESS | BRF_PRG },
+	{ "Final Fantasy VI Reimagined (2024)(DrakeyC).sfc", 4194304, 0x60aff03d, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(snes_Ff6rmd)
@@ -30496,10 +30496,10 @@ struct BurnDriver BurnDrvsnes_Jimpoweree = {
 	512, 448, 4, 3
 };
 
-// Legend of Zelda, The - 18 Hours Past (Hack, v1.11)
+// Legend of Zelda, The - 18 Hours Past (Hack, v1.12)
 // https://www.romhacking.net/hacks/7732/
 static struct BurnRomInfo snes_Legendofzelda18hpRomDesc[] = {
-	{ "Legend of Zelda, The - 18 Hours Past v1.11 (2024)(Letterbomb).sfc", 2097152, 0x45d6950f, BRF_ESS | BRF_PRG },
+	{ "Legend of Zelda, The - 18 Hours Past v1.12 (2024)(Letterbomb).sfc", 2097152, 0xc2dc7b83, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(snes_Legendofzelda18hp)
@@ -30507,7 +30507,7 @@ STD_ROM_FN(snes_Legendofzelda18hp)
 
 struct BurnDriver BurnDrvsnes_Legendofzelda18hp = {
 	"snes_legendofzelda18hp", "snes_legendofzelda", NULL, NULL, "2024",
-	"Legend of Zelda, The - 18 Hours Past (Hack, v1.11)\0", NULL, "Letterbomb", "Nintendo",
+	"Legend of Zelda, The - 18 Hours Past (Hack, v1.12)\0", NULL, "Letterbomb", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_SNES, GBF_ACTION | GBF_ADV, 0,
 	SNESGetZipName, snes_Legendofzelda18hpRomInfo, snes_Legendofzelda18hpRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
@@ -30990,10 +30990,10 @@ struct BurnDriver BurnDrvsnes_Racedrivinsa1o = {
 	512, 448, 4, 3
 };
 
-// Ranma 1/2 - Chougi Ranbu Hen (Japan)
+// Ranma 1/2 - Chougi Ranbu Hen (Hack, Framerate Imp. v1.4)
 // https://romhackplaza.org/romhacks/ranma-1-2-chougi-ranbu-hen-big-framerate-improvement-snes/
 static struct BurnRomInfo snes_Ranmahb2jfrRomDesc[] = {
-	{ "Ranma 1-2 - Chougi Ranbu Hen frameratehack v1.3 (2024)(Upsilandre).sfc", 4194304, 0x71aaff40, BRF_ESS | BRF_PRG },
+	{ "Ranma 1-2 - Chougi Ranbu Hen frameratehack v1.4 (2024)(Upsilandre).sfc", 4194304, 0x1705415f, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(snes_Ranmahb2jfr)
@@ -31001,7 +31001,7 @@ STD_ROM_FN(snes_Ranmahb2jfr)
 
 struct BurnDriver BurnDrvsnes_Ranmahb2jfr = {
 	"snes_ranmahb2jfr", "snes_ranmahb2te", NULL, NULL, "2024",
-	"Ranma 1/2 - Chougi Ranbu Hen (Hack, Framerate Imp. v1.3)\0", NULL, "Upsilandre", "Nintendo",
+	"Ranma 1/2 - Chougi Ranbu Hen (Hack, Framerate Imp. v1.4)\0", NULL, "Upsilandre", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_SNES, GBF_VSFIGHT, 0,
 	SNESGetZipName, snes_Ranmahb2jfrRomInfo, snes_Ranmahb2jfrRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
@@ -31009,11 +31009,11 @@ struct BurnDriver BurnDrvsnes_Ranmahb2jfr = {
 	512, 448, 4, 3
 };
 
-// Ranma 1/2 - Hard Battle II - Super Move Hustle (Hack, English v1.10 + Framerate Imp. v1.3)
+// Ranma 1/2 - Hard Battle II - Super Move Hustle (Hack, English v1.10 + Framerate Imp. v1.4)
 // https://www.romhacking.net/translations/3516/
 // https://romhackplaza.org/romhacks/ranma-1-2-chougi-ranbu-hen-big-framerate-improvement-snes/
 static struct BurnRomInfo snes_Ranmahb2tefrRomDesc[] = {
-	{ "Ranma 1-2 - Hard Battle II - Super Move Hustle T-Eng + frameratehack v1.3 (2024)(Upsilandre).sfc", 4194304, 0x4401b68c, BRF_ESS | BRF_PRG },
+	{ "Ranma 1-2 - Hard Battle II - Super Move Hustle T-Eng + frameratehack v1.4 (2024)(Upsilandre).sfc", 4194304, 0x22ae0893, BRF_ESS | BRF_PRG },
 };
 
 STD_ROM_PICK(snes_Ranmahb2tefr)
@@ -31021,7 +31021,7 @@ STD_ROM_FN(snes_Ranmahb2tefr)
 
 struct BurnDriver BurnDrvsnes_Ranmahb2tefr = {
 	"snes_ranmahb2tefr", "snes_ranmahb2te", NULL, NULL, "2024",
-	"Ranma 1/2 - Hard Battle II - Super Move Hustle (Hack, English v1.10 + Framerate Imp. v1.3)\0", NULL, "Dynamic-Designs - Upsilandre", "Nintendo",
+	"Ranma 1/2 - Hard Battle II - Super Move Hustle (Hack, English v1.10 + Framerate Imp. v1.4)\0", NULL, "Dynamic-Designs - Upsilandre", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_SNES, GBF_VSFIGHT, 0,
 	SNESGetZipName, snes_Ranmahb2tefrRomInfo, snes_Ranmahb2tefrRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,


### PR DESCRIPTION
d_megadrive
added: bssf2gq [as requested by author]
updated: mkaee (v2.1)

d_msx:
updated: mokarima (romFileName only, removed invalid character)

d_nes:
marioadventure3 (v1.9.9), murdmaze (version in gameName, info, romFileName)

d_snes
updated: bahalagoonts (v1.03c), dezaemonte (romFileName only, removed extra dot)
ff6rmd (2024-10-30), legendofzelda18hp (v1.12) [crcs by lolsuite]
ranmahb2jfr (v1.4), ranmahb2tefr (v1.10 / v1.4) [crcs by SoulReeverUK]