### PR TITLE
MSX and NGPC updates

### DIFF
--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -23231,7 +23231,7 @@ struct BurnDriver BurnDrvMSX_dkongeu = {
 	272, 228, 4, 3
 };
 
-// Don Quijote - Parte I (Euro, Spanish)
+// Don Quijote - Part I (Euro, Spanish)
 
 static struct BurnRomInfo MSX_donquijote1RomDesc[] = {
 	{ "Don Quijote (Euro, ES)(1987)(Dinamic Software)(Side A)[RUN'CAS-'].cas",	54252, 0x68395271, BRF_PRG | BRF_ESS },
@@ -23242,7 +23242,7 @@ STD_ROM_FN(MSX_donquijote1)
 
 struct BurnDriver BurnDrvMSX_donquijote1 = {
 	"msx_donquijote1", NULL, "msx_msx", NULL, "1987",
-	"Don Quijote - Parte I (Euro, Spanish)\0", NULL, "Dinamic Software", "MSX",
+	"Don Quijote - Part I (Euro, Spanish)\0", NULL, "Dinamic Software", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_ADV, 0,
 	MSXGetZipName, MSX_donquijote1RomInfo, MSX_donquijote1RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXKeyClickDIPInfo,
@@ -23250,7 +23250,7 @@ struct BurnDriver BurnDrvMSX_donquijote1 = {
 	272, 228, 4, 3
 };
 
-// Don Quijote - Parte II (Euro, Spanish)
+// Don Quijote - Part II (Euro, Spanish)
 
 static struct BurnRomInfo MSX_donquijote2RomDesc[] = {
 	{ "Don Quijote (Euro, ES)(1987)(Dinamic Software)(Side B)[RUN'CAS-'].cas",	51442, 0x833d4f52, BRF_PRG | BRF_ESS },
@@ -23261,7 +23261,7 @@ STD_ROM_FN(MSX_donquijote2)
 
 struct BurnDriver BurnDrvMSX_donquijote2 = {
 	"msx_donquijote2", "msx_donquijote1", "msx_msx", NULL, "1987",
-	"Don Quijote - Parte II (Euro, Spanish)\0", "Password: EL BALSAMO DE FIERABRAS", "Dinamic Software", "MSX",
+	"Don Quijote - Part II (Euro, Spanish)\0", "Password: EL BALSAMO DE FIERABRAS", "Dinamic Software", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_MSX, GBF_ADV, 0,
 	MSXGetZipName, MSX_donquijote2RomInfo, MSX_donquijote2RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXKeyClickDIPInfo,
@@ -27140,22 +27140,40 @@ struct BurnDriver BurnDrvMSX_timetrax = {
 	272, 228, 4, 3
 };
 
-// Titanic (Euro, Spanish)
+// Titanic - Part 1 (Euro, Spanish)
 
-static struct BurnRomInfo MSX_titanicRomDesc[] = {
+static struct BurnRomInfo MSX_titanic1RomDesc[] = {
 	{ "Titanic (Euro, ES)(1988)(Topo Soft)(Side A)[RUN'CAS-'].cas",	0x0c300, 0x7e7a8653, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(MSX_titanic1, MSX_titanic1, msx_msx)
+STD_ROM_FN(MSX_titanic1)
+
+struct BurnDriver BurnDrvMSX_titanic1 = {
+	"msx_titanic1", NULL, "msx_msx", NULL, "1988",
+	"Titanic - Part 1 (Euro, Spanish)\0", NULL, "Topo Soft", "MSX",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	MSXGetZipName, MSX_titanic1RomInfo, MSX_titanic1RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXEuropeJoyport2DIPInfo,
+	CasRunDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
+	272, 228, 4, 3
+};
+
+// Titanic - Part 2 (Euro, Spanish)
+
+static struct BurnRomInfo MSX_titanic2RomDesc[] = {
 	{ "Titanic (Euro, ES)(1988)(Topo Soft)(Side B)[RUN'CAS-'].cas",	0x0c91c, 0x45b1c035, BRF_PRG | BRF_ESS },
 };
 
-STDROMPICKEXT(MSX_titanic, MSX_titanic, msx_msx)
-STD_ROM_FN(MSX_titanic)
+STDROMPICKEXT(MSX_titanic2, MSX_titanic2, msx_msx)
+STD_ROM_FN(MSX_titanic2)
 
-struct BurnDriver BurnDrvMSX_titanic = {
-	"msx_titanic", NULL, "msx_msx", NULL, "1988",
-	"Titanic (Euro, Spanish)\0", NULL, "Topo Soft", "MSX",
+struct BurnDriver BurnDrvMSX_titanic2 = {
+	"msx_titanic2", "msx_titanic1", "msx_msx", NULL, "1988",
+	"Titanic - Part 2 (Euro, Spanish)\0", "Password: SUSIE", "Topo Soft", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_ACTION, 0,
-	MSXGetZipName, MSX_titanicRomInfo, MSX_titanicRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXEuropeJoyport2DIPInfo,
+	BDF_GAME_WORKING | BDF_CLONE, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	MSXGetZipName, MSX_titanic2RomInfo, MSX_titanic2RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXEuropeJoyport2DIPInfo,
 	CasRunDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
 };
@@ -27361,7 +27379,7 @@ STD_ROM_FN(MSX_viajecentro)
 
 struct BurnDriver BurnDrvMSX_viajecentro = {
 	"msx_viajecentro", NULL, "msx_msx", NULL, "1989",
-	"Viaje al Centro de la Tierra (Euro, Spanish)\0", "PASSWORDS: Fase 2: EVAMARIASEFUE / Fase 3: LOU REED", "Topo Soft", "MSX",
+	"Viaje al Centro de la Tierra (Euro, Spanish)\0", "Passwords: Fase 2: EVAMARIASEFUE / Fase 3: LOU REED", "Topo Soft", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING, 1, HARDWARE_MSX, GBF_ADV | GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_viajecentroRomInfo, MSX_viajecentroRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXJoyport2DIPInfo,

--- a/src/burn/drv/pst90s/d_ngp.cpp
+++ b/src/burn/drv/pst90s/d_ngp.cpp
@@ -1661,6 +1661,25 @@ struct BurnDriver BurnDrvngpc_kofpara = {
 	160, 152, 4, 3
 };
 
+// King of Fighters, The: Battle de Paradise (Hack, English)
+// https://www.romhacking.net/translations/7436/
+static struct BurnRomInfo ngpc_kofparaeRomDesc[] = {
+	{ "King of Fighters, The - Battle de Paradise T-Eng (2025)(marc_max).ngp", 0x200000, 0xe08dc918, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_kofparae, ngpc_kofparae, ngpc_ngp)
+STD_ROM_FN(ngpc_kofparae)
+
+struct BurnDriver BurnDrvngpc_kofparae = {
+	"ngp_kofparae", "ngp_kofpara", "ngp_ngp", NULL, "2025",
+	"King of Fighters, The: Battle de Paradise (Hack, English)\0", "Force B&W mode to unlock the hidden game 'Yosaku'", "marc_max", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_SNK_NGPC, GBF_BOARD, 0,
+	NgpGetZipName, ngpc_kofparaeRomInfo, ngpc_kofparaeRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpcDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
 // King of Fighters R-1 - Pocket Fighting Series (Euro, Japan)
 static struct BurnRomInfo ngp_kofr1RomDesc[] = {
 	{ "King of Fighters R-1 - Pocket Fighting Series (Euro, Japan)(1998)(SNK).ngp", 0x200000, 0xdceb7e11, 1 | BRF_PRG | BRF_ESS }, // Cartridge
@@ -2796,6 +2815,25 @@ struct BurnDriver BurnDrvngpc_rockmanb = {
 	160, 152, 4, 3
 };
 
+// Rockman: Battle & Fighters (Hack, English v0.9)
+// https://www.romhacking.net/translations/3925/
+static struct BurnRomInfo ngpc_rockmanbeRomDesc[] = {
+	{ "Rockman - Battle & Fighters T-Eng v0.9 (2018)(marc_max).ngp", 0x200000, 0x65985356, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_rockmanbe, ngpc_rockmanbe, ngpc_ngp)
+STD_ROM_FN(ngpc_rockmanbe)
+
+struct BurnDriver BurnDrvngpc_rockmanbe = {
+	"ngp_rockmanbe", "ngp_rockmanb", "ngp_ngp", NULL, "2018",
+	"Rockman: Battle & Fighters (Hack, English v0.9)\0", NULL, "marc_max", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_SNK_NGPC, GBF_PLATFORM, 0,
+	NgpGetZipName, ngpc_rockmanbeRomInfo, ngpc_rockmanbeRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
 // Rockman: Battle & Fighters (Japan, Demo)
 static struct BurnRomInfo ngpc_rockmanbdRomDesc[] = {
 	{ "Rockman - Battle & Fighters (Japan, Demo)(2000)(Capcom).ngp", 0x200000, 0x16a98ac4, 1 | BRF_PRG | BRF_ESS }, // Cartridge
@@ -3327,14 +3365,14 @@ struct BurnDriver BurnDrvngpc_gearsoffate = {
 
 // Manic Miner (HB, v1.0)
 static struct BurnRomInfo ngpc_mminerRomDesc[] = {
-	{ "Manic Miner V1.0 by Lindon Dodd (PD).ngc", 524288, 0x7b23af97, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+	{ "Manic Miner v1.0 (2001)(Lindon Dodd).ngp", 524288, 0x7b23af97, 1 | BRF_PRG | BRF_ESS }, // Cartridge
 };
 
 STDROMPICKEXT(ngpc_mminer, ngpc_mminer, ngpc_ngp)
 STD_ROM_FN(ngpc_mminer)
 
 struct BurnDriver BurnDrvngpc_mminer = {
-	"ngp_mminer", NULL, "ngp_ngp", NULL, "200x",
+	"ngp_mminer", NULL, "ngp_ngp", NULL, "2001",
 	"Manic Miner (HB, v1.0)\0", NULL, "Lindon Dodd", "NeoGeo Pocket Color",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION, 0,


### PR DESCRIPTION
d_msx.cpp: fixed "Titanic (Spanish) (Euro)":
This game got two parts, one in each side of the tape. Previous romset contains both tape sides but only the first one was available. Now this romset is splitted in two parts like their "ZX Spectrum" counterpart.

d_ngp.cpp: added the support to:
- "King of Fighters, The: Battle de Paradise (Hack, English)"
- "Rockman: Battle & Fighters (Hack, English v0.9)"