### PR TITLE
MSX and ZX Spectrum updates

### DIFF
--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -12969,7 +12969,7 @@ STD_ROM_FN(MSX_livingstone2)
 
 struct BurnDriver BurnDrvMSX_livingstone2 = {
 	"msx_livingstone2", NULL, "msx_msx", NULL, "1989",
-	"Livingstone Supongo II (Euro, Spanish)\0", NULL, "Opera Soft", "MSX",
+	"Livingstone Supongo II (Euro, Spanish)\0", "Password Part 2: 15215", "Opera Soft", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_livingstone2RomInfo, MSX_livingstone2RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXJoyport2DIPInfo,
@@ -21790,7 +21790,7 @@ STD_ROM_FN(MSX_abadcrim)
 
 struct BurnDriver BurnDrvMSX_abadcrim = {
 	"msx_abadcrim", NULL, "msx_msx", NULL, "1988",
-	"Abadia del Crimen, La (Euro, Spanish)\0", NULL, "Opera Soft", "MSX",
+	"Abadia del Crimen, La (Euro, Spanish)\0", "To use main character: A, K, L and SPACE", "Opera Soft", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_ADV, 0,
 	MSXGetZipName, MSX_abadcrimRomInfo, MSX_abadcrimRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
@@ -23089,10 +23089,10 @@ STDROMPICKEXT(MSX_desperado, MSX_desperado, msx_msx)
 STD_ROM_FN(MSX_desperado)
 
 struct BurnDriver BurnDrvMSX_desperado = {
-	"msx_desperado", NULL, "msx_msx", NULL, "1987",
+	"msx_desperado", "msx_gunsmokee", "msx_msx", NULL, "1987",
 	"Desperado (Euro, Spanish)\0", "At title & options screen turn the Tape to Side B", "Topo Soft", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_RUNGUN, 0,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_MSX, GBF_RUNGUN, 0,
 	MSXGetZipName, MSX_desperadoRomInfo, MSX_desperadoRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXEuropeJoyport2DIPInfo,
 	CasRunDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
@@ -26226,22 +26226,40 @@ struct BurnDriver BurnDrvMSX_stdragon = {
 	272, 228, 4, 3
 };
 
-// Satan (Euro)
+// Satan - Part 1 (Euro)
 
-static struct BurnRomInfo MSX_satanRomDesc[] = {
+static struct BurnRomInfo MSX_satan1RomDesc[] = {
 	{ "Satan (Euro)(1989)(Dinamic Software)(Side A)[RUN'CAS-'].cas",	0x0da31, 0x6c16e392, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(MSX_satan1, MSX_satan1, msx_msx)
+STD_ROM_FN(MSX_satan1)
+
+struct BurnDriver BurnDrvMSX_satan1 = {
+	"msx_satan1", NULL, "msx_msx", NULL, "1989",
+	"Satan - Part 1 (Euro)\0", NULL, "Dinamic Software", "MSX",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_RUNGUN | GBF_PLATFORM, 0,
+	MSXGetZipName, MSX_satan1RomInfo, MSX_satan1RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
+	CasRunDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
+	272, 228, 4, 3
+};
+
+// Satan - Part 2 (Euro)
+
+static struct BurnRomInfo MSX_satan2RomDesc[] = {
 	{ "Satan (Euro)(1989)(Dinamic Software)(Side B)[RUN'CAS-'].cas",	0x0da31, 0x10914f8a, BRF_PRG | BRF_ESS },
 };
 
-STDROMPICKEXT(MSX_satan, MSX_satan, msx_msx)
-STD_ROM_FN(MSX_satan)
+STDROMPICKEXT(MSX_satan2, MSX_satan2, msx_msx)
+STD_ROM_FN(MSX_satan2)
 
-struct BurnDriver BurnDrvMSX_satan = {
-	"msx_satan", NULL, "msx_msx", NULL, "1989",
-	"Satan (Euro)\0", NULL, "Dinamic Software", "MSX",
+struct BurnDriver BurnDrvMSX_satan2 = {
+	"msx_satan2", "msx_satan1", "msx_msx", NULL, "1989",
+	"Satan - Part 2 (Euro)\0", "Password: 01020304", "Dinamic Software", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_RUNGUN | GBF_PLATFORM, 0,
-	MSXGetZipName, MSX_satanRomInfo, MSX_satanRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_MSX, GBF_RUNGUN | GBF_PLATFORM, 0,
+	MSXGetZipName, MSX_satan2RomInfo, MSX_satan2RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	CasRunDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
 };
@@ -26532,22 +26550,40 @@ struct BurnDriver BurnDrvMSX_solnegro2 = {
 	272, 228, 4, 3
 };
 
-// Soviet (Euro)
+// Soviet - Part 1 (Euro)
 
-static struct BurnRomInfo MSX_sovietRomDesc[] = {
+static struct BurnRomInfo MSX_soviet1RomDesc[] = {
 	{ "Soviet (Euro)(1990)(Opera Soft)(Side A)[BLOAD'CAS-',R].cas",	102992, 0xeac0c700, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(MSX_soviet1, MSX_soviet1, msx_msx)
+STD_ROM_FN(MSX_soviet1)
+
+struct BurnDriver BurnDrvMSX_soviet1 = {
+	"msx_soviet1", NULL, "msx_msx", NULL, "1990",
+	"Soviet - Part 1 (Euro)\0", NULL, "Opera Soft", "MSX",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_SHOOT, 0,
+	MSXGetZipName, MSX_soviet1RomInfo, MSX_soviet1RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXJoyport2DIPInfo,
+	CasBloadDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
+	272, 228, 4, 3
+};
+
+// Soviet - Part 2 (Euro)
+
+static struct BurnRomInfo MSX_soviet2RomDesc[] = {
 	{ "Soviet (Euro)(1990)(Opera Soft)(Side B)[BLOAD'CAS-',R].cas",	119128, 0x183dcfb4, BRF_PRG | BRF_ESS },
 };
 
-STDROMPICKEXT(MSX_soviet, MSX_soviet, msx_msx)
-STD_ROM_FN(MSX_soviet)
+STDROMPICKEXT(MSX_soviet2, MSX_soviet2, msx_msx)
+STD_ROM_FN(MSX_soviet2)
 
-struct BurnDriver BurnDrvMSX_soviet = {
-	"msx_soviet", NULL, "msx_msx", NULL, "1990",
-	"Soviet (Euro)\0", NULL, "Opera Soft", "MSX",
+struct BurnDriver BurnDrvMSX_soviet2 = {
+	"msx_soviet2", "msx_soviet1", "msx_msx", NULL, "1990",
+	"Soviet - Part 2 (Euro)\0", "Password: REDWOLF", "Opera Soft", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_SHOOT, 0,
-	MSXGetZipName, MSX_sovietRomInfo, MSX_sovietRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXJoyport2DIPInfo,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_MSX, GBF_SHOOT, 0,
+	MSXGetZipName, MSX_soviet2RomInfo, MSX_soviet2RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXJoyport2DIPInfo,
 	CasBloadDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
 };

--- a/src/burn/drv/spectrum/d_spectrum.cpp
+++ b/src/burn/drv/spectrum/d_spectrum.cpp
@@ -5513,21 +5513,40 @@ struct BurnDriver BurnSpeccanywarr = {
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
-// Capitan Sevilla (Spanish) (48K)
+// Capitan Sevilla - Part 1 (Spanish) (48K)
 
-static struct BurnRomInfo SpecCaptsevillaRomDesc[] = {
-	{ "Capitan Sevilla ES 48K (1988)(Dinamic Software).tap", 97238, 0x8f8c61e7, BRF_ESS | BRF_PRG },
+static struct BurnRomInfo SpecCaptsevilla1RomDesc[] = {
+	{ "Capitan Sevilla - Part 1 ES 48K (1988)(Dinamic Software).tap", 48619, 0x1f0ef121, BRF_ESS | BRF_PRG },
 };
 
-STDROMPICKEXT(SpecCaptsevilla, SpecCaptsevilla, Spectrum)
-STD_ROM_FN(SpecCaptsevilla)
+STDROMPICKEXT(SpecCaptsevilla1, SpecCaptsevilla1, Spectrum)
+STD_ROM_FN(SpecCaptsevilla1)
 
-struct BurnDriver BurnSpecCaptsevilla = {
-	"spec_captsevilla", NULL, "spec_spectrum", NULL, "1988",
-	"Capitan Sevilla (Spanish) (48K)\0", "SPACE: change to Cap. Sevilla (if available)", "Dinamic Software", "ZX Spectrum",
+struct BurnDriver BurnSpecCaptsevilla1 = {
+	"spec_captsevilla1", NULL, "spec_spectrum", NULL, "1988",
+	"Capitan Sevilla - Part 1 (Spanish) (48K)\0", NULL, "Dinamic Software", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_SPECTRUM, GBF_PLATFORM, 0,
-	SpectrumGetZipName, SpecCaptsevillaRomInfo, SpecCaptsevillaRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
+	SpectrumGetZipName, SpecCaptsevilla1RomInfo, SpecCaptsevilla1RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Capitan Sevilla - Part 2 (Spanish) (48K)
+
+static struct BurnRomInfo SpecCaptsevilla2RomDesc[] = {
+	{ "Capitan Sevilla - Part 2 ES 48K (1988)(Dinamic Software).tap", 48619, 0x7109d33d, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecCaptsevilla2, SpecCaptsevilla2, Spectrum)
+STD_ROM_FN(SpecCaptsevilla2)
+
+struct BurnDriver BurnSpecCaptsevilla2 = {
+	"spec_captsevilla2", "spec_captsevilla1", "spec_spectrum", NULL, "1988",
+	"Capitan Sevilla - Part 2 (Spanish) (48K)\0", "Password: 574527", "Dinamic Software", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SPECTRUM, GBF_PLATFORM, 0,
+	SpectrumGetZipName, SpecCaptsevilla2RomInfo, SpecCaptsevilla2RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
 	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
@@ -19463,15 +19482,15 @@ struct BurnDriver BurnSpecNarc = {
 // Narco Police (128K)
 
 static struct BurnRomInfo SpecNarcopolRomDesc[] = {
-	{ "Narco Police 128K (1991)(Rajsoft).tap", 0x1cf59, 0xd47256a3, BRF_ESS | BRF_PRG },
+	{ "Narco Police 128K (1990)(Dinamic Software).tap", 0x1cf59, 0xd47256a3, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(SpecNarcopol, SpecNarcopol, Spec128)
 STD_ROM_FN(SpecNarcopol)
 
 struct BurnDriver BurnSpecNarcopol = {
-	"spec_narcopol", NULL, "spec_spec128", NULL, "1991",
-	"Narco Police (128K)\0", NULL, "Rajsoft", "ZX Spectrum",
+	"spec_narcopol", NULL, "spec_spec128", NULL, "1990",
+	"Narco Police (128K)\0", NULL, "Dinamic Software", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_SPECTRUM, GBF_SHOOT, 0,
 	SpectrumGetZipName, SpecNarcopolRomInfo, SpecNarcopolRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecIntf2DIPInfo,
@@ -25559,10 +25578,10 @@ struct BurnDriver BurnSpecSoldierone = {
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
-// Sol Negro: Special Edition - Part 1 (Spanish) (48K)
+// Sol Negro - Part 1 (Spanish) (48K)
 
 static struct BurnRomInfo Specsolnegro1RomDesc[] = {
-	{ "Sol Negro - Special Edition - Part 1 48K-AY (1989)(Opera Soft).z80", 42525, 0x27b7e34f, BRF_ESS | BRF_PRG },
+	{ "Sol Negro - Part 1 ES 48K (1989)(Opera Soft).tap", 48329, 0x3a029c8a, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(Specsolnegro1, Specsolnegro1, Spectrum)
@@ -25570,7 +25589,7 @@ STD_ROM_FN(Specsolnegro1)
 
 struct BurnDriver BurnSpecsolnegro1 = {
 	"spec_solnegro1", NULL, "spec_spectrum", NULL, "1989",
-	"Sol Negro: Special Edition - Part 1 (Spanish) (48K)\0", "AY Sound supported", "Opera Soft", "ZX Spectrum",
+	"Sol Negro - Part 1 (Spanish) (48K)\0", NULL, "Opera Soft", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_SPECTRUM, GBF_RUNGUN, 0,
 	SpectrumGetZipName, Specsolnegro1RomInfo, Specsolnegro1RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecQAOPSpaceDIPInfo,
@@ -25578,10 +25597,10 @@ struct BurnDriver BurnSpecsolnegro1 = {
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
-// Sol Negro: Special Edition - Part 2 (Spanish) (48K)
+// Sol Negro - Part 2 (Spanish) (48K)
 
 static struct BurnRomInfo Specsolnegro2RomDesc[] = {
-	{ "Sol Negro - Special Edition - Part 2 48K-AY (1989)(Opera Soft).z80", 37075, 0xaf912284, BRF_ESS | BRF_PRG },
+	{ "Sol Negro - Part 2 ES 48K (1989)(Opera Soft).tap", 89549, 0x4400c360, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(Specsolnegro2, Specsolnegro2, Spectrum)
@@ -25589,10 +25608,48 @@ STD_ROM_FN(Specsolnegro2)
 
 struct BurnDriver BurnSpecsolnegro2 = {
 	"spec_solnegro2", "spec_solnegro1", "spec_spectrum", NULL, "1989",
-	"Sol Negro: Special Edition - Part 2 (Spanish) (48K)\0", "AY Sound supported", "Opera Soft", "ZX Spectrum",
+	"Sol Negro - Part 2 (Spanish) (48K)\0", "Password: 2414520", "Opera Soft", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SPECTRUM, GBF_RUNGUN, 0,
 	SpectrumGetZipName, Specsolnegro2RomInfo, Specsolnegro2RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecQAOPSpaceDIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Sol Negro: Special Edition - Part 1 (Spanish) (48K)
+
+static struct BurnRomInfo Specsolnegrose1RomDesc[] = {
+	{ "Sol Negro - Special Edition - Part 1 ES 48K-AY (1989)(Opera Soft).z80", 42525, 0x27b7e34f, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(Specsolnegrose1, Specsolnegrose1, Spectrum)
+STD_ROM_FN(Specsolnegrose1)
+
+struct BurnDriver BurnSpecsolnegrose1 = {
+	"spec_solnegrose1", NULL, "spec_spectrum", NULL, "1989",
+	"Sol Negro: Special Edition - Part 1 (Spanish) (48K)\0", "AY Sound supported", "Opera Soft", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 1, HARDWARE_SPECTRUM, GBF_RUNGUN, 0,
+	SpectrumGetZipName, Specsolnegrose1RomInfo, Specsolnegrose1RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecQAOPSpaceDIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Sol Negro: Special Edition - Part 2 (Spanish) (48K)
+
+static struct BurnRomInfo Specsolnegrose2RomDesc[] = {
+	{ "Sol Negro - Special Edition - Part 2 ES 48K-AY (1989)(Opera Soft).z80", 37075, 0xaf912284, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(Specsolnegrose2, Specsolnegrose2, Spectrum)
+STD_ROM_FN(Specsolnegrose2)
+
+struct BurnDriver BurnSpecsolnegrose2 = {
+	"spec_solnegrose2", "spec_solnegrose1", "spec_spectrum", NULL, "1989",
+	"Sol Negro: Special Edition - Part 2 (Spanish) (48K)\0", "AY Sound supported", "Opera Soft", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_SPECTRUM, GBF_RUNGUN, 0,
+	SpectrumGetZipName, Specsolnegrose2RomInfo, Specsolnegrose2RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecQAOPSpaceDIPInfo,
 	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };


### PR DESCRIPTION
d_msx.cpp:
- Fixed "Satan (Euro)" and "Soviet (Euro)": These games got two parts, one in each side of the tape. Previous romsets contains both tape sides but only the first one was available. Now these romsets are splitted in two parts like their "ZX Spectrum" counterpart.
- Fixed parent/clone relation between "Desperado (Euro, Spanish)" and "Gunsmoke (Euro)".
- Added password for "Livingstone Supongo II (Euro, Spanish)" Part 2 in Notes.
- Added main character keys for "Abadia del Crimen, La (Euro, Spanish)" in Notes.

d_spectrum.cpp:
- Add the support to "Sol Negro (Spanish) (48K)"
- Fixed "Capitan Sevilla (Spanish) (48K)": This game got two parts, one in each side of the tape. Previous romset contains both tape sides in one big .tap file so only the first part was available. Now that file is splitted and both parts are available.
- Fixed "Narco Police (128K)" release year and publisher (previous data was the game cracker).