### PR TITLE
Put back nightly `MacOS` compilation

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -288,22 +288,31 @@ jobs:
           asset_path: Linux SDL 1.2.zip
           asset_content_type: application/zip
 
-#  build_macos:
-#    name: macOS
-#    needs: nightly_release
-#    runs-on: macOS-latest
-#    env:
-#      DEVELOPER_DIR: /Applications/Xcode.app
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: Build FBNeo
-#        run: |
-#             cd projectfiles/xcode
-#             xcodebuild ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO -target Emulator -configuration Debug
-#
-#      - name: Upload Artifact
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: macOS
-#          path: "projectfiles/xcode/build/Debug/FinalBurn Neo.app"
+  build_macos:
+    name: macOS
+    needs: nightly_release
+    runs-on: macOS-latest-large # As we are building for x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build FBNeo
+        run: |
+          cd projectfiles/xcode
+          xcodebuild ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO -target Emulator -configuration Release
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS
+          path: "projectfiles/xcode/build/Release/FinalBurn Neo.app"
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.nightly_release.outputs.upload_url }}
+          asset_name: FinalBurn_Neo_macOS.zip
+          asset_path: |
+            projectfiles/xcode/build/Release/FinalBurn Neo.app
+          asset_content_type: application/zip


### PR DESCRIPTION
Thanks to the work done with @frangarcj in the #1996 we can finally put back the CI for generating the `.app` file.

Cheers