### PR TITLE
d_msx.cpp: added the support to "Arcade Fever (HB)" and "Casio Collection (HB)"

### DIFF
--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -28018,6 +28018,24 @@ struct BurnDriver BurnDrvMSX_antiair = {
 	272, 228, 4, 3
 };
 
+// Arcade Fever (HB)
+static struct BurnRomInfo MSX_arcadefeverRomDesc[] = {
+	{ "Arcade Fever (2025)(SMX Team).rom",	1998848, 0x5cc305c3, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(MSX_arcadefever, MSX_arcadefever, msx_msx)
+STD_ROM_FN(MSX_arcadefever)
+
+struct BurnDriver BurnDrvMSX_arcadefever = {
+	"msx_arcadefever", NULL, "msx_msx", NULL, "2025",
+	"Arcade Fever (HB)\0", "R-Type doesn't work", "SMX Team", "MSX",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_MISC, 0,
+	MSXGetZipName, MSX_arcadefeverRomInfo, MSX_arcadefeverRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
+	272, 228, 4, 3
+};
+
 // Arcomage (HB)
 static struct BurnRomInfo MSX_arcomageRomDesc[] = {
 	{ "Arcomage (2015)(Bitvision).rom",	65536, 0xa72794ba, BRF_PRG | BRF_ESS },
@@ -28879,6 +28897,24 @@ struct BurnDriver BurnDrvMSX_caos = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_caosRomInfo, MSX_caosRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
+	272, 228, 4, 3
+};
+
+// Casio Collection (HB)
+static struct BurnRomInfo MSX_casiocollRomDesc[] = {
+	{ "Casio Collection (2025)(SMX Team).rom",	827392, 0xcb857ad7, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(MSX_casiocoll, MSX_casiocoll, msx_msx)
+STD_ROM_FN(MSX_casiocoll)
+
+struct BurnDriver BurnDrvMSX_casiocoll = {
+	"msx_casiocoll", NULL, "msx_msx", NULL, "2025",
+	"Casio Collection (HB)\0", NULL, "SMX Team", "MSX",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_MISC, 0,
+	MSXGetZipName, MSX_casiocollRomInfo, MSX_casiocollRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
 };


### PR DESCRIPTION
"Arcade Fever (HB)": 34 games in one ROM!

1942
Arkanoid
Bank Panic
Bomber Man Special
Bosconian
Chack'n Pop
Circus Charlie
Dig Dug
Donkey Kong
Elevator Action
Exerion
Formation Z
Frogger
Front Line
Galaga
Galaxian
Green Beret
Hang-On
Hunchback
Kung Fu Acho
Mappy
Ninja Princess
Pac-Man
Puznic
Q-Bert
R-Type
Rally-X
Space Invaders
Star Force
Super Cobra
Tetris
The Fairy Land Story
Twin Bee
Zaxxon

"Casio Collection (HB)": 32 games in one ROM!

Exciting Jockey
Exciting Baseball
Ski Command
Pachinko Ufo
Circus Charlie
Konami's Tennis
Flappy Limited
Yie Are Kung-Fu
Volguard
King's Valley
Mopi Ranger
Ice World
Eagle Fighter
Casio World Open
Zexas Limited
Road Fighter
Notebook of Iga's Techniq
car Fighter
Sinbad
Exoide-Z
Yie Are Kung-Fu II
Knightmare
Ghost House
Adventure of a Small Cat
The Stone of Wisdom
Spelumker
Twin Bee
The Fight of Full Moon Ca
Exoide-Z Area 5
Secret Treasure of Moai
King Hades of Darkness
Small Boy's Quiz