### PR TITLE
d_xunit.cpp: increase cmos's default volume

### DIFF
--- a/src/burn/drv/midway/d_xunit.cpp
+++ b/src/burn/drv/midway/d_xunit.cpp
@@ -791,6 +791,16 @@ static INT32 DrvFrame()
 		DrvDoReset();
 	}
 
+	// normalize volume with other drivers by increasing it from its default 25% to around 60% in service menu
+	// note : this can't be done at init because the cmos has to be initialized first
+	// note2: we could also normalize by boosting volume with Dcs2kSetVolume,
+	//        but then the volume would be way too loud for anyone who did increase it in service menu
+	if (DrvNVRAM[0x41cc] == 0x3f && DrvNVRAM[0x4360] == 0xfd && DrvNVRAM[0x4364] == 0x05) {
+		DrvNVRAM[0x41cc] = 0xac;
+		DrvNVRAM[0x4360] = 0xfc;
+		DrvNVRAM[0x4364] = 0x98;
+	}
+
 	{
 		memset (DrvInputs, 0xff, sizeof(DrvInputs));
 


### PR DESCRIPTION
@dinkc64 i'm not too happy with the default volume for revx and was trying to find a better compromise. What do you think of this ? It'll only increase volume on a fresh nvram with the default setting.