### PR TITLE
Add SDL2 set window scale command line option

### DIFF
--- a/src/burner/sdl/burner_sdl.h
+++ b/src/burner/sdl/burner_sdl.h
@@ -43,6 +43,7 @@ extern bool  bAlwaysProcessKeyboardInput;
 extern TCHAR szAppBurnVer[16];
 extern bool  bAppFullscreen;
 extern bool bIntegerScale;
+extern int  nWindowScale;
 extern bool bAlwaysMenu;
 extern int 	nGameSelect;
 extern int 	nFilterSelect;

--- a/src/burner/sdl/main.cpp
+++ b/src/burner/sdl/main.cpp
@@ -24,6 +24,7 @@ bool bAlwaysProcessKeyboardInput = 0;
 int usemenu = 0, usejoy = 0, vsync = 1, dat = 0;
 bool bSaveconfig = 1;
 bool bIntegerScale = false;
+int nWindowScale = 2;			// Default to 2 for compatibility with previous hard coded value.
 bool bAlwaysMenu = false;
 int nGameSelect = 0;
 int nFilterSelect = HARDWARE_PUBLIC_MASK;
@@ -69,6 +70,22 @@ int parseSwitches(int argc, char* argv[])
 		else if (strcmp(argv[i], "-integerscale") == 0)
 		{
 			set_commandline_option(bIntegerScale, 1);
+		}
+		else if (strcmp(argv[i], "-windowscale") == 0)
+		{
+			int num;
+
+			if (++i >= argc)
+			{
+				return 1;
+			}
+
+			num = atoi(argv[i]);
+			if (num < 1 || 20 < num)	// Check it's not too small or ridiculously too big.
+			{
+				return 1;
+			}
+			set_commandline_option(nWindowScale, num);
 		}
 		else if (strcmp(argv[i], "-dat") == 0)
 		{
@@ -290,18 +307,19 @@ int main(int argc, char* argv[])
 	// set default videofiltering
 	snprintf(videofiltering, 3, "0");
 
-	parseSwitches(argc, argv);
+	bool switchesOK = parseSwitches(argc, argv) == 0;
 
 	// Do these bits before override via ConfigAppLoad
 	bCheatsAllowed = 1;
 	nAudDSPModule[0] = 0;
 	EnableHiscores = 1;
 
-	if ((romname == NULL) && !usemenu && !bAlwaysMenu && !dat)
+	if (!switchesOK || ((romname == NULL) && !usemenu && !bAlwaysMenu && !dat))
 	{
-		printf("Usage: %s [-cd] [-joy] [-menu] [-novsync] [-integerscale] [-fullscreen] [-dat] [-autosave] [-nearest] [-linear] [-best] <romname>\n", argv[0]);
+		printf("Usage: %s [-cd] [-joy] [-menu] [-novsync] [-integerscale] [-windowscale <num>] [-fullscreen] [-dat] [-autosave] [-nearest] [-linear] [-best] <romname>\n", argv[0]);
 		printf("Note the -menu switch does not require a romname\n");
 		printf("e.g.: %s mslug\n", argv[0]);
+		printf("e.g.: %s -windowscale 1 asteroid\n", argv[0]);
 		printf("e.g.: %s -menu -joy\n", argv[0]);
 		printf("For NeoCD games:\n");
 		printf("%s neocdz -cd path/to/ccd/filename.cue (or .ccd)\n", argv[0]);

--- a/src/intf/video/sdl/vid_sdl2.cpp
+++ b/src/intf/video/sdl/vid_sdl2.cpp
@@ -78,19 +78,19 @@ void AdjustImageSize()
 {
 	screenFlags = SDL_GetWindowFlags(sdlWindow);
 
-	// Scale forced to "*2"
+	// Scale governed by -windowscale command line option.
 	// Screen center fix thanks to Woises
 	if (nRotateGame) {
 		if (screenFlags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) {
 			int w;
 			int h;
 			SDL_GetWindowSize(sdlWindow, &w, &h);
-			SDL_SetWindowSize(sdlWindow, (display_w * w / h) * 2, display_w * 2);
+			SDL_SetWindowSize(sdlWindow, (display_w * w / h) * nWindowScale, display_w * nWindowScale);
 			SDL_RenderSetLogicalSize(sdlRenderer, (display_w * w / h), display_w);
 			dstrect.x = ((display_w * w / h) - display_w) / 2;
 		} else {
 			SDL_RestoreWindow(sdlWindow);		// If started fullscreen, switching to window can get maximized
-			SDL_SetWindowSize(sdlWindow, display_h * 2, display_w * 2);
+			SDL_SetWindowSize(sdlWindow, display_h * nWindowScale, display_w * nWindowScale);
 			SDL_RenderSetLogicalSize(sdlRenderer, display_h, display_w);
 			dstrect.x = (display_h - display_w) / 2;
 		}
@@ -101,7 +101,7 @@ void AdjustImageSize()
 			int w;
 			int h;
 			SDL_GetWindowSize(sdlWindow, &w, &h);
-			SDL_SetWindowSize(sdlWindow, (display_h * w / h) * 2, display_h * 2);
+			SDL_SetWindowSize(sdlWindow, (display_h * w / h) * nWindowScale, display_h * nWindowScale);
 
 			if (display_w < (display_h * w / h)) {
 				SDL_RenderSetLogicalSize(sdlRenderer, (display_h * w / h), display_h);
@@ -114,7 +114,7 @@ void AdjustImageSize()
 			}
 		} else {
 			SDL_RestoreWindow(sdlWindow);
-			SDL_SetWindowSize(sdlWindow, display_w * 2, display_h * 2);
+			SDL_SetWindowSize(sdlWindow, display_w * nWindowScale, display_h * nWindowScale);
 			SDL_RenderSetLogicalSize(sdlRenderer, display_w, display_h);
 			dstrect.x = 0;
 			dstrect.y = 0;


### PR DESCRIPTION
In the SDL2 front end, the window is scaled to * 2 the game screen resolution. Whilst this works find for raster games on normal DPI monitors it doesn't work so well for :-

- raster games on HiDPI displays where the window appears too small.

- vector games where the window appears too big.

This change allows the user to specify a window scale at the command line. It defaults to * 2 for backward compatibility with the old version.

Full screen and window resizing via dragging is not affected by this change.