### PR TITLE
Update pgm2： A new card will be inserted by default if no card is inserted.

### DIFF
--- a/src/burn/drv/pgm2/pgm2_run.cpp
+++ b/src/burn/drv/pgm2/pgm2_run.cpp
@@ -841,7 +841,13 @@ static void pgm2McuCommand(bool isCommand)
             break;
 
             case 0xc0: // insert card / check card presence
-            case 0xc1: // check ready/busy
+                if (!pgm2CardPresent(arg1 & 3)) {
+                    status = 0x00f70000;
+                }
+                Pgm2McuResult0 = cmd;
+			break;
+
+			case 0xc1: // check ready/busy
                 if (!pgm2CardPresent(arg1)) {
                     status = 0x00f40000;
                 }


### PR DESCRIPTION
 A temp new card will be inserted by default if no card is inserted.

This allows the use of special characters that can only be used when a card is inserted. It does not affect normal card insertion; it only takes effect when no card is inserted.

<img width="1796" height="956" alt="1" src="https://github.com/user-attachments/assets/048a09bd-11d4-4874-ae85-f21619aa5cba" />

<img width="1444" height="1020" alt="2" src="https://github.com/user-attachments/assets/569839bc-fa21-4411-860f-17e9294556b9" />
