### PR TITLE
t-bra: some changes in cps/taito/pre90s/sms/megadrive

### DIFF
--- a/src/burn/drv/capcom/d_cps1.cpp
+++ b/src/burn/drv/capcom/d_cps1.cpp
@@ -26883,7 +26883,7 @@ struct BurnDriver BurnDrvCpsSf2mix = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-// Street Fighter II': Champion Edition (920313 Brasil, v1.0, Hack)
+// Street Fighter II': Champion Edition (Brasil 920313, v1.0, Hack)
 // Modified by Alan Yagami & BisonSAS
 
 static struct BurnRomInfo Sf2cebrRomDesc[] = {
@@ -27086,7 +27086,7 @@ struct BurnDriver BurnDrvCpsMercsc = {
 	&CpsRecalcPal, 0x1000, 224, 384, 3, 4
 };
 
-// Willow (Portuguese-BR Translation v1.06, Hack)
+// Willow (Hack, Portuguese-BR Translation, v1.06)
 // Modified by Antígeno
 
 static struct BurnRomInfo WillowbrRomDesc[] = {
@@ -27125,8 +27125,8 @@ STD_ROM_FN(Willowbr)
 
 struct BurnDriver BurnDrvCpsWillowbr = {
 	"willowbr", "willow", NULL, NULL, "2019",
-	"Willow (hack, Portuguese-BR Translation, v1.06)\0", NULL, "hack (Antigeno)", "CPS1",
-	NULL, NULL, NULL, NULL,
+	"Willow (Hack, Portuguese-BR Translation, v1.06)\0", NULL, "hack (Antigeno)", "CPS1",
+	NULL, NULL, L"hack (Ant\u00EDgeno)", NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS1, GBF_PLATFORM, 0,
 	NULL, WillowbrRomInfo, WillowbrRomName, NULL, NULL, NULL, NULL, WillowInputInfo, WillowDIPInfo,
 	DrvInit, DrvExit, Cps1Frame, CpsRedraw, CpsAreaScan,

--- a/src/burn/drv/capcom/d_cps2.cpp
+++ b/src/burn/drv/capcom/d_cps2.cpp
@@ -16033,7 +16033,7 @@ struct BurnDriver BurnDrvCpsSfa2ultra = {
 	&CpsRecalcPal, 0x1000, 384, 224, 4, 3
 };
 
-// Street Fighter Alpha 3 (050513 Brasil) Portuguese translation version v2.0
+// Street Fighter Alpha 3 (Brasil 050513) Portuguese translation version v2.0
 // Modified by Alan Yagami & BisonSAS
 
 static struct BurnRomInfo Sfa3brRomDesc[] = {
@@ -16069,7 +16069,7 @@ STD_ROM_FN(Sfa3br)
 
 struct BurnDriver BurnDrvCpsSfa3br = {
 	"sfa3br", "sfa3", NULL, NULL, "2005",
-	"Street Fighter Alpha 3 (050513 Brasil, v2.0, Hack)\0", "Portuguese translation", "hack (Alan Web Page)", "CPS2",
+	"Street Fighter Alpha 3 (Brasil 050513, v2.0, Hack)\0", "Portuguese translation", "hack (Alan Web Page)", "CPS2",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_CAPCOM_CPS2, GBF_VSFIGHT, FBF_SF,
 	NULL, Sfa3brRomInfo, Sfa3brRomName, NULL, NULL, NULL, NULL, Cps2FightingInputInfo, NULL,

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -44845,7 +44845,7 @@ struct BurnDriver BurnDrvmd_zerowingc = {
 // Disney's Aladdin (Hack, Portuguese)
 // https://romhackers.org/traducoes/console/mega-drive/disneys-aladdin-nicolas-mega/
 static struct BurnRomInfo md_aladdinptRomDesc[] = {
-	{ "Disney's Aladdin PT-BR (2007)(Nenhum).bin", 2097152, 0xe2090f4a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Disney's Aladdin PT-BR (2007)(Nicolas Mega).bin", 2097152, 0xe2090f4a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_aladdinpt)
@@ -44853,7 +44853,7 @@ STD_ROM_FN(md_aladdinpt)
 
 struct BurnDriver BurnDrvmd_aladdinpt = {
 	"md_aladdinpt", "md_aladdin", NULL, NULL, "2007",
-	"Disney's Aladdin (Hack, Portuguese)\0", NULL, "Nenhum", "Genesis / Mega Drive",
+	"Disney's Aladdin (Hack, Portuguese)\0", NULL, "hack (Nicolas Mega)", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 1, HARDWARE_SEGA_MEGADRIVE, GBF_PLATFORM, 0,
 	MegadriveGetZipName, md_aladdinptRomInfo, md_aladdinptRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -44902,7 +44902,7 @@ struct BurnDriver BurnDrvmd_castlillpt = {
 // Chakan (Hack, Portuguese)
 // https://romhackers.org/traducoes/console/mega-drive/chakan-the-forever-man-volstag-e-panca-loca/
 static struct BurnRomInfo md_chakanptRomDesc[] = {
-	{ "Chakan PT-BR (2002)(Nenhum).bin", 1048576, 0x59b93489, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Chakan PT-BR (2002)(Volstag, Panca Loca).bin", 1048576, 0x59b93489, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_chakanpt)
@@ -44910,7 +44910,7 @@ STD_ROM_FN(md_chakanpt)
 
 struct BurnDriver BurnDrvmd_chakanpt = {
 	"md_chakanpt", "md_chakan", NULL, NULL, "2002",
-	"Chakan (Hack, Portuguese)\0", NULL, "Nenhum", "Genesis / Mega Drive",
+	"Chakan (Hack, Portuguese)\0", NULL, "hack (Volstag, Panca Loca)", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 1, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT | GBF_PLATFORM, 0,
 	MegadriveGetZipName, md_chakanptRomInfo, md_chakanptRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -45206,7 +45206,7 @@ struct BurnDriver BurnDrvmd_shinfrcept = {
 // Shining Force II (Hack, Portuguese)
 // https://romhackers.org/traducoes/console/mega-drive/shining-force-ii-daniel-v.-dias-e-outros/
 static struct BurnRomInfo md_shinfrc2ptRomDesc[] = {
-	{ "Shining Force II PT-BR (2007)(Nenhum).bin", 2097152, 0x39afbe56, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Shining Force II PT-BR (2007)(Various).bin", 2097152, 0x39afbe56, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_shinfrc2pt)
@@ -45214,7 +45214,7 @@ STD_ROM_FN(md_shinfrc2pt)
 
 struct BurnDriver BurnDrvmd_shinfrc2pt = {
 	"md_shinfrc2pt", "md_shinfrc2", NULL, NULL, "2007",
-	"Shining Force II (Hack, Portuguese)\0", NULL, "Nenhum", "Genesis / Mega Drive",
+	"Shining Force II (Hack, Portuguese)\0", NULL, "hack (Various)", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HACK, 1, HARDWARE_SEGA_MEGADRIVE | HARDWARE_SEGA_MEGADRIVE_PCB_SEGA_SRAM, GBF_RPG, 0,
 	MegadriveGetZipName, md_shinfrc2ptRomInfo, md_shinfrc2ptRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/pre90s/d_toki.cpp
+++ b/src/burn/drv/pre90s/d_toki.cpp
@@ -1856,9 +1856,9 @@ struct BurnDriver BurnDrvTokib = {
 	256, 224, 4, 3
 };
 
-// -----------------------------------------------------------------------------
+// ----------------------
 // Hacks and Translations
-// -----------------------------------------------------------------------------
+// ----------------------
 
 // Toki (Portuguese-BR Translation v1.07, Hack)
 // Modified by Antígeno
@@ -1893,8 +1893,8 @@ STD_ROM_FN(tokibr)
 
 struct BurnDriver BurnDrvTokibr = {
 	"tokibr", "toki", NULL, NULL, "2019",
-	"Toki (Portuguese-BR Translation v1.07, Hack)\0", NULL, "hack (Ant\u00EDgeno)", "Miscellaneous",
-	NULL, NULL, NULL, NULL,
+	"Toki (Portuguese-BR Translation v1.07, Hack)\0", NULL, "hack (Antigeno)", "Miscellaneous",
+	NULL, NULL, L"hack (Ant\u00EDgeno)", NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_MISC_PRE90S, GBF_RUNGUN, 0,
 	NULL, tokibrRomInfo, tokibrRomName, NULL, NULL, NULL, NULL, TokiInputInfo, TokiDIPInfo,
 	DrvInit, DrvExit, DrvFrame, DrvDraw, DrvScan, &DrvRecalc, 0x400,

--- a/src/burn/drv/sms/d_sms.cpp
+++ b/src/burn/drv/sms/d_sms.cpp
@@ -914,24 +914,6 @@ struct BurnDriver BurnDrvsms_alexkidd1 = {
 	256, 192, 4, 3
 };
 
-// Alex Kidd in Miracle World (Brazil, v1, Pirate)
-static struct BurnRomInfo sms_alexkiddbRomDesc[] = {
-	{ "Alex Kidd in Miracle World (Brazil, v1, Pirate)(1986).bin",	0x20000, 0x7545d7c2, BRF_PRG | BRF_ESS },
-};
-
-STD_ROM_PICK(sms_alexkiddb)
-STD_ROM_FN(sms_alexkiddb)
-
-struct BurnDriver BurnDrvsms_alexkiddb = {
-	"sms_alexkiddb", "sms_alexkidd", NULL, NULL, "1986",
-	"Alex Kidd in Miracle World (Brazil, v1, Pirate)\0", NULL, "<unknown>", "Sega Master System",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
-	SMSGetZipName, sms_alexkiddbRomInfo, sms_alexkiddbRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
-	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
-	256, 192, 4, 3
-};
-
 // Alex Kidd no Miracle World (Japan)
 static struct BurnRomInfo sms_alexkiddjRomDesc[] = {
 	{ "Alex Kidd no Miracle World (Japan)(1986)(Sega).sms",	0x20000, 0x08c9ec91, BRF_PRG | BRF_ESS },
@@ -21474,6 +21456,24 @@ struct BurnDriver BurnDrvgg_zoop = {
 // -------------------------------
 
 
+// 4lex Kidd In Nightmare World (GlobalHack)
+static struct BurnRomInfo sms_4lexkiddnwRomDesc[] = {
+	{ "4lex Kidd In Nightmare World (GlobalHack)(2023)(pinkeyeFR).sms",	524288, 0xd2586223, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sms_4lexkiddnw)
+STD_ROM_FN(sms_4lexkiddnw)
+
+struct BurnDriver BurnDrvsms_4lexkiddnw = {
+	"sms_4lexkiddnw", NULL, NULL, NULL, "2023",
+	"4lex Kidd In Nightmare World (GlobalHack)\0", NULL, "pinkeyeFR", "Sega Master System",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HACK | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
+	SMSGetZipName, sms_4lexkiddnwRomInfo, sms_4lexkiddnwRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Acid Reflux (HB, v1.1)
 static struct BurnRomInfo sms_acrefluxRomDesc[] = {
 	{ "Acid Reflux v1.1 (2016)(furrtek & robotwo).sms",	32768, 0x9d9919df, BRF_PRG | BRF_ESS },
@@ -21596,6 +21596,27 @@ struct BurnDriver BurnDrvsms_alexkidd3 = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW | BDF_HACK, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
 	SMSGetZipName, sms_alexkidd3RomInfo, sms_alexkidd3RomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Alex Kidd no Mundo dos Milagres (Hack, Portuguese v1.0)
+// https://romhackers.org/traducoes/console/master-system/alex-kidd-in-miracle-world-po.b.r.e
+// Modified by Mr.Fox
+
+static struct BurnRomInfo sms_AlexkiddbRomDesc[] = {
+	{ "Alex Kidd no Mundo dos Milagres T-Por v1.0 (2017)(PO.B.R.E).sms",	262144, 0x4c7c2042, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sms_Alexkiddb)
+STD_ROM_FN(sms_Alexkiddb)
+
+struct BurnDriver BurnDrvsms_Alexkiddb = {
+	"sms_alexkiddb", "sms_alexkidd", NULL, NULL, "2017",
+	"Alex Kidd no Mundo dos Milagres (Hack, Portuguese v1.0)\0", NULL, "hack (PO.B.R.E)", "Sega Master System",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
+	SMSGetZipName, sms_AlexkiddbRomInfo, sms_AlexkiddbRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };

--- a/src/burn/drv/taito/d_taitomisc.cpp
+++ b/src/burn/drv/taito/d_taitomisc.cpp
@@ -6426,11 +6426,11 @@ struct BurnDriver BurnDrvVolfieduo = {
 	NULL, 0x2000, 240, 320, 3, 4
 };
 
-// -----------------------------------------------------------------------------
+// ----------------------
 // Hacks and Translations
-// -----------------------------------------------------------------------------
+// ----------------------
 
-// Rastan Saga (Portuguese-BR v1.11, Hack)
+// Rastan Saga (Portuguese-BR Translation v1.11, Hack)
 // Modified by Antígeno
 
 static struct BurnRomInfo RastsagabrRomDesc[] = {
@@ -6461,8 +6461,8 @@ STD_ROM_FN(Rastsagabr)
 
 struct BurnDriver BurnDrvRastsagabr = {
 	"rastsagabr", "rastan", NULL, NULL, "2019",
-	"Rastan Saga (Portuguese-BR Translation v1.11, Hack)\0", NULL, "hack (Ant\u00EDgeno)", "Taito Misc",
-	NULL, NULL, NULL, NULL,
+	"Rastan Saga (Portuguese-BR Translation v1.11, Hack)\0", NULL, "hack (Antigeno)", "Taito Misc",
+	NULL, NULL, L"hack (Ant\u00EDgeno)", NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_TAITO_MISC, GBF_PLATFORM, 0,
 	NULL, RastsagabrRomInfo, RastsagabrRomName, NULL, NULL, NULL, NULL, RastanInputInfo, RastanDIPInfo,
 	RastanInit, TaitoMiscExit, TaitoMiscFrame, RastanDraw, TaitoMiscScan,


### PR DESCRIPTION
Fixed "published by" in willobr, tokibr, rastsagbr.
Fixed "GameName/comment" in sf2cebr, sfa3br
Fixed "Author" in md_alladinpt, md_chakanpt, md_shinfrc2pt. "Nenhum" means "None", isn't a group name.
Updated sms_alexkiddb (better version) and moved to hacks section.
Added sms_4lexkiddnw (Yes. is really 4lex, not Alex).