### PR TITLE
Some changes in: MD / FDS / SNES / NG / CPS / TAITO / PRE-POST 90S

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -16996,6 +16996,7 @@ static const struct GameConfig ConfigTable[] =
 	{ "willowu"       , CPS_B_03    , mapper_WL24B , 0, NULL                },
 	{ "willowuo"      , CPS_B_03    , mapper_WL24B , 0, NULL                },
 	{ "willowj"       , CPS_B_03    , mapper_WL24B , 0, NULL                },
+	{ "willowbr"      , CPS_B_03    , mapper_WL24B , 0, NULL                },
 	{ "wof"           , CPS_B_21_QS1, mapper_TK263B, 0, wof_decode          },
 	{ "wofr1"         , CPS_B_21_DEF, mapper_TK263B, 0, wof_decode          },
 	{ "wofu"          , CPS_B_21_QS1, mapper_TK263B, 0, wof_decode          },
@@ -25785,43 +25786,6 @@ struct BurnDriverX BurnDrvCpsMbombrdu = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-static struct BurnRomInfo Sf2cebrRomDesc[] = {
-	{ "sf2cebr.23",    0x080000, 0x74e848ee, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "sf2cebr.22",    0x080000, 0xc3c49626, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-	{ "s92_21a.bin",   0x080000, 0x925a7877, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
-
-	{ "s92_01.bin",    0x080000, 0x03b0d852, BRF_GRA | CPS1_TILES },
-	{ "s92_02.bin",    0x080000, 0x840289ec, BRF_GRA | CPS1_TILES },
-	{ "s92_03.bin",    0x080000, 0xcdb5f027, BRF_GRA | CPS1_TILES },
-	{ "s92_04.bin",    0x080000, 0xe2799472, BRF_GRA | CPS1_TILES },
-	{ "s92_05.bin",    0x080000, 0xba8a2761, BRF_GRA | CPS1_TILES },
-	{ "s92_06.bin",    0x080000, 0xe584bfb5, BRF_GRA | CPS1_TILES },
-	{ "s92_07.bin",    0x080000, 0x21e3f87d, BRF_GRA | CPS1_TILES },
-	{ "s92_08.bin",    0x080000, 0xbefc47df, BRF_GRA | CPS1_TILES },
-	{ "s92br_10.bin",  0x080000, 0xb3e1dd5f, BRF_GRA | CPS1_TILES },
-	{ "s92br_11.bin",  0x080000, 0xf13af812, BRF_GRA | CPS1_TILES },
-	{ "s92br_12.bin",  0x080000, 0x10ce42af, BRF_GRA | CPS1_TILES },
-	{ "s92br_13.bin",  0x080000, 0x32cf5af3, BRF_GRA | CPS1_TILES },
-
-	{ "s92_09.bin",    0x010000, 0x08f6b60e, BRF_PRG | CPS1_Z80_PROGRAM },
-
-	{ "s92_18.bin",    0x020000, 0x7f162009, BRF_SND | CPS1_OKIM6295_SAMPLES },
-	{ "s92_19.bin",    0x020000, 0xbeade53f, BRF_SND | CPS1_OKIM6295_SAMPLES },
-};
-
-STD_ROM_PICK(Sf2cebr)
-STD_ROM_FN(Sf2cebr)
-
-struct BurnDriverX BurnDrvCpsSf2cebr = {
-	"sf2cebr", "sf2ce", NULL, NULL, "1992",
-	"Street Fighter II': Champion Edition (bootleg, Brazil)\0", NULL, "Capcom", "CPS1",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS1, GBF_VSFIGHT, FBF_SF,
-	NULL, Sf2cebrRomInfo, Sf2cebrRomName, NULL, NULL, NULL, NULL, Sf2InputInfo, Sf2DIPInfo,
-	TwelveMhzInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
-	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
-};
-
 static struct BurnRomInfo Sf2cehRomDesc[] = {
 	{ "sf2ceh.23",     0x080000, 0x25dc14c8, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
 	{ "sf2ceh.22",     0x080000, 0x1c9dd91c, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
@@ -26214,6 +26178,54 @@ struct BurnDriver BurnDrvCpsSf2mix = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
+// Street Fighter II' - Champion Edition (920313 Brasil, v1.0, Hack)
+// Modified by Alan Yagami & BisonSAS
+
+static struct BurnRomInfo Sf2cebrRomDesc[] = {
+	{ "sf2cebr.23",		0x080000, 0x74e848ee, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "sf2cebr.22",		0x080000, 0xc3c49626, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+	{ "s92_21a.6f",		0x080000, 0x925a7877, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+
+	{ "s92-1m.3a",		0x080000, 0x03b0d852, BRF_GRA | CPS1_TILES },
+	{ "s92-3m.5a",		0x080000, 0x840289ec, BRF_GRA | CPS1_TILES },
+	{ "s92-2m.4a",		0x080000, 0xcdb5f027, BRF_GRA | CPS1_TILES },
+	{ "s92-4m.6a",		0x080000, 0xe2799472, BRF_GRA | CPS1_TILES },
+	{ "s92-5m.7a",		0x080000, 0xba8a2761, BRF_GRA | CPS1_TILES },
+	{ "s92-7m.9a",		0x080000, 0xe584bfb5, BRF_GRA | CPS1_TILES },
+	{ "s92-6m.8a",		0x080000, 0x21e3f87d, BRF_GRA | CPS1_TILES },
+	{ "s92-8m.10a",		0x080000, 0xbefc47df, BRF_GRA | CPS1_TILES },
+	{ "s92br_10.bin",	0x080000, 0xb3e1dd5f, BRF_GRA | CPS1_TILES },
+	{ "s92br_11.bin",	0x080000, 0xf13af812, BRF_GRA | CPS1_TILES },
+	{ "s92br_12.bin",	0x080000, 0x10ce42af, BRF_GRA | CPS1_TILES },
+	{ "s92br_13.bin",	0x080000, 0x32cf5af3, BRF_GRA | CPS1_TILES },
+
+	{ "s92_09.11a",		0x010000, 0x08f6b60e, BRF_PRG | CPS1_Z80_PROGRAM },
+
+	{ "s92_18.11c",		0x020000, 0x7f162009, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "s92_19.12c",		0x020000, 0xbeade53f, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	
+	A_BOARD_PLDS
+	
+	{ "s9263b.1a",		0x000117, 0x0a7ecfe0, BRF_OPT },	// b-board PLDs
+	{ "iob1.12d",		0x000117, 0x3abc0700, BRF_OPT },
+	{ "bprg1.11d",		0x000117, 0x31793da7, BRF_OPT },
+	{ "ioc1.ic7",		0x000104, 0xa399772d, BRF_OPT },	// c-board PLDs
+	{ "c632.ic1",		0x000117, 0x0fbd9270, BRF_OPT },
+};
+
+STD_ROM_PICK(Sf2cebr)
+STD_ROM_FN(Sf2cebr)
+
+struct BurnDriver BurnDrvCpsSf2cebr = {
+	"sf2cebr", "sf2ce", NULL, NULL, "2005",
+	"Street Fighter II' - Champion Edition (920313 Brasil, v1.0, Hack)\0", NULL, "hack (NeoGeo BR Team)", "CPS1",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_CAPCOM_CPS1, GBF_VSFIGHT, FBF_SF,
+	NULL, Sf2cebrRomInfo, Sf2cebrRomName, NULL, NULL, NULL, NULL, Sf2InputInfo, Sf2DIPInfo,
+	TwelveMhzInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
 // Street Fighter II' - Champion Edition Golden Magic Hack
 // Files date: 2020-Oct-13
 
@@ -26315,6 +26327,53 @@ struct BurnDriver BurnDrvCpsMercsc = {
 	NULL, MercscRomInfo, MercscRomName, NULL, NULL, NULL, NULL, MercsInputInfo, MercsDIPInfo,
 	MercsInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
 	&CpsRecalcPal, 0x1000, 224, 384, 3, 4
+};
+
+//  (Portuguese-BR Translation v1.06, Hack)
+// Modified by Antígeno
+
+static struct BurnRomInfo WillowbrRomDesc[] = {
+	{ "wlbr_30.11f",	0x020000, 0x05814ce1, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "wlbr_35.11h",	0x020000, 0x48bdd898, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "wlbr_31.12f",	0x020000, 0xb188553b, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "wlbr_36.12h",	0x020000, 0x8bba3252, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_BYTESWAP },
+	{ "wlbr_32.8h",		0x080000, 0xa64d6469, BRF_ESS | BRF_PRG | CPS1_68K_PROGRAM_NO_BYTESWAP },
+
+	{ "wlbr-7m.7a",		0x080000, 0x0264d809, BRF_GRA | CPS1_TILES },
+	{ "wlbr-5m.9a",		0x080000, 0x44da08d9, BRF_GRA | CPS1_TILES },
+	{ "wlbr-3m.3a",		0x080000, 0x3f54884c, BRF_GRA | CPS1_TILES },
+	{ "wlbr-1m.5a",		0x080000, 0x8fd41c4e, BRF_GRA | CPS1_TILES },
+	{ "wlbr_24.7d",		0x020000, 0xc4d86fb2, BRF_GRA | CPS1_TILES },
+	{ "wlbr_14.7c",		0x020000, 0xfa45c4d4, BRF_GRA | CPS1_TILES },
+	{ "wlbr_26.9d",		0x020000, 0x282f95b0, BRF_GRA | CPS1_TILES },
+	{ "wlbr_16.9c",		0x020000, 0xbf6a9d5c, BRF_GRA | CPS1_TILES },
+	{ "wlbr_20.3d",		0x020000, 0x08cfa420, BRF_GRA | CPS1_TILES },
+	{ "wlbr_10.3c",		0x020000, 0x3cb28fed, BRF_GRA | CPS1_TILES },
+	{ "wlbr_22.5d",		0x020000, 0xccebdbe6, BRF_GRA | CPS1_TILES },
+	{ "wlbr_12.5c",		0x020000, 0x332ecf17, BRF_GRA | CPS1_TILES },
+
+	{ "wl_09.12b",		0x010000, 0xf6b3d060, BRF_PRG | CPS1_Z80_PROGRAM },
+
+	{ "wl_18.11c",		0x020000, 0xbde23d4d, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	{ "wl_19.12c",		0x020000, 0x683898f5, BRF_SND | CPS1_OKIM6295_SAMPLES },
+	
+	A_BOARD_PLDS
+	
+	{ "wl24b.1a",		0x000117, 0x7101cdf1, BRF_OPT },	// b-board PLDs
+	{ "lwio.11e",		0x000117, 0xad52b90c, BRF_OPT },
+};
+
+STD_ROM_PICK(Willowbr)
+STD_ROM_FN(Willowbr)
+
+struct BurnDriver BurnDrvCpsWillowbr = {
+	"willowbr", "willow", NULL, NULL, "2019",
+	"Willow (Portuguese-BR Translation v1.06, Hack)\0", NULL, "hack (Ant\u00EDgeno)", "CPS1",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS1, GBF_PLATFORM, 0,
+	NULL, WillowbrRomInfo, WillowbrRomName, NULL, NULL, NULL, NULL, WillowInputInfo, WillowDIPInfo,
+	DrvInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
 

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -15342,6 +15342,50 @@ struct BurnDriver BurnDrvCpsSfa2ultra = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
+// Street Fighter Alpha 3 (050513 Brasil) Portuguese translation version v2.0
+// Modified by Alan Yagami & BisonSAS
+
+static struct BurnRomInfo Sfa3brRomDesc[] = {
+	{ "sz3br.03c",		0x080000, 0xb2a99137, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3br.04c",		0x080000, 0x3e5cefe6, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3.05c",		0x080000, 0x57fd0a40, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3.06c",		0x080000, 0xf6305f8b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3.07c",		0x080000, 0x6eab0f6f, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3.08c",		0x080000, 0x910c4a3b, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3.09c",		0x080000, 0xb29e5199, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+	{ "sz3.10b",		0x080000, 0xdeb2ff52, CPS2_PRG_68K | BRF_ESS | BRF_PRG },
+
+	{ "sz3br.13m",		0x400000, 0xf18ffe2d, CPS2_GFX | BRF_GRA },
+	{ "sz3br.15m",		0x400000, 0x3283878c, CPS2_GFX | BRF_GRA },
+	{ "sz3br.17m",		0x400000, 0x869e0ae2, CPS2_GFX | BRF_GRA },
+	{ "sz3br.19m",		0x400000, 0x81e0ebfa, CPS2_GFX | BRF_GRA },
+	{ "sz3.14m",		0x400000, 0x5ff98297, CPS2_GFX | BRF_GRA },
+	{ "sz3.16m",		0x400000, 0x52b5bdee, CPS2_GFX | BRF_GRA },
+	{ "sz3.18m",		0x400000, 0x40631ed5, CPS2_GFX | BRF_GRA },
+	{ "sz3.20m",		0x400000, 0x763409b4, CPS2_GFX | BRF_GRA },
+
+	{ "sz3.01",			0x020000, 0xde810084, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+	{ "sz3.02",			0x020000, 0x72445dc4, CPS2_PRG_Z80 | BRF_ESS | BRF_PRG },
+
+	{ "sz3.11m",		0x400000, 0x1c89eed1, CPS2_QSND | BRF_SND },
+	{ "sz3.12m",		0x400000, 0xf392b13a, CPS2_QSND | BRF_SND },
+	
+	{ "sfa3u.key",		0x000014, 0x4a8f98c1, CPS2_ENCRYPTION_KEY },
+};
+
+STD_ROM_PICK(Sfa3br)
+STD_ROM_FN(Sfa3br)
+
+struct BurnDriver BurnDrvCpsSfa3br = {
+	"sfa3br", "sfa3", NULL, NULL, "2005",
+	"Street Fighter Alpha 3 (050513 Brasil, v2.0, Hack)\0", "Portuguese translation", "hack (NeoGeo BR Team)", "CPS2",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, FBF_SF,
+	NULL, Sfa3brRomInfo, Sfa3brRomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,
+	Cps2Init, DrvExit, Cps2Frame, CpsRedraw, CpsAreaScan,
+	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
+};
+
 // X-Men Vs. Street Fighter (Coop, Hack)
 // Modified by bankbank
 // 202205

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -47830,11 +47830,11 @@ struct BurnDriver BurnDrvmd_btomatog = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)
+// Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.7)
 // https://romhackplaza.org/romhacks/bishoujo-super-street-fighter-ii-glamor-queen-genesis/
 
 static struct BurnRomInfo md_bssf2gqRomDesc[] = {
-	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.6 (2024)(Yoni Arousement).bin", 5242880, 0xf8aab4d4, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Bishoujo Super Street Fighter II - Glamor Queen v1.7 (2024)(Yoni Arousement).bin", 5242880, 0x6ed2530f, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_bssf2gq)
@@ -47842,7 +47842,7 @@ STD_ROM_FN(md_bssf2gq)
 
 struct BurnDriver BurnDrvmd_bssf2gq = {
 	"md_bssf2gq", "md_ssf2", NULL, NULL, "2024",
-	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.6)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
+	"Bishoujo Super Street Fighter II: Glamor Queen (Hack, v1.7)\0", NULL, "hack (Yoni Arousement)", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 2, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SSF2, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_bssf2gqRomInfo, md_bssf2gqRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -49230,6 +49230,25 @@ struct BurnDriver BurnDrvmd_landstlkc = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 1, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_SRAM | HARDWARE_SEGA_MEGADRIVE_SRAM_10000, GBF_PLATFORM | GBF_RPG, 0,
 	MegadriveGetZipName, md_landstlkcRomInfo, md_landstlkcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Landstalker - The Emperor's Treasure Remix (Hack, v1.0)
+// https://romhackplaza.org/romhacks/landstalker-remix-genesis/
+static struct BurnRomInfo md_landstlkrmxRomDesc[] = {
+	{ "Landstalker - The Emperor's Treasure Remix v1.0 (2024)(paleskies).bin", 2097152, 0x34083de3, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_landstlkrmx)
+STD_ROM_FN(md_landstlkrmx)
+
+struct BurnDriver BurnDrvmd_landstlkrmx = {
+	"md_landstlkrmx", "md_landstlk", NULL, NULL, "2024",
+	"Landstalker - The Emperor's Treasure Remix (Hack, v1.0)\0", NULL, "Sega", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE, 1, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_SRAM | HARDWARE_SEGA_MEGADRIVE_SRAM_10000, GBF_PLATFORM | GBF_RPG, 0,
+	MegadriveGetZipName, md_landstlkrmxRomInfo, md_landstlkrmxRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -16695,6 +16695,42 @@ struct BurnDriver BurnDrvNinjamasha = {
 	0x1000,	320, 224, 4, 3
 };
 
+// Rage of the Dragons (Portuguese Edition, Hack)
+// Modified by BisonSAS
+
+ static struct BurnRomInfo rotdbrRomDesc[] = {
+	{ "264-p1br.p1",	0x800000, 0x8a973ecf, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	
+	{ "264-s1br.s1",	0x020000, 0x28b387d6, 2 | BRF_GRA | BRF_PRG }, //  1 Text layer tile
+
+	{ "264-c1d.c1",		0x800000, 0xec9d18c0, 3 | BRF_GRA },           //  1 Sprite data
+	{ "264-c2d.c2",		0x800000, 0xb1069066, 3 | BRF_GRA },           //  2
+	{ "264-c3d.c3",		0x800000, 0x7e636d49, 3 | BRF_GRA },           //  3
+	{ "264-c4d.c4",		0x800000, 0x76892fda, 3 | BRF_GRA },           //  4
+	{ "264-c5d.c5",		0x800000, 0x469061bc, 3 | BRF_GRA },           //  5
+	{ "264-c6d.c6",		0x800000, 0x2200220a, 3 | BRF_GRA },           //  6
+	{ "264-c7d.c7",		0x800000, 0xedda4baf, 3 | BRF_GRA },           //  7
+	{ "264-c8d.c8",		0x800000, 0x82b1ba22, 3 | BRF_GRA },           //  8
+
+	{ "264-m1d.m1",		0x020000, 0xc5d36af9, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
+
+	{ "264-v1d.v1",		0x800000, 0x2c49f3fa, 5 | BRF_SND },           // 10 Sound data
+	{ "264-v2d.v2",		0x800000, 0x967279da, 5 | BRF_SND },           // 11
+};
+
+STDROMPICKEXT(rotdbr, rotdbr, neogeo)
+STD_ROM_FN(rotdbr)
+
+struct BurnDriver BurnDrvRotdbr = {
+	"rotdbr", "rotd", "neogeo", NULL, "2005",
+	"Rage of the Dragons (Portuguese edition, Hack)\0", NULL, "hack (NeoGeo BR Team)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, 0,
+	NULL, rotdbrRomInfo, rotdbrRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000,	320, 224, 4, 3
+};
+
 
 // Super Dodge Ball / Kunio no Nekketsu Toukyuu Densetsu (Secret Character Hack)
 // Unlock MAOU TEAM - hack by PlayerX
@@ -16731,6 +16767,39 @@ struct BurnDriver BurnDrvSdodgebh = {
 // -----------------------------------------------------------------------------
 // Art of Fighting / Art of Fighting Series
 // -----------------------------------------------------------------------------
+
+// Art of Fighting / Ryuuko no Ken (Portuguese Edition v1.0, Hack)
+// Modified by Mr.Fox (aka devilfox) & BisonSAS
+
+static struct BurnRomInfo aofbrRomDesc[] = {
+	{ "044-p1br.p1",	0x080000, 0xea8577a1, 1 | BRF_ESS | BRF_PRG }, //  0 68K Code
+
+	{ "044-s1br.s1",	0x020000, 0xa6d76be7, 2 | BRF_GRA },           //  1 Text layer tiles
+
+	{ "044-c1.c1",		0x200000, 0xddab98a7, 3 | BRF_GRA },           //  2 Sprite data
+	{ "044-c2.c2",		0x200000, 0xd8ccd575, 3 | BRF_GRA },           //  3
+	{ "044-c3br.c3",	0x200000, 0x7b312e56, 3 | BRF_GRA },	          //  4
+	{ "044-c4br.c4",	0x200000, 0x4d31b52b, 3 | BRF_GRA },	          //  5
+
+	{ "044-m1.m1",		0x020000, 0x0987e4bb, 4 | BRF_ESS | BRF_PRG }, //  6 Z80 code
+
+	{ "044-v2.v2",		0x200000, 0x3ec632ea, 5 | BRF_SND },           //  7 Sound data
+	{ "044-v4.v4",		0x200000, 0x4b0f8e23, 5 | BRF_SND },           //  8
+};
+
+STDROMPICKEXT(aofbr, aofbr, neogeo)
+STD_ROM_FN(aofbr)
+
+struct BurnDriver BurnDrvAofbr = {
+	"aofbr", "aof", "neogeo", NULL, "2016",
+	"Art of Fighting / Ryuuko no Ken (Portuguese edition v1.0, Hack)\0", NULL, "hack (NeoGeo BR Team)", "Neo Geo MVS",
+	L"Art of Fighting\0\u9F8D\u864E\u306E\u62F3 (Portuguese Edition)\0", NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_SWAPC, GBF_VSFIGHT, 0,
+	NULL, aofbrRomInfo, aofbrRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
 
 #define AOF2_COMPONENTS													\
 	{ "056-s1.s1",    0x020000, 0x8b02638e, 2 | BRF_GRA },				\
@@ -25724,6 +25793,29 @@ struct BurnDriver BurnDrvKof2k2omg9 = {
 	0x1000,	304, 224, 4, 3
 };
 
+// The King of Fighters 2002 (Portuguese Edition, Hack)
+// Modified by KyoX
+
+static struct BurnRomInfo kof2k2brRomDesc[] = {
+	{ "265-p1br.p1",	0x100000, 0x95986d7a, 1 | BRF_ESS | BRF_PRG },
+	{ "265-p2br.sp2",	0x400000, 0x9b4d2ba4, 1 | BRF_ESS | BRF_PRG },
+
+	KOF2002_DECRYPTED_COMPONENTS
+};
+
+STDROMPICKEXT(kof2k2br, kof2k2br, neogeo)
+STD_ROM_FN(kof2k2br)
+
+struct BurnDriver BurnDrvKof2k2br = {
+	"kof2k2br", "kof2002", "neogeo", NULL, "2005",
+	"The King of Fighters 2002 (Portuguese Edition, Hack)\0", NULL, "hack (NeoGeo BR Team)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof2k2brRomInfo, kof2k2brRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
+};
+
 #define KOF10TH_DECRYPTED_SOUND											\
 	{ "kf10-m1.bin",	0x020000, 0xf6fab859, 4 | BRF_ESS | BRF_PRG },	\
 	{ "kf10-v1.bin",	0x800000, 0x0fc9a58d, 5 | BRF_SND },			\
@@ -25986,6 +26078,38 @@ struct BurnDriver BurnDrvKf2k3p2s = {
 	NULL, kf2k3p2sRomInfo, kf2k3p2sRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
 	kof2003Init, NeoPVCExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
+};
+
+// The King of Fighters 2003 (Portuguese Edition, Hack)
+// Modified by Mr.Fox (aka devilfox) & BisonSAS
+
+static struct BurnRomInfo kof2k3brRomDesc[] = {
+	{ "271-p1br.p1",	0x800000, 0xa131786e, 1 | BRF_ESS | BRF_PRG },
+	
+	KOF2003_DECRYPTED_TEXT
+	
+	KOF2003_DECRYPTED_SPR1
+	KOF2003_DECRYPTED_SPR2
+	KOF2003_DECRYPTED_SPR3
+	{ "271-c7br.c7",	0x800000, 0xf3d81b6e, 3 | BRF_GRA },
+	{ "271-c8br.c8",	0x800000, 0x5310c6dc, 3 | BRF_GRA },
+
+	KOF2003_DECRYPTED_Z80
+	
+	KOF2003_DECRYPTED_SND
+};
+
+STDROMPICKEXT(kof2k3br, kof2k3br, neogeo)
+STD_ROM_FN(kof2k3br)
+
+struct BurnDriver BurnDrvKof2k3br = {
+	"kof2k3br", "kof2003", "neogeo", NULL, "2005",
+	"The King of Fighters 2003 (Portuguese Edition, Hack)\0", NULL, "hack (NeoGeo BR Team)", "Neo Geo MVS",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_ALTERNATE_TEXT, GBF_VSFIGHT, FBF_KOF,
+	NULL, kof2k3brRomInfo, kof2k3brRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
+	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	0x1000, 304, 224, 4, 3
 };
 
 

--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -12556,18 +12556,37 @@ struct BurnDriver BurnDrvfds_drcha = {
 };
 
 // Dracula II - Noroi no Fuuin (Japan)
-static struct BurnRomInfo fds_dracuiiRomDesc[] = {
+static struct BurnRomInfo fds_dracuiijRomDesc[] = {
 	{ "Dracula II - Noroi no Fuuin (Japan)(1987)(Konami).fds",          131016, 0x2d1ec77c, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(fds_dracuiij, fds_dracuiij, fds_fdsbios)
+STD_ROM_FN(fds_dracuiij)
+
+struct BurnDriver BurnDrvfds_dracuiij = {
+	"fds_dracuiij", "fds_dracuii", "fds_fdsbios", NULL, "1987",
+	"Dracula II - Noroi no Fuuin (Japan)\0", NULL, "Konami", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_FDS, GBF_PLATFORM | GBF_ADV, 0,
+	NESGetZipName, fds_dracuiijRomInfo, fds_dracuiijRomName, NULL, NULL, NULL, NULL, NESFDSInputInfo, NESFDSDIPInfo,
+	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
+// Dracula II - The Cursed Seal (Hack, English v1.0)
+// https://romhackplaza.org/translations/dracula-ii-noroi-no-fuuin-english-translation-fds/
+static struct BurnRomInfo fds_dracuiiRomDesc[] = {
+	{ "Dracula II - The Cursed Seal T-Eng v1.0 (2024)(BlackPaladin).fds",          131016, 0x3251423f, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(fds_dracuii, fds_dracuii, fds_fdsbios)
 STD_ROM_FN(fds_dracuii)
 
 struct BurnDriver BurnDrvfds_dracuii = {
-	"fds_dracuii", NULL, "fds_fdsbios", NULL, "1987",
-	"Dracula II - Noroi no Fuuin (Japan)\0", NULL, "Konami", "Miscellaneous",
+	"fds_dracuii", NULL, "fds_fdsbios", NULL, "2024",
+	"Dracula II - The Cursed Seal (Hack, English v1.0)\0", NULL, "BlackPaladin", "Miscellaneous",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING, 1, HARDWARE_FDS, GBF_PLATFORM | GBF_ADV, 0,
+	BDF_GAME_WORKING | BDF_HACK, 1, HARDWARE_FDS, GBF_PLATFORM | GBF_ADV, 0,
 	NESGetZipName, fds_dracuiiRomInfo, fds_dracuiiRomName, NULL, NULL, NULL, NULL, NESFDSInputInfo, NESFDSDIPInfo,
 	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT

--- a/src/burn/drv/pre90s/d_toki.cpp
+++ b/src/burn/drv/pre90s/d_toki.cpp
@@ -1855,3 +1855,48 @@ struct BurnDriver BurnDrvTokib = {
 	TokibInit, DrvExit, TokibFrame, TokibDraw, DrvScan, &DrvRecalc, 0x400,
 	256, 224, 4, 3
 };
+
+// -----------------------------------------------------------------------------
+// Hacks and Translations
+// -----------------------------------------------------------------------------
+
+// Toki (Portuguese-BR Translation v1.07, Hack)
+// Modified by Antígeno
+
+static struct BurnRomInfo tokibrRomDesc[] = {
+	{ "tokibr_6e.m10",		0x20000, 0xbac99bd8, 1 | BRF_PRG | BRF_ESS }, //  0 68k Code
+	{ "tokibr_4e.k10",		0x20000, 0x18318c36, 1 | BRF_PRG | BRF_ESS }, //  1
+	{ "tokibr_5.m12",		0x10000, 0x01dde064, 1 | BRF_PRG | BRF_ESS }, //  2
+	{ "tokibr_3.k12",		0x10000, 0xe443c83f, 1 | BRF_PRG | BRF_ESS }, //  3
+
+	{ "8.m3",				0x02000, 0x6c87c4c5, 2 | BRF_PRG | BRF_ESS }, //  4 Z80 Code (encrypted)
+	{ "7.m7",				0x10000, 0xa67969c4, 2 | BRF_PRG | BRF_ESS }, //  5
+
+	{ "tokibr_1.c5",		0x10000, 0x6c15674d, 3 | BRF_GRA },           //  6 Characters
+	{ "tokibr_2.c3",		0x10000, 0x72b52e63, 3 | BRF_GRA },           //  7
+
+	{ "tokibr_obj1.c20",	0x80000, 0x9233d8bf, 4 | BRF_GRA },           //  8 Background Tiles
+	{ "tokibr_obj2.c22",	0x80000, 0x483cc50a, 4 | BRF_GRA },           //  9
+
+	{ "toki_bk1.cd8",		0x80000, 0xfdaa5f4b, 5 | BRF_GRA },           // 10 Foreground Tiles
+
+	{ "tokibr_bk2.ef8",		0x80000, 0x5a18182b, 6 | BRF_GRA },           // 11 Sprites
+
+	{ "9.m1",				0x20000, 0xae7a6b8b, 7 | BRF_SND },           // 12 MSM6295 Samples
+	
+	{ "prom27.j3",			0x00100, 0xe616ae85, 0 | BRF_OPT },
+	{ "prom26.b6",			0x00100, 0xea6312c6, 0 | BRF_OPT },
+};
+
+STD_ROM_PICK(tokibr)
+STD_ROM_FN(tokibr)
+
+struct BurnDriver BurnDrvTokibr = {
+	"tokibr", "toki", NULL, NULL, "2019",
+	"Toki (Portuguese-BR Translation v1.07, Hack)\0", NULL, "hack (Ant\u00EDgeno)", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_MISC_PRE90S, GBF_RUNGUN, 0,
+	NULL, tokibrRomInfo, tokibrRomName, NULL, NULL, NULL, NULL, TokiInputInfo, TokiDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x400,
+	256, 224, 4, 3
+};

--- a/src/burn/drv/pst90s/d_powerins.cpp
+++ b/src/burn/drv/pst90s/d_powerins.cpp
@@ -790,7 +790,7 @@ static INT32 powerinsInit()
 
 	m6295size = 0x80000 * 4 * 2;
 
-	if ( strcmp(BurnDrvGetTextA(DRV_NAME), "powerins") == 0 || strcmp(BurnDrvGetTextA(DRV_NAME), "powerinsj") == 0) {
+	if ( strcmp(BurnDrvGetTextA(DRV_NAME), "powerins") == 0 || strcmp(BurnDrvGetTextA(DRV_NAME), "powerinsj") == 0 || strcmp(BurnDrvGetTextA(DRV_NAME), "powernbr") == 0) {
 		game_drv = GAME_POWERINS;
 	} else
 	if ( strcmp(BurnDrvGetTextA(DRV_NAME), "powerinsa") == 0 ) {
@@ -1556,6 +1556,59 @@ struct BurnDriver BurnDrvPowerinsc = {
 	NULL, NULL, NULL, NULL,
 	BDF_CLONE | BDF_BOOTLEG | BDF_HISCORE_SUPPORTED, 2, HARDWARE_MISC_POST90S, GBF_VSFIGHT, FBF_PWRINST,
 	NULL, powerinscRomInfo, powerinscRomName, NULL, NULL, NULL, NULL, powerinsInputInfo, powerinsDIPInfo,
+	powerinsInit, powerinsExit, powerinsFrame, DrvDraw, powerinsScan, &bRecalcPalette, 0x800,
+	320, 224, 4, 3
+};
+
+// -----------------------------------------------------------------------------
+// Hacks and Translations
+// -----------------------------------------------------------------------------
+
+// Power Instinct (Brasil) Portuguese translation v1.0
+// Modified by Mr.Fox (aka devilfox) & BisonSAS
+
+static struct BurnRomInfo powernbrRomDesc[] = {
+	{ "93095-3br.u108",	0x080000, 0x522e776a, BRF_ESS | BRF_PRG },	// 68000 code
+	{ "93095-4.u109",	0x080000, 0xd3d7a782, BRF_ESS | BRF_PRG },	//  1
+
+	{ "93095-2.u90",	0x020000, 0x4b123cc6, BRF_ESS | BRF_PRG },	//  2 Z80 code
+
+	{ "93095-5.u16",	0x100000, 0xb1371808, BRF_GRA }, 			//  3 layer 0
+	{ "93095-6br.u17",	0x100000, 0x4a7a6bd8, BRF_GRA },
+	{ "93095-7.u18",	0x080000, 0x2dd76149, BRF_GRA },			//  5
+
+	{ "93095-1br.u15",	0x020000, 0x7e73e1d8, BRF_GRA }, 			//  6 layer 1
+
+	{ "93095-12.u116",	0x100000, 0x35f3c2a3, BRF_GRA },			//  7 sprites
+	{ "93095-13.u117",	0x100000, 0x1ebd45da, BRF_GRA },			//  8
+	{ "93095-14.u118",	0x100000, 0x760d871b, BRF_GRA },			//  9
+	{ "93095-15.u119",	0x100000, 0xd011be88, BRF_GRA },			// 10
+	{ "93095-16.u120",	0x100000, 0xa9c16c9c, BRF_GRA },			// 11
+	{ "93095-17.u121",	0x100000, 0x51b57288, BRF_GRA },			// 12
+	{ "93095-18.u122",	0x100000, 0xb135e3f2, BRF_GRA },			// 13
+	{ "93095-19.u123",	0x100000, 0x67695537, BRF_GRA },			// 14
+
+	{ "93095-10.u48",	0x100000, 0x329ac6c5, BRF_SND }, 			// 15 sound 1
+	{ "93095-11.u49",	0x100000, 0x75d6097c, BRF_SND },			// 16
+
+	{ "93095-8.u46",	0x100000, 0xf019bedb, BRF_SND }, 			// 17 sound 2
+	{ "93095-9.u47",	0x100000, 0xadc83765, BRF_SND },			// 18
+
+	{ "22.u81",			0x000020, 0x67d5ec4b, BRF_OPT },			// 19 unknown
+	{ "21.u71",			0x000100, 0x182cd81f, BRF_OPT },			// 20
+	{ "20.u54",			0x000100, 0x38bd0e2f, BRF_OPT },			// 21
+
+};
+
+STD_ROM_PICK(powernbr)
+STD_ROM_FN(powernbr)
+
+struct BurnDriver BurnDrvPowernbr = {
+	"powernbr", "powerins", NULL, NULL, "2006",
+	"Power Instinct (Brasil)(Hack, v1.0)\0", "Portuguese translation", "hack (NeoGeo BR Team)", "Miscellaneous",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_MISC_POST90S, GBF_VSFIGHT, FBF_PWRINST,
+	NULL, powernbrRomInfo, powernbrRomName, NULL, NULL, NULL, NULL, powerinsInputInfo, powerinsDIPInfo,
 	powerinsInit, powerinsExit, powerinsFrame, DrvDraw, powerinsScan, &bRecalcPalette, 0x800,
 	320, 224, 4, 3
 };

--- a/src/burn/drv/snes/d_snes.cpp
+++ b/src/burn/drv/snes/d_snes.cpp
@@ -3527,6 +3527,25 @@ struct BurnDriver BurnDrvsnes_Blackthornej = {
 	512, 448, 4, 3
 };
 
+// Blackthorne (Hack, Portuguese v1.02)
+// https://www.romhacking.net/translations/7196/
+static struct BurnRomInfo snes_BlackthornetpRomDesc[] = {
+	{ "Blackthorne T-Por v1.02 (2024)(Dindo, Rod Merida).sfc", 1048576, 0x03cc4c7d, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Blackthornetp)
+STD_ROM_FN(snes_Blackthornetp)
+
+struct BurnDriver BurnDrvsnes_Blackthornetp = {
+	"snes_blackthornetp", "snes_blackthorne", NULL, NULL, "2024",
+	"Blackthorne (Hack, Portuguese v1.02)\0", NULL, "Dindo, Rod Merida", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_SNES, GBF_RUNGUN | GBF_PLATFORM, 0,
+	SNESGetZipName, snes_BlackthornetpRomInfo, snes_BlackthornetpRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
 // Blazing Skies (Euro)
 
 static struct BurnRomInfo snes_BlazingskiesRomDesc[] = {
@@ -4511,6 +4530,44 @@ struct BurnDriver BurnDrvsnes_Captsubasa3ts = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_SNES, GBF_SPORTSFOOTBALL | GBF_RPG, 0,
 	SNESGetZipName, snes_Captsubasa3tsRomInfo, snes_Captsubasa3tsRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
+// Captain Tsubasa IV - Pro no Rival Tachi (Japan)
+
+static struct BurnRomInfo snes_Captsubasa4jRomDesc[] = {
+	{ "Captain Tsubasa IV - Pro no Rival Tachi (Japan)(1993)(Tecmo).sfc", 1572864, 0x3e04b246, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Captsubasa4j)
+STD_ROM_FN(snes_Captsubasa4j)
+
+struct BurnDriver BurnDrvsnes_Captsubasa4j = {
+	"snes_captsubasa4j", NULL, NULL, NULL, "1993",
+	"Captain Tsubasa IV - Pro no Rival Tachi (Japan)\0", NULL, "Tecmo", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_SPORTSFOOTBALL | GBF_RPG, 0,
+	SNESGetZipName, snes_Captsubasa4jRomInfo, snes_Captsubasa4jRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
+// Captain Tsubasa V - Hasha no Shougou Campione (Japan)
+
+static struct BurnRomInfo snes_Captsubasa5jRomDesc[] = {
+	{ "Captain Tsubasa V - Hasha no Shougou Canpione (Japan)(1994)(Tecmo).sfc", 2097152, 0xe2b26d99, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Captsubasa5j)
+STD_ROM_FN(snes_Captsubasa5j)
+
+struct BurnDriver BurnDrvsnes_Captsubasa5j = {
+	"snes_captsubasa5j", NULL, NULL, NULL, "1994",
+	"Captain Tsubasa V - Hasha no Shougou Campione (Japan)\0", NULL, "Tecmo", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_SPORTSFOOTBALL | GBF_RPG, 0,
+	SNESGetZipName, snes_Captsubasa5jRomInfo, snes_Captsubasa5jRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
 	512, 448, 4, 3
 };
@@ -19354,6 +19411,25 @@ struct BurnDriver BurnDrvsnes_Qbert3j = {
 	512, 448, 4, 3
 };
 
+// Quinty
+
+static struct BurnRomInfo snes_QuintyRomDesc[] = {
+	{ "Quinty (1999)(Game Freak).sfc", 2097152, 0x1225927b, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Quinty)
+STD_ROM_FN(snes_Quinty)
+
+struct BurnDriver BurnDrvsnes_Quinty = {
+	"snes_quinty", NULL, NULL, NULL, "1999",
+	"Quinty (Japan, Prototype)\0", NULL, "Game Freak", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_PROTOTYPE, 1, HARDWARE_SNES, GBF_MISC, 0,
+	SNESGetZipName, snes_QuintyRomInfo, snes_QuintyRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
 // Race Drivin' (USA)
 
 static struct BurnRomInfo snes_RacedrivinRomDesc[] = {
@@ -20965,6 +21041,44 @@ struct BurnDriver BurnDrvsnes_Seikdens2 = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SNES, GBF_ACTION | GBF_RPG, 0,
 	SNESGetZipName, snes_Seikdens2RomInfo, snes_Seikdens2RomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
+// Seiken Densetsu 3 (Japan)
+
+static struct BurnRomInfo snes_Seikdens3jRomDesc[] = {
+	{ "Seiken Densetsu 3 (Japan)(1995)(Squaresoft).sfc", 4194304, 0x863ed0b8, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Seikdens3j)
+STD_ROM_FN(snes_Seikdens3j)
+
+struct BurnDriver BurnDrvsnes_Seikdens3j = {
+	"snes_seikdens3j", "snes_seikdens3te", NULL, NULL, "1993",
+	"Seiken Densetsu 3 (Japan)\0", NULL, "Squaresoft", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SNES, GBF_ACTION | GBF_RPG, 0,
+	SNESGetZipName, snes_Seikdens3jRomInfo, snes_Seikdens3jRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
+// Seiken Densetsu 3 (Hack, English v1.01)
+// https://www.romhacking.net/translations/440/
+static struct BurnRomInfo snes_Seikdens3teRomDesc[] = {
+	{ "Seiken Densetsu 3 T-Eng v1.01 (2000)(LNF Translations, Neill Corlett, SoM2Freak).sfc", 4194304, 0x7dbde871, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Seikdens3te)
+STD_ROM_FN(snes_Seikdens3te)
+
+struct BurnDriver BurnDrvsnes_Seikdens3te = {
+	"snes_seikdens3te", NULL, NULL, NULL, "2000",
+	"Seiken Densetsu 3 (Hack, English v1.01)\0", NULL, "LNF Translations, Neill Corlett, SoM2Freak", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HACK, 1, HARDWARE_SNES, GBF_ACTION | GBF_RPG, 0,
+	SNESGetZipName, snes_Seikdens3teRomInfo, snes_Seikdens3teRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
 	512, 448, 4, 3
 };
@@ -24333,6 +24447,25 @@ struct BurnDriver BurnDrvsnes_Supchiworldte = {
 	512, 478, 4, 3
 };
 
+// Super Conflict (USA)
+
+static struct BurnRomInfo snes_SconflictRomDesc[] = {
+	{ "Super Conflict (USA)(1993)(Vic Tokai).sfc", 1048576, 0xf254d5cf, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Sconflict)
+STD_ROM_FN(snes_Sconflict)
+
+struct BurnDriver BurnDrvsnes_Sconflict = {
+	"snes_sconflict", NULL, NULL, NULL, "1993",
+	"Super Conflict (USA)\0", NULL, "Vic Tokai", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_STRATEGY, 0,
+	SNESGetZipName, snes_SconflictRomInfo, snes_SconflictRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
 // Super Cup Soccer (Japan)
 
 static struct BurnRomInfo snes_SupcupsoccerRomDesc[] = {
@@ -25697,6 +25830,25 @@ struct BurnDriver BurnDrvsnes_Supervalisj = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SNES, GBF_PLATFORM, 0,
 	SNESGetZipName, snes_SupervalisjRomInfo, snes_SupervalisjRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
+// Super Variable Geo (Japan)
+
+static struct BurnRomInfo snes_SvgeoRomDesc[] = {
+	{ "Super Variable Geo (Japan)(1995)(TGL).sfc", 3145728, 0xde3262e7, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Svgeo)
+STD_ROM_FN(snes_Svgeo)
+
+struct BurnDriver BurnDrvsnes_Svgeo = {
+	"snes_svgeo", NULL, NULL, NULL, "1995",
+	"Super Variable Geo (Japan)\0", NULL, "TGL", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_VSFIGHT, 0,
+	SNESGetZipName, snes_SvgeoRomInfo, snes_SvgeoRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
 	512, 448, 4, 3
 };
@@ -29465,40 +29617,40 @@ struct BurnDriver BurnDrvsnes_Ys4te = {
 
 // Yuu Yuu Hakusho
 
-static struct BurnRomInfo snes_YuuyuuhakushoRomDesc[] = {
+static struct BurnRomInfo snes_YuuyuuhakRomDesc[] = {
 	{ "Yuu Yuu Hakusho (1993)(Namcot).sfc", 2097152, 0xec96d517, BRF_ESS | BRF_PRG },
 };
 
-STD_ROM_PICK(snes_Yuuyuuhakusho)
-STD_ROM_FN(snes_Yuuyuuhakusho)
+STD_ROM_PICK(snes_Yuuyuuhak)
+STD_ROM_FN(snes_Yuuyuuhak)
 
-struct BurnDriver BurnDrvsnes_Yuuyuuhakusho = {
-	"snes_yuuyuuhakusho", NULL, NULL, NULL, "1993",
+struct BurnDriver BurnDrvsnes_Yuuyuuhak = {
+	"snes_yuuyuuhak", NULL, NULL, NULL, "1993",
 	"Yuu Yuu Hakusho (Japan)\0", NULL, "Namcot", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_VSFIGHT, 0,
-	SNESGetZipName, snes_YuuyuuhakushoRomInfo, snes_YuuyuuhakushoRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	SNESGetZipName, snes_YuuyuuhakRomInfo, snes_YuuyuuhakRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
 	512, 448, 4, 3
 };
 
 // Yuu Yuu Hakusho Final - Makai Saikyou Retsuden
 
-static struct BurnRomInfo snes_YuuyuuhakushofinalRomDesc[] = {
+static struct BurnRomInfo snes_YuuyuufinRomDesc[] = {
 	{ "Yuu Yuu Hakusho Final - Makai Saikyou Retsuden (1995)(Namcot).sfc", 3145728, 0x5617a42e, BRF_ESS | BRF_PRG },
 };
 
-STD_ROM_PICK(snes_Yuuyuuhakushofinal)
-STD_ROM_FN(snes_Yuuyuuhakushofinal)
+STD_ROM_PICK(snes_Yuuyuufin)
+STD_ROM_FN(snes_Yuuyuufin)
 
-struct BurnDriver BurnDrvsnes_Yuuyuuhakushofinal = {
-	"snes_yuuyuuhakushofinal", NULL, NULL, NULL, "1995",
+struct BurnDriver BurnDrvsnes_Yuuyuufin = {
+	"snes_yuuyuufin", NULL, NULL, NULL, "1995",
 	"Yuu Yuu Hakusho Final - Makai Saikyou Retsuden (Japan)\0", NULL, "Namcot", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_VSFIGHT, 0,
-	SNESGetZipName, snes_YuuyuuhakushofinalRomInfo, snes_YuuyuuhakushofinalRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	SNESGetZipName, snes_YuuyuufinRomInfo, snes_YuuyuufinRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
-	512, 480, 4, 3
+	512, 448, 4, 3
 };
 
 // Yuu Yuu Hakusho 2 - Kakutou no Shou (Japan)
@@ -29520,21 +29672,40 @@ struct BurnDriver BurnDrvsnes_Yuuyuuhak2j = {
 	512, 448, 4, 3
 };
 
+// Yu Yu Hakusho 2 - The Fighting Chapter (Hack, Portuguese v1.0)
+// https://www.romhacking.net/translations/7223/
+static struct BurnRomInfo snes_Yuuyuuhak2tpRomDesc[] = {
+	{ "Yu Yu Hakusho 2 - The Fighting Chapter T-Por v1.0 (2024)(Hextinkers).sfc", 2097152, 0x52ac1195, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(snes_Yuuyuuhak2tp)
+STD_ROM_FN(snes_Yuuyuuhak2tp)
+
+struct BurnDriver BurnDrvsnes_Yuuyuuhak2tp = {
+	"snes_yuuyuuhak2tp", "snes_yuuyuuhak2j", NULL, NULL, "2024",
+	"Yu Yu Hakusho 2 - The Fighting Chapter (Hack, Portuguese v1.0)\0", NULL, "Hextinkers", "Nintendo",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_SNES, GBF_VSFIGHT, 0,
+	SNESGetZipName, snes_Yuuyuuhak2tpRomInfo, snes_Yuuyuuhak2tpRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
+	512, 448, 4, 3
+};
+
 // Yuu Yuu Hakusho - Tokubetsu Hen (Japan)
 
-static struct BurnRomInfo snes_YuuyuuhakjRomDesc[] = {
+static struct BurnRomInfo snes_YuuyuutokuRomDesc[] = {
 	{ "Yuu Yuu Hakusho - Tokubetsu Hen (J)(1994)(Namco).sfc", 2097152, 0x535cccac, BRF_ESS | BRF_PRG },
 };
 
-STD_ROM_PICK(snes_Yuuyuuhakj)
-STD_ROM_FN(snes_Yuuyuuhakj)
+STD_ROM_PICK(snes_Yuuyuutoku)
+STD_ROM_FN(snes_Yuuyuutoku)
 
-struct BurnDriver BurnDrvsnes_Yuuyuuhakj = {
-	"snes_yuuyuuhakj", NULL, NULL, NULL, "1994",
+struct BurnDriver BurnDrvsnes_Yuuyuutoku = {
+	"snes_yuuyuutoku", NULL, NULL, NULL, "1994",
 	"Yuu Yuu Hakusho - Tokubetsu Hen (Japan)\0", NULL, "Namco", "Nintendo",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 2, HARDWARE_SNES, GBF_VSFIGHT | GBF_ADV, 0,
-	SNESGetZipName, snes_YuuyuuhakjRomInfo, snes_YuuyuuhakjRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
+	SNESGetZipName, snes_YuuyuutokuRomInfo, snes_YuuyuutokuRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
 	512, 448, 4, 3
 };
@@ -31804,25 +31975,6 @@ struct BurnDriver BurnDrvsnes_Zombies2h = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_SNES, GBF_RUNGUN, 0,
 	SNESGetZipName, snes_Zombies2hRomInfo, snes_Zombies2hRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
-	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
-	512, 448, 4, 3
-};
-
-// Quinty
-
-static struct BurnRomInfo snes_QuintyRomDesc[] = {
-	{ "Quinty (1999)(Game Freak).sfc", 2097152, 0x1225927b, BRF_ESS | BRF_PRG },
-};
-
-STD_ROM_PICK(snes_Quinty)
-STD_ROM_FN(snes_Quinty)
-
-struct BurnDriver BurnDrvsnes_Quinty = {
-	"snes_quinty", NULL, NULL, NULL, "1999",
-	"Quinty (Japan, Prototype)\0", NULL, "Game Freak", "Nintendo",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_PROTOTYPE, 1, HARDWARE_SNES, GBF_MISC, 0,
-	SNESGetZipName, snes_QuintyRomInfo, snes_QuintyRomName, NULL, NULL, NULL, NULL, SNESInputInfo, SNESDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x8000,
 	512, 448, 4, 3
 };

--- a/src/burn/drv/taito/d_taitomisc.cpp
+++ b/src/burn/drv/taito/d_taitomisc.cpp
@@ -6425,3 +6425,46 @@ struct BurnDriver BurnDrvVolfieduo = {
 	VolfiedInit, TaitoMiscExit, JumpingFrame, VolfiedDraw, TaitoMiscScan,
 	NULL, 0x2000, 240, 320, 3, 4
 };
+
+// -----------------------------------------------------------------------------
+// Hacks and Translations
+// -----------------------------------------------------------------------------
+
+// Rastan Saga (Portuguese-BR v1.11, Hack)
+// Modified by Antígeno
+
+static struct BurnRomInfo RastsagabrRomDesc[] = {
+	{ "b04br-14.19",	0x10000, 0xf33adf4d, BRF_ESS | BRF_PRG | TAITO_68KROM1_BYTESWAP },
+	{ "b04br-13.7",		0x10000, 0xdcc16c00, BRF_ESS | BRF_PRG | TAITO_68KROM1_BYTESWAP },
+	{ "b04br-16-1.20",	0x10000, 0x8375d5a3, BRF_ESS | BRF_PRG | TAITO_68KROM1_BYTESWAP },
+	{ "b04br-15-1.8",	0x10000, 0x602ccf6d, BRF_ESS | BRF_PRG | TAITO_68KROM1_BYTESWAP },
+	{ "b04br-18-1.21",	0x10000, 0x1846353b, BRF_ESS | BRF_PRG | TAITO_68KROM1_BYTESWAP },
+	{ "b04br-17-1.9",	0x10000, 0x8f4414b8, BRF_ESS | BRF_PRG | TAITO_68KROM1_BYTESWAP },
+
+	{ "b04-19.49",		0x10000, 0xee81fdd8, BRF_ESS | BRF_PRG | TAITO_Z80ROM1 },
+
+	{ "b04br-01.40",	0x20000, 0x56494cce, BRF_GRA | TAITO_CHARS },
+	{ "b04-03.39",		0x20000, 0xab67e064, BRF_GRA | TAITO_CHARS },
+	{ "b04br-02.67",	0x20000, 0xe4beeb34, BRF_GRA | TAITO_CHARS },
+	{ "b04-04.66",		0x20000, 0x94737e93, BRF_GRA | TAITO_CHARS },
+
+	{ "b04br-05.15",	0x20000, 0xd0de533f, BRF_GRA | TAITO_SPRITESA },
+	{ "b04br-07.14",	0x20000, 0x7521af01, BRF_GRA | TAITO_SPRITESA },
+	{ "b04br-06.28",	0x20000, 0x78510eed, BRF_GRA | TAITO_SPRITESA },
+	{ "b04br-08.27",	0x20000, 0xca183d63, BRF_GRA | TAITO_SPRITESA },
+
+	{ "b04-20.76",		0x10000, 0xfd1a34cc, BRF_SND | TAITO_MSM5205 },
+};
+
+STD_ROM_PICK(Rastsagabr)
+STD_ROM_FN(Rastsagabr)
+
+struct BurnDriver BurnDrvRastsagabr = {
+	"rastsagabr", "rastan", NULL, NULL, "2019",
+	"Rastan Saga (Portuguese-BR Translation v1.11, Hack)\0", NULL, "hack (Ant\u00EDgeno)", "Taito Misc",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_TAITO_MISC, GBF_PLATFORM, 0,
+	NULL, RastsagabrRomInfo, RastsagabrRomName, NULL, NULL, NULL, NULL, RastanInputInfo, RastanDIPInfo,
+	RastanInit, TaitoMiscExit, TaitoMiscFrame, RastanDraw, TaitoMiscScan,
+	NULL, 0x2000, 320, 240, 4, 3
+};


### PR DESCRIPTION
cps1 - add: sf2cebr, willowbr
cps2 - add: sfa3br (original game 'sfa3b' don't have portuguese language)
megadrive - updated: bssf2gq, add landstlkrmx
neogeo - add: rotdbr, aofbr, kof2k2br, kof2k3br
fds - add: dracuii t-eng, current rom renamed to dracuiij
pre90s - add: tokibr
post90s - add: powernbr, init fix by dinkc64
taito - add: rastsagabr
snes - add: blackthornetp, captsubasa4j, captsubasa5j, seikdens3j, seikdens3te (no header), sconflict, svgeo, yuuyuu2tp
renamed yu yu hakusho games. correct size for yu yu hakusho final.




