### PR TITLE
Fix crash when no game selected

### DIFF
--- a/src/burner/macos/FBMainThread+Etc.mm
+++ b/src/burner/macos/FBMainThread+Etc.mm
@@ -45,6 +45,9 @@
 
 - (NSString *) setName
 {
+    if (nBurnDrvActive == ~0U) {
+        return nil;
+    }
     return [NSString stringWithCString:BurnDrvGetText(DRV_NAME)
                               encoding:NSASCIIStringEncoding];
 }


### PR DESCRIPTION
This avoids the crash when trying to open the menu if no game loaded
<img width="1103" alt="Screenshot 2025-05-08 at 17 00 17" src="https://github.com/user-attachments/assets/efb984c6-fa3b-4cb4-baa8-87d4fd45f168" />

I will try to fix the remaining options in a separate PR