### PR TITLE
sprite offsets for metmqstr

### DIFF
--- a/src/burn/drv/cave/cave.h
+++ b/src/burn/drv/cave/cave.h
@@ -52,6 +52,7 @@ INT32 CaveTileInitLayer(INT32 nLayer, INT32 nROMSize, INT32 nBitdepth, INT32 nOf
 
 // cave_sprite.cpp
 extern INT32 CaveSpriteVisibleXOffset;
+extern INT32 CaveSpriteVisibleYOffset;
 
 extern UINT8* CaveSpriteROM;
 extern UINT8* CaveSpriteRAM;

--- a/src/burn/drv/cave/cave_sprite.cpp
+++ b/src/burn/drv/cave/cave_sprite.cpp
@@ -2,6 +2,7 @@
 #include "cave.h"
 
 INT32 CaveSpriteVisibleXOffset;
+INT32 CaveSpriteVisibleYOffset;
 
 UINT8* CaveSpriteROM = NULL;
 UINT8* CaveSpriteRAM = NULL;
@@ -379,7 +380,7 @@ static INT32 CaveSpriteBuffer_NoZoom()
 #if 0
 		y = (BURN_ENDIAN_SWAP_INT16(pSprite[3]) + nCaveExtraYOffset) & 0x03FF;
 #else
-		y = BURN_ENDIAN_SWAP_INT16(pSprite[3]) & 0x03FF;
+		y = (BURN_ENDIAN_SWAP_INT16(pSprite[3]) + CaveSpriteVisibleYOffset) & 0x03FF;
 #endif
 		if (y >= 240) {
 			if (y + ys <= 0x0400) {
@@ -455,7 +456,7 @@ static INT32 CaveSpriteBuffer_ZoomA()
 #if 0
 		y = ((BURN_ENDIAN_SWAP_INT16(pSprite[1]) >> 6) + nCaveExtraYOffset) & 0x03FF;
 #else
-		y = (BURN_ENDIAN_SWAP_INT16(pSprite[1]) >> 6) & 0x03FF;
+		y = ((BURN_ENDIAN_SWAP_INT16(pSprite[1]) >> 6) + CaveSpriteVisibleYOffset) & 0x03FF;
 #endif
 
 		if (BURN_ENDIAN_SWAP_INT16(pSprite[4]) <= 0x0100 && BURN_ENDIAN_SWAP_INT16(pSprite[5]) <= 0x0100) {
@@ -543,7 +544,7 @@ static INT32 CaveSpriteBuffer_ZoomB()
 #if 0
 		y = (BURN_ENDIAN_SWAP_INT16(pSprite[1]) + nCaveExtraYOffset) & 0x03FF;
 #else
-		y = BURN_ENDIAN_SWAP_INT16(pSprite[1]) & 0x03FF;
+		y = (BURN_ENDIAN_SWAP_INT16(pSprite[1]) + CaveSpriteVisibleYOffset) & 0x03FF;
 #endif
 
 		if (BURN_ENDIAN_SWAP_INT16(pSprite[4]) <= 0x0100 && BURN_ENDIAN_SWAP_INT16(pSprite[5]) <= 0x0100) {
@@ -669,6 +670,7 @@ void CaveSpriteExit()
 	BurnFree(pZBuffer);
 	
 	CaveSpriteVisibleXOffset = 0;
+	CaveSpriteVisibleYOffset = 0;
 
 	return;
 }

--- a/src/burn/drv/cave/d_metmqstr.cpp
+++ b/src/burn/drv/cave/d_metmqstr.cpp
@@ -164,8 +164,8 @@ void __fastcall metmqstrWriteWord(UINT32 sekAddress, UINT16 wordValue)
 			return;
 			
 		case 0xa80008:
-			CaveSpriteBuffer();
 			nCaveSpriteBank = wordValue;
+			CaveSpriteBuffer();
 			return;
 			
 		case 0xa8006E:
@@ -734,8 +734,10 @@ static INT32 DrvInit()
 	CaveTileInitLayer(1, 0x400000, 8, 0x4000);
 	CaveTileInitLayer(2, 0x400000, 8, 0x4000);
 	
-	nCaveExtraXOffset = -126;
-	CaveSpriteVisibleXOffset = -126;
+	nCaveExtraXOffset = -125;
+	nCaveExtraYOffset = +1;
+	CaveSpriteVisibleXOffset = -125;
+	CaveSpriteVisibleYOffset = +1;
 	
 	BurnYM2151Init(4000000);
 	BurnYM2151SetIrqHandler(&DrvYM2151IrqHandler);


### PR DESCRIPTION
I fixed the sprite offset while creating an fpga implementation for Metamoqester. Here's the necessary changes to display the correct offsets. Grid pattern shown for reference.

Before:
<img width="3840" height="2051" alt="00" src="https://github.com/user-attachments/assets/c766be9a-bc40-4536-a724-3a5f11f4fd60" />
After:
<img width="3840" height="2051" alt="01" src="https://github.com/user-attachments/assets/1e8b60ed-2461-4512-ad3c-e0883f6e2942" />
