### PR TITLE
Ignore SwapBytes.c (not used and has build error in SDL fork)

### DIFF
--- a/makefile.sdl
+++ b/makefile.sdl
@@ -75,7 +75,7 @@ ifdef INCLUDE_7Z_SUPPORT
 depobj	+=	un7z.o \
 			\
 			7zArcIn.o 7zBuf.o 7zBuf2.o 7zCrc.o 7zCrcOpt.o 7zDec.o 7zFile.o 7zStream.o Alloc.o Bcj2.o Bra.o Bra86.o BraIA64.o CpuArch.o \
-			Delta.o LzFindOpt.o LzmaDec.o Lzma2Dec.o MtDec.o Ppmd7.o Ppmd7Dec.o Ppmd7aDec.o Sha256.o Sha1Opt.o Sha256Opt.o SwapBytes.o Threads.o Xxh64.o Xz.o XzCrc64.o XzCrc64Opt.o XzDec.o ZstdDec.o
+			Delta.o LzFindOpt.o LzmaDec.o Lzma2Dec.o MtDec.o Ppmd7.o Ppmd7Dec.o Ppmd7aDec.o Sha256.o Sha1Opt.o Sha256Opt.o Threads.o Xxh64.o Xz.o XzCrc64.o XzCrc64Opt.o XzDec.o ZstdDec.o
 endif
 
 autobj += $(depobj)

--- a/makefile.sdl2
+++ b/makefile.sdl2
@@ -80,7 +80,7 @@ ifdef INCLUDE_7Z_SUPPORT
 depobj	+=	un7z.o \
 			\
 			7zArcIn.o 7zBuf.o 7zBuf2.o 7zCrc.o 7zCrcOpt.o 7zDec.o 7zFile.o 7zStream.o Alloc.o Bcj2.o Bra.o Bra86.o BraIA64.o CpuArch.o \
-			Delta.o LzFindOpt.o LzmaDec.o Lzma2Dec.o MtDec.o Ppmd7.o Ppmd7Dec.o Ppmd7aDec.o Sha256.o Sha1Opt.o Sha256Opt.o SwapBytes.o Threads.o Xxh64.o Xz.o XzCrc64.o XzCrc64Opt.o XzDec.o ZstdDec.o
+			Delta.o LzFindOpt.o LzmaDec.o Lzma2Dec.o MtDec.o Ppmd7.o Ppmd7Dec.o Ppmd7aDec.o Sha256.o Sha1Opt.o Sha256Opt.o Threads.o Xxh64.o Xz.o XzCrc64.o XzCrc64Opt.o XzDec.o ZstdDec.o
 endif
 
 autobj += $(depobj)


### PR DESCRIPTION
When compiling SwapBytes.c (to be precise, cross compiling for armv7 was what I tested), fails with multiple errors like these:

`
src/dep/libs/lib7z/SwapBytes.c:598:47: error: expected ')' before ':' token
   #define SWAP2_32_VAR(v)  asm ("rev16 %0,%0" : "+r" (v)); // for clang/gcc
`

As pointed by @barbudreadmon , SwapBytes.c is not needed ( https://github.com/libretro/FBNeo/blob/master/src/burner/libretro/Makefile.common#L299-L314 ), so it should be safe to ignore.