### PR TITLE
Added the support to 48 Inufuto's games

### DIFF
--- a/src/burn/drv/coleco/d_coleco.cpp
+++ b/src/burn/drv/coleco/d_coleco.cpp
@@ -5325,7 +5325,7 @@ struct BurnDriver BurnDrvcv_ascend = {
 	"cv_ascend", NULL, "cv_coleco", NULL, "2022",
 	"Ascend (HB)\0", NULL, "Inufuto", "ColecoVision",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_PLATFORM, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_PLATFORM, 0,
 	CVGetZipName, cv_ascendRomInfo, cv_ascendRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
@@ -5399,6 +5399,24 @@ struct BurnDriver BurnDrvcv_astorm = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_MULTISHOOT, 0,
 	CVGetZipName, cv_astormRomInfo, cv_astormRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Awass (HB)
+static struct BurnRomInfo cv_awassRomDesc[] = {
+	{ "Awass (2026)(Inufuto).rom",	9341, 0xc38cdf41, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_awass, cv_awass, cv_coleco)
+STD_ROM_FN(cv_awass)
+
+struct BurnDriver BurnDrvcv_awass = {
+	"cv_awass", NULL, "cv_coleco", NULL, "2026",
+	"Awass (HB)\0", NULL, "Inufuto", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_PLATFORM | GBF_PUZZLE, 0,
+	CVGetZipName, cv_awassRomInfo, cv_awassRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -6513,7 +6531,7 @@ struct BurnDriver BurnDrvcv_cracky = {
 	"cv_cracky", NULL, "cv_coleco", NULL, "2023",
 	"Cracky (HB)\0", NULL, "Inufuto", "ColecoVision",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_PLATFORM, 0,
 	CVGetZipName, cv_crackyRomInfo, cv_crackyRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
@@ -8067,6 +8085,24 @@ struct BurnDriver BurnDrvcv_impetus = {
 	272, 228, 4, 3
 };
 
+// Impetus+ (HB)
+static struct BurnRomInfo cv_impetusplusRomDesc[] = {
+	{ "Impetus+ (2025)(Inufuto).rom",	17919, 0x08e88ad2, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_impetusplus, cv_impetusplus, cv_coleco)
+STD_ROM_FN(cv_impetusplus)
+
+struct BurnDriver BurnDrvcv_impetusplus = {
+	"cv_impetusplus", NULL, "cv_coleco", NULL, "2025",
+	"Impetus+ (HB)\0", NULL, "Inufuto", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_VERSHOOT, 0,
+	CVGetZipName, cv_impetusplusRomInfo, cv_impetusplusRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Insane Pickin' Sticks VIII (HB)
 static struct BurnRomInfo cv_insanepickRomDesc[] = {
     { "Insane Pickin' Sticks VIII (2010)(Daniel Bienvenu).rom",	0x7890, 0x5a6c2d2f, BRF_PRG | BRF_ESS },
@@ -8583,7 +8619,7 @@ struct BurnDriver BurnDrvcv_lift = {
 	"cv_lift", NULL, "cv_coleco", NULL, "2022",
 	"Lift (HB)\0", NULL, "Inufuto", "ColecoVision",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_PLATFORM, 0,
 	CVGetZipName, cv_liftRomInfo, cv_liftRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
@@ -9053,6 +9089,24 @@ struct BurnDriver BurnDrvcv_mmtxvol2 = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_PLATFORM, 0,
 	CVGetZipName, cv_mmtxvol2RomInfo, cv_mmtxvol2RomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Mieyen (HB)
+static struct BurnRomInfo cv_mieyenRomDesc[] = {
+	{ "Mieyen (2025)(Inufuto).rom",	8361, 0xf47e5bf5, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_mieyen, cv_mieyen, cv_coleco)
+STD_ROM_FN(cv_mieyen)
+
+struct BurnDriver BurnDrvcv_mieyen = {
+	"cv_mieyen", NULL, "cv_coleco", NULL, "2025",
+	"Mieyen (HB)\0", NULL, "Inufuto", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_MAZE, 0,
+	CVGetZipName, cv_mieyenRomInfo, cv_mieyenRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -9555,7 +9609,7 @@ struct BurnDriver BurnDrvcv_osotos = {
 	"cv_osotos", NULL, "cv_coleco", NULL, "2024",
 	"Osotos (HB)\0", NULL, "Inufuto", "ColecoVision",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_PLATFORM, 0,
 	CVGetZipName, cv_osotosRomInfo, cv_osotosRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
@@ -11396,9 +11450,9 @@ struct BurnDriver BurnDrvcv_swtacorn = {
     272, 228, 4, 3
 };
 
-// Sword Work (HB)
+// SwordWork (HB)
 static struct BurnRomInfo cv_swordworkRomDesc[] = {
-	{ "Sword Work (2026)(Inufuto).rom",	16384, 0xc4a13993, BRF_PRG | BRF_ESS },
+	{ "SwordWork (2026)(Inufuto).rom",	16384, 0xc4a13993, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(cv_swordwork, cv_swordwork, cv_coleco)
@@ -11406,9 +11460,9 @@ STD_ROM_FN(cv_swordwork)
 
 struct BurnDriver BurnDrvcv_swordwork = {
 	"cv_swordwork", NULL, "cv_coleco", NULL, "2026",
-	"Sword Work (HB)\0", NULL, "Inufuto", "ColecoVision",
+	"SwordWork (HB)\0", NULL, "Inufuto", "ColecoVision",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_MAZE, 0,
 	CVGetZipName, cv_swordworkRomInfo, cv_swordworkRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3

--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -28088,7 +28088,7 @@ struct BurnDriver BurnDrvMSX_ascend = {
 	"msx_ascend", NULL, "msx_msx", NULL, "2022",
 	"Ascend (HB)\0", NULL, "Inufuto", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION | GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_ascendRomInfo, MSX_ascendRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
@@ -29439,7 +29439,7 @@ struct BurnDriver BurnDrvMSX_cracky = {
 	"msx_cracky", NULL, "msx_msx", NULL, "2023",
 	"Cracky (HB)\0", NULL, "Inufuto", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION | GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_crackyRomInfo, MSX_crackyRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	CasBloadDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
@@ -31582,7 +31582,7 @@ struct BurnDriver BurnDrvMSX_lift = {
 	"msx_lift", NULL, "msx_msx", NULL, "2021",
 	"Lift (HB)\0", NULL, "Inufuto", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION | GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_liftRomInfo, MSX_liftRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
@@ -33023,7 +33023,7 @@ struct BurnDriver BurnDrvMSX_osotos = {
 	"msx_osotos", NULL, "msx_msx", NULL, "2024",
 	"Osotos (HB)\0", NULL, "Inufuto", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION | GBF_PLATFORM, 0,
 	MSXGetZipName, MSX_osotosRomInfo, MSX_osotosRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	CasBloadDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3
@@ -34848,9 +34848,9 @@ struct BurnDriver BurnDrvMSX_svellas = {
 	272, 228, 4, 3
 };
 
-// Sword Work (HB)
+// SwordWork (HB)
 static struct BurnRomInfo MSX_swordworkRomDesc[] = {
-	{ "Sword Work (2026)(Inufuto).cas",	8578, 0x4273bce0, BRF_PRG | BRF_ESS },
+	{ "SwordWork (2026)(Inufuto).cas",	8578, 0x4273bce0, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(MSX_swordwork, MSX_swordwork, msx_msx)
@@ -34858,9 +34858,9 @@ STD_ROM_FN(MSX_swordwork)
 
 struct BurnDriver BurnDrvMSX_swordwork = {
 	"msx_swordwork", NULL, "msx_msx", NULL, "2026",
-	"Sword Work (HB)\0", NULL, "Inufuto", "MSX",
+	"SwordWork (HB)\0", NULL, "Inufuto", "MSX",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION | GBF_MAZE, 0,
 	MSXGetZipName, MSX_swordworkRomInfo, MSX_swordworkRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
 	CasBloadDrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
 	272, 228, 4, 3

--- a/src/burn/drv/pst90s/d_ngp.cpp
+++ b/src/burn/drv/pst90s/d_ngp.cpp
@@ -3326,20 +3326,164 @@ struct BurnDriverX BurnDrvngpc_ppaa01 = {
 // Aftermarket/Homebrew Games
 // --------------------------
 
-// Fruity Pals' Revenge (HB, v1.2)
-static struct BurnRomInfo ngpc_fruitypalsrRomDesc[] = {
-	{ "Fruity Pals' Revenge v1.2 (2025)(Infinite State Games).ngp", 2097152, 0xf92db309, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+// Aerial Mini (HB)
+static struct BurnRomInfo ngpc_aerialmRomDesc[] = {
+	{ "Aerial Mini (2025)(Inufuto).ngp", 524288, 0x3fc9f157, 1 | BRF_PRG | BRF_ESS }, // Cartridge
 };
 
-STDROMPICKEXT(ngpc_fruitypalsr, ngpc_fruitypalsr, ngpc_ngp)
-STD_ROM_FN(ngpc_fruitypalsr)
+STDROMPICKEXT(ngpc_aerialm, ngpc_aerialm, ngpc_ngp)
+STD_ROM_FN(ngpc_aerialm)
 
-struct BurnDriver BurnDrvngpc_fruitypalsr = {
-	"ngp_fruitypalsr", NULL, "ngp_ngp", NULL, "2025",
-	"Fruity Pals' Revenge (HB, v1.2)\0", NULL, "Infinite State Games", "NeoGeo Pocket Color",
+struct BurnDriver BurnDrvngpc_aerialm = {
+	"ngp_aerialm", NULL, "ngp_ngp", NULL, "2025",
+	"Aerial Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_PUZZLE, 0,
-	NgpGetZipName, ngpc_fruitypalsrRomInfo, ngpc_fruitypalsrRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_HORSHOOT, 0,
+	NgpGetZipName, ngpc_aerialmRomInfo, ngpc_aerialmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// AntiAir Mini (HB)
+static struct BurnRomInfo ngpc_antiairmRomDesc[] = {
+	{ "AntiAir Mini (2025)(Inufuto).ngp", 524288, 0x5b006870, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_antiairm, ngpc_antiairm, ngpc_ngp)
+STD_ROM_FN(ngpc_antiairm)
+
+struct BurnDriver BurnDrvngpc_antiairm = {
+	"ngp_antiairm", NULL, "ngp_ngp", NULL, "2025",
+	"AntiAir Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_VERSHOOT, 0,
+	NgpGetZipName, ngpc_antiairmRomInfo, ngpc_antiairmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Ascend Mini (HB)
+static struct BurnRomInfo ngpc_ascendmRomDesc[] = {
+	{ "Ascend Mini (2025)(Inufuto).ngp", 524288, 0xc827c339, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_ascendm, ngpc_ascendm, ngpc_ngp)
+STD_ROM_FN(ngpc_ascendm)
+
+struct BurnDriver BurnDrvngpc_ascendm = {
+	"ngp_ascendm", NULL, "ngp_ngp", NULL, "2025",
+	"Ascend Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_PLATFORM, 0,
+	NgpGetZipName, ngpc_ascendmRomInfo, ngpc_ascendmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Awass Micro (HB)
+static struct BurnRomInfo ngpc_awassmRomDesc[] = {
+	{ "Awass Micro (2026)(Inufuto).ngp", 524288, 0x0304dbca, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_awassm, ngpc_awassm, ngpc_ngp)
+STD_ROM_FN(ngpc_awassm)
+
+struct BurnDriver BurnDrvngpc_awassm = {
+	"ngp_awassm", NULL, "ngp_ngp", NULL, "2026",
+	"Awass Micro (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_PLATFORM | GBF_PUZZLE, 0,
+	NgpGetZipName, ngpc_awassmRomInfo, ngpc_awassmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Battlot Mini (HB)
+static struct BurnRomInfo ngpc_battlotmRomDesc[] = {
+	{ "Battlot Mini (2025)(Inufuto).ngp", 524288, 0x694eed46, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_battlotm, ngpc_battlotm, ngpc_ngp)
+STD_ROM_FN(ngpc_battlotm)
+
+struct BurnDriver BurnDrvngpc_battlotm = {
+	"ngp_battlotm", NULL, "ngp_ngp", NULL, "2025",
+	"Battlot Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_MAZE | GBF_RUNGUN, 0,
+	NgpGetZipName, ngpc_battlotmRomInfo, ngpc_battlotmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Bootskell Mini (HB)
+static struct BurnRomInfo ngpc_bootskellmRomDesc[] = {
+	{ "Bootskell Mini (2025)(Inufuto).ngp", 524288, 0x3aa89e2e, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_bootskellm, ngpc_bootskellm, ngpc_ngp)
+STD_ROM_FN(ngpc_bootskellm)
+
+struct BurnDriver BurnDrvngpc_bootskellm = {
+	"ngp_bootskellm", NULL, "ngp_ngp", NULL, "2025",
+	"Bootskell Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_bootskellmRomInfo, ngpc_bootskellmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Cacorm Mini (HB)
+static struct BurnRomInfo ngpc_cacormmRomDesc[] = {
+	{ "Cacorm Mini (2025)(Inufuto).ngp", 524288, 0x473d7943, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_cacormm, ngpc_cacormm, ngpc_ngp)
+STD_ROM_FN(ngpc_cacormm)
+
+struct BurnDriver BurnDrvngpc_cacormm = {
+	"ngp_cacormm", NULL, "ngp_ngp", NULL, "2025",
+	"Cacorm Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_cacormmRomInfo, ngpc_cacormmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Cavit Mini (HB)
+static struct BurnRomInfo ngpc_cavitmRomDesc[] = {
+	{ "Cavit Mini (2025)(Inufuto).ngp", 524288, 0x3b10d453, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_cavitm, ngpc_cavitm, ngpc_ngp)
+STD_ROM_FN(ngpc_cavitm)
+
+struct BurnDriver BurnDrvngpc_cavitm = {
+	"ngp_cavitm", NULL, "ngp_ngp", NULL, "2025",
+	"Cavit Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION, 0,
+	NgpGetZipName, ngpc_cavitmRomInfo, ngpc_cavitmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Cracky Mini (HB)
+static struct BurnRomInfo ngpc_crackymRomDesc[] = {
+	{ "Cracky Mini (2025)(Inufuto).ngp", 524288, 0x7cb9fe1f, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_crackym, ngpc_crackym, ngpc_ngp)
+STD_ROM_FN(ngpc_crackym)
+
+struct BurnDriver BurnDrvngpc_crackym = {
+	"ngp_crackym", NULL, "ngp_ngp", NULL, "2025",
+	"Cracky Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_PLATFORM, 0,
+	NgpGetZipName, ngpc_crackymRomInfo, ngpc_crackymRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
 	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
 	160, 152, 4, 3
 };
@@ -3362,6 +3506,24 @@ struct BurnDriver BurnDrvngpc_ddmr = {
 	160, 152, 4, 3
 };
 
+// Fruity Pals' Revenge (HB, v1.2)
+static struct BurnRomInfo ngpc_fruitypalsrRomDesc[] = {
+	{ "Fruity Pals' Revenge v1.2 (2025)(Infinite State Games).ngp", 2097152, 0xf92db309, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_fruitypalsr, ngpc_fruitypalsr, ngpc_ngp)
+STD_ROM_FN(ngpc_fruitypalsr)
+
+struct BurnDriver BurnDrvngpc_fruitypalsr = {
+	"ngp_fruitypalsr", NULL, "ngp_ngp", NULL, "2025",
+	"Fruity Pals' Revenge (HB, v1.2)\0", NULL, "Infinite State Games", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_PUZZLE, 0,
+	NgpGetZipName, ngpc_fruitypalsrRomInfo, ngpc_fruitypalsrRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
 // Gears of Fate (HB)
 static struct BurnRomInfo ngpc_gearsoffateRomDesc[] = {
 	{ "Gears of Fate (2009)(Thor).ngp", 1917732, 0x3c75807e, 1 | BRF_PRG | BRF_ESS }, // Cartridge
@@ -3380,6 +3542,96 @@ struct BurnDriver BurnDrvngpc_gearsoffate = {
 	160, 152, 4, 3
 };
 
+// Guntus Mini (HB)
+static struct BurnRomInfo ngpc_guntusmRomDesc[] = {
+	{ "Guntus Mini (2025)(Inufuto).ngp", 524288, 0x66e24bdb, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_guntusm, ngpc_guntusm, ngpc_ngp)
+STD_ROM_FN(ngpc_guntusm)
+
+struct BurnDriver BurnDrvngpc_guntusm = {
+	"ngp_guntusm", NULL, "ngp_ngp", NULL, "2025",
+	"Guntus Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_VERSHOOT, 0,
+	NgpGetZipName, ngpc_guntusmRomInfo, ngpc_guntusmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Hopman Mini (HB)
+static struct BurnRomInfo ngpc_hopmanmRomDesc[] = {
+	{ "Hopman Mini (2025)(Inufuto).ngp", 524288, 0x4c8a4bf2, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_hopmanm, ngpc_hopmanm, ngpc_ngp)
+STD_ROM_FN(ngpc_hopmanm)
+
+struct BurnDriver BurnDrvngpc_hopmanm = {
+	"ngp_hopmanm", NULL, "ngp_ngp", NULL, "2025",
+	"Hopman Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_PLATFORM, 0,
+	NgpGetZipName, ngpc_hopmanmRomInfo, ngpc_hopmanmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Impetus Mini (HB)
+static struct BurnRomInfo ngpc_impetusmRomDesc[] = {
+	{ "Impetus Mini (2025)(Inufuto).ngp", 524288, 0x0bef4816, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_impetusm, ngpc_impetusm, ngpc_ngp)
+STD_ROM_FN(ngpc_impetusm)
+
+struct BurnDriver BurnDrvngpc_impetusm = {
+	"ngp_impetusm", NULL, "ngp_ngp", NULL, "2025",
+	"Impetus Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_VERSHOOT, 0,
+	NgpGetZipName, ngpc_impetusmRomInfo, ngpc_impetusmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Impetus+ Micro (HB)
+static struct BurnRomInfo ngpc_impetuspmRomDesc[] = {
+	{ "Impetus+ Micro (2025)(Inufuto).ngp", 524288, 0xce7a627c, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_impetuspm, ngpc_impetuspm, ngpc_ngp)
+STD_ROM_FN(ngpc_impetuspm)
+
+struct BurnDriver BurnDrvngpc_impetuspm = {
+	"ngp_impetuspm", NULL, "ngp_ngp", NULL, "2025",
+	"Impetus+ Micro (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_VERSHOOT, 0,
+	NgpGetZipName, ngpc_impetuspmRomInfo, ngpc_impetuspmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Lift Mini (HB)
+static struct BurnRomInfo ngpc_liftmRomDesc[] = {
+	{ "Lift Mini (2025)(Inufuto).ngp", 524288, 0x09ef36ea, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_liftm, ngpc_liftm, ngpc_ngp)
+STD_ROM_FN(ngpc_liftm)
+
+struct BurnDriver BurnDrvngpc_liftm = {
+	"ngp_liftm", NULL, "ngp_ngp", NULL, "2025",
+	"Lift Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_PLATFORM, 0,
+	NgpGetZipName, ngpc_liftmRomInfo, ngpc_liftmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
 // Manic Miner (HB, v1.0)
 static struct BurnRomInfo ngpc_mminerRomDesc[] = {
 	{ "Manic Miner v1.0 (2001)(Lindon Dodd).ngp", 524288, 0x7b23af97, 1 | BRF_PRG | BRF_ESS }, // Cartridge
@@ -3394,6 +3646,150 @@ struct BurnDriver BurnDrvngpc_mminer = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION, 0,
 	NgpGetZipName, ngpc_mminerRomInfo, ngpc_mminerRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Mazy Mini (HB)
+static struct BurnRomInfo ngpc_mazymRomDesc[] = {
+	{ "Mazy Mini (2025)(Inufuto).ngp", 524288, 0xf7180631, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_mazym, ngpc_mazym, ngpc_ngp)
+STD_ROM_FN(ngpc_mazym)
+
+struct BurnDriver BurnDrvngpc_mazym = {
+	"ngp_mazym", NULL, "ngp_ngp", NULL, "2025",
+	"Mazy Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_mazymRomInfo, ngpc_mazymRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Mazy 2 Micro (HB)
+static struct BurnRomInfo ngpc_mazy2mRomDesc[] = {
+	{ "Mazy 2 Micro (2025)(Inufuto).ngp", 524288, 0xf98b615a, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_mazy2m, ngpc_mazy2m, ngpc_ngp)
+STD_ROM_FN(ngpc_mazy2m)
+
+struct BurnDriver BurnDrvngpc_mazy2m = {
+	"ngp_mazy2m", NULL, "ngp_ngp", NULL, "2025",
+	"Mazy 2 Micro (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_mazy2mRomInfo, ngpc_mazy2mRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Mieyen Mini (HB)
+static struct BurnRomInfo ngpc_mieyenmRomDesc[] = {
+	{ "Mieyen Mini (2025)(Inufuto).ngp", 524288, 0x17cd1b2d, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_mieyenm, ngpc_mieyenm, ngpc_ngp)
+STD_ROM_FN(ngpc_mieyenm)
+
+struct BurnDriver BurnDrvngpc_mieyenm = {
+	"ngp_mieyenm", NULL, "ngp_ngp", NULL, "2025",
+	"Mieyen Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_mieyenmRomInfo, ngpc_mieyenmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Neuras Mini (HB)
+static struct BurnRomInfo ngpc_neurasmRomDesc[] = {
+	{ "Neuras Mini (2025)(Inufuto).ngp", 524288, 0xf03b93fe, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_neurasm, ngpc_neurasm, ngpc_ngp)
+STD_ROM_FN(ngpc_neurasm)
+
+struct BurnDriver BurnDrvngpc_neurasm = {
+	"ngp_neurasm", NULL, "ngp_ngp", NULL, "2025",
+	"Neuras Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_neurasmRomInfo, ngpc_neurasmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Osotos Mini (HB)
+static struct BurnRomInfo ngpc_osotosmRomDesc[] = {
+	{ "Osotos Mini (2025)(Inufuto).ngp", 524288, 0xdeb63720, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_osotosm, ngpc_osotosm, ngpc_ngp)
+STD_ROM_FN(ngpc_osotosm)
+
+struct BurnDriver BurnDrvngpc_osotosm = {
+	"ngp_osotosm", NULL, "ngp_ngp", NULL, "2025",
+	"Osotos Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_PLATFORM, 0,
+	NgpGetZipName, ngpc_osotosmRomInfo, ngpc_osotosmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Ruptus Mini (HB)
+static struct BurnRomInfo ngpc_ruptusmRomDesc[] = {
+	{ "Ruptus Mini (2025)(Inufuto).ngp", 524288, 0x09f1b098, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_ruptusm, ngpc_ruptusm, ngpc_ngp)
+STD_ROM_FN(ngpc_ruptusm)
+
+struct BurnDriver BurnDrvngpc_ruptusm = {
+	"ngp_ruptusm", NULL, "ngp_ngp", NULL, "2025",
+	"Ruptus Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_MULTISHOOT, 0,
+	NgpGetZipName, ngpc_ruptusmRomInfo, ngpc_ruptusmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Svellas Micro (HB)
+static struct BurnRomInfo ngpc_svellasmRomDesc[] = {
+	{ "Svellas Micro (2025)(Inufuto).ngp", 524288, 0xc10d5ff6, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_svellasm, ngpc_svellasm, ngpc_ngp)
+STD_ROM_FN(ngpc_svellasm)
+
+struct BurnDriver BurnDrvngpc_svellasm = {
+	"ngp_svellasm", NULL, "ngp_ngp", NULL, "2025",
+	"Svellas Micro (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_svellasmRomInfo, ngpc_svellasmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
+// Yewdow Mini (HB)
+static struct BurnRomInfo ngpc_yewdowmRomDesc[] = {
+	{ "Yewdow Mini (2025)(Inufuto).ngp", 524288, 0x2b56cec9, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_yewdowm, ngpc_yewdowm, ngpc_ngp)
+STD_ROM_FN(ngpc_yewdowm)
+
+struct BurnDriver BurnDrvngpc_yewdowm = {
+	"ngp_yewdowm", NULL, "ngp_ngp", NULL, "2025",
+	"Yewdow Mini (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_yewdowmRomInfo, ngpc_yewdowmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
 	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
 	160, 152, 4, 3
 };

--- a/src/burn/drv/sg1000/d_sg1000.cpp
+++ b/src/burn/drv/sg1000/d_sg1000.cpp
@@ -4084,6 +4084,24 @@ struct BurnDriver BurnDrvsg1k_arnodash2 = {
 	272, 228, 4, 3
 };
 
+// Ascend (HB)
+static struct BurnRomInfo sg1k_ascendRomDesc[] = {
+	{ "Ascend (2022)(Inufuto).sg",	9451, 0x69e60ce5, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_ascend)
+STD_ROM_FN(sg1k_ascend)
+
+struct BurnDriver BurnDrvsg1k_ascend = {
+	"sg1k_ascend", NULL, NULL, NULL, "2022",
+	"Ascend (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_PLATFORM, 0,
+	SG1KGetZipName, sg1k_ascendRomInfo, sg1k_ascendRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Astrododge (HB)
 static struct BurnRomInfo sg1k_astrododgeRomDesc[] = {
 	{ "Astrododge (2012)(Revival Studios).sg",	32768, 0xb895942d, BRF_PRG | BRF_ESS },
@@ -4120,6 +4138,24 @@ struct BurnDriver BurnDrvsg1k_awass = {
 	272, 228, 4, 3
 };
 
+// Battlot (HB)
+static struct BurnRomInfo sg1k_battlotRomDesc[] = {
+	{ "Battlot (2021)(Inufuto).sg",	9745, 0x90532d80, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_battlot)
+STD_ROM_FN(sg1k_battlot)
+
+struct BurnDriver BurnDrvsg1k_battlot = {
+	"sg1k_battlot", NULL, NULL, NULL, "2021",
+	"Battlot (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_MAZE | GBF_RUNGUN, 0,
+	SG1KGetZipName, sg1k_battlotRomInfo, sg1k_battlotRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Bloktris (HB)
 static struct BurnRomInfo sg1k_bloktrisRomDesc[] = {
 	{ "Bloktris (2023)(Under4Mhz).sg",	49152, 0x7febcd40, BRF_PRG | BRF_ESS },
@@ -4134,6 +4170,24 @@ struct BurnDriver BurnDrvsg1k_bloktris = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_PUZZLE, 0,
 	SG1KGetZipName, sg1k_bloktrisRomInfo, sg1k_bloktrisRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Bootskell (HB)
+static struct BurnRomInfo sg1k_bootskellRomDesc[] = {
+	{ "Bootskell (2021)(Inufuto).sg",	9448, 0xc2413720, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_bootskell)
+STD_ROM_FN(sg1k_bootskell)
+
+struct BurnDriver BurnDrvsg1k_bootskell = {
+	"sg1k_bootskell", NULL, NULL, NULL, "2021",
+	"Bootskell (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_MAZE, 0,
+	SG1KGetZipName, sg1k_bootskellRomInfo, sg1k_bootskellRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -4240,7 +4294,7 @@ struct BurnDriver BurnDrvsg1k_cracky = {
 	"sg1k_cracky", NULL, NULL, NULL, "2023",
 	"Cracky (HB)\0", NULL, "Inufuto", "Sega SG-1000",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_PLATFORM, 0,
 	SG1KGetZipName, sg1k_crackyRomInfo, sg1k_crackyRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
@@ -4426,6 +4480,24 @@ struct BurnDriver BurnDrvsg1k_ksolitaire = {
 	272, 228, 4, 3
 };
 
+// Lift (HB)
+static struct BurnRomInfo sg1k_liftRomDesc[] = {
+	{ "Lift (2022)(Inufuto).sg",	8297, 0xf5e62875, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_lift)
+STD_ROM_FN(sg1k_lift)
+
+struct BurnDriver BurnDrvsg1k_lift = {
+	"sg1k_lift", NULL, NULL, NULL, "2022",
+	"Lift (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_PLATFORM, 0,
+	SG1KGetZipName, sg1k_liftRomInfo, sg1k_liftRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Mahjong Solitaire (HB, v1.16)
 static struct BurnRomInfo sg1k_msolitaireRomDesc[] = {
 	{ "Mahjong Solitaire v1.16 (2023)(Under4Mhz).sg",	32768, 0xd07afa95, BRF_PRG | BRF_ESS },
@@ -4498,6 +4570,24 @@ struct BurnDriver BurnDrvsg1k_mieyen = {
 	272, 228, 4, 3
 };
 
+// Neuras (HB)
+static struct BurnRomInfo sg1k_neurasRomDesc[] = {
+	{ "Neuras (2021)(Inufuto).sg",	8373, 0xbeb45e42, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_neuras)
+STD_ROM_FN(sg1k_neuras)
+
+struct BurnDriver BurnDrvsg1k_neuras = {
+	"sg1k_neuras", NULL, NULL, NULL, "2021",
+	"Neuras (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_MAZE, 0,
+	SG1KGetZipName, sg1k_neurasRomInfo, sg1k_neurasRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Operation Hibernation Plus (HB, Rev.2)
 static struct BurnRomInfo sg1k_ophibernplusRomDesc[] = {
 	{ "Operation Hibernation Plus Rev.2 (2025)(Jess Creations - ArugulaZ).sg",	49152, 0xd4b2189a, BRF_PRG | BRF_ESS },
@@ -4512,6 +4602,24 @@ struct BurnDriver BurnDrvsg1k_ophibernplus = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_PLATFORM, 0,
 	SG1KGetZipName, sg1k_ophibernplusRomInfo, sg1k_ophibernplusRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Osotos (HB)
+static struct BurnRomInfo sg1k_osotosRomDesc[] = {
+	{ "Osotos (2024)(Inufuto).sg",	16384, 0x5e4238de, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_osotos)
+STD_ROM_FN(sg1k_osotos)
+
+struct BurnDriver BurnDrvsg1k_osotos = {
+	"sg1k_osotos", NULL, NULL, NULL, "2024",
+	"Osotos (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_PLATFORM, 0,
+	SG1KGetZipName, sg1k_osotosRomInfo, sg1k_osotosRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -4585,6 +4693,24 @@ struct BurnDriver BurnDrvsg1k_retropipe = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_PUZZLE, 0,
 	SG1KGetZipName, sg1k_retropipeRomInfo, sg1k_retropipeRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Ruptus (HB)
+static struct BurnRomInfo sg1k_ruptusRomDesc[] = {
+	{ "Ruptus (2021)(Inufuto).sg",	12455, 0x61b4a940, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sg1k_ruptus)
+STD_ROM_FN(sg1k_ruptus)
+
+struct BurnDriver BurnDrvsg1k_ruptus = {
+	"sg1k_ruptus", NULL, NULL, NULL, "2021",
+	"Ruptus (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_MULTISHOOT, 0,
+	SG1KGetZipName, sg1k_ruptusRomInfo, sg1k_ruptusRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -4697,9 +4823,9 @@ struct BurnDriver BurnDrvsg1k_svellas = {
 	272, 228, 4, 3
 };
 
-// Sword Work (HB)
+// SwordWork (HB)
 static struct BurnRomInfo sg1k_swordworkRomDesc[] = {
-	{ "Sword Work (2026)(Inufuto).sg",	16384, 0x1bfc657f, BRF_PRG | BRF_ESS },
+	{ "SwordWork (2026)(Inufuto).sg",	16384, 0x1bfc657f, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sg1k_swordwork)
@@ -4707,9 +4833,9 @@ STD_ROM_FN(sg1k_swordwork)
 
 struct BurnDriver BurnDrvsg1k_swordwork = {
 	"sg1k_swordwork", NULL, NULL, NULL, "2026",
-	"Sword Work (HB)\0", NULL, "Inufuto", "Sega SG-1000",
+	"SwordWork (HB)\0", NULL, "Inufuto", "Sega SG-1000",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_MAZE, 0,
 	SG1KGetZipName, sg1k_swordworkRomInfo, sg1k_swordworkRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3

--- a/src/burn/drv/sms/d_sms.cpp
+++ b/src/burn/drv/sms/d_sms.cpp
@@ -21675,7 +21675,7 @@ struct BurnDriver BurnDrvsms_ascend = {
 	"sms_ascend", NULL, NULL, NULL, "2022",
 	"Ascend (HB)\0", "YM2413 FM sound chip supported", "Inufuto", "Sega Master System",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_PLATFORM, 0,
 	SMSGetZipName, sms_ascendRomInfo, sms_ascendRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
@@ -22145,7 +22145,7 @@ struct BurnDriver BurnDrvsms_cracky = {
 	"sms_cracky", NULL, NULL, NULL, "2023",
 	"Cracky (HB)\0", "YM2413 FM sound chip supported", "Inufuto", "Sega Master System",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_PLATFORM, 0,
 	SMSGetZipName, sms_crackyRomInfo, sms_crackyRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
@@ -22889,6 +22889,24 @@ struct BurnDriver BurnDrvsms_impetus = {
 	256, 192, 4, 3
 };
 
+// Impetus+ (HB)
+static struct BurnRomInfo sms_impetusplusRomDesc[] = {
+	{ "Impetus+ (2025)(Inufuto).sms",	24576, 0x98e5dabf, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sms_impetusplus)
+STD_ROM_FN(sms_impetusplus)
+
+struct BurnDriver BurnDrvsms_impetusplus = {
+	"sms_impetusplus", NULL, NULL, NULL, "2025",
+	"Impetus+ (HB)\0", "YM2413 FM sound chip supported", "Inufuto", "Sega Master System",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_VERSHOOT, 0,
+	SMSGetZipName, sms_impetusplusRomInfo, sms_impetusplusRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Iron Man (HB)
 static struct BurnRomInfo sms_ironmanRomDesc[] = {
 	{ "Iron Man (2025)(old_pirate).sms",	507904, 0xd2f3fed6, BRF_PRG | BRF_ESS },
@@ -23063,7 +23081,7 @@ struct BurnDriver BurnDrvsms_lift = {
 	"sms_lift", NULL, NULL, NULL, "2021",
 	"Lift (HB)\0", "YM2413 FM sound chip supported", "Inufuto", "Sega Master System",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_PLATFORM, 0,
 	SMSGetZipName, sms_liftRomInfo, sms_liftRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
@@ -23497,7 +23515,7 @@ struct BurnDriver BurnDrvsms_osotos = {
 	"sms_osotos", NULL, NULL, NULL, "2024",
 	"Osotos (HB)\0", "YM2413 FM sound chip supported", "Inufuto", "Sega Master System",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_PLATFORM, 0,
 	SMSGetZipName, sms_osotosRomInfo, sms_osotosRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
@@ -24408,9 +24426,9 @@ struct BurnDriver BurnDrvsms_svellas = {
 	256, 192, 4, 3
 };
 
-// Sword Work (HB)
+// SwordWork (HB)
 static struct BurnRomInfo sms_swordworkRomDesc[] = {
-	{ "Sword Work (2026)(Inufuto).sms",	16384, 0x3936e21c, BRF_PRG | BRF_ESS },
+	{ "SwordWork (2026)(Inufuto).sms",	16384, 0x3936e21c, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sms_swordwork)
@@ -24418,9 +24436,9 @@ STD_ROM_FN(sms_swordwork)
 
 struct BurnDriver BurnDrvsms_swordwork = {
 	"sms_swordwork", NULL, NULL, NULL, "2026",
-	"Sword Work (HB)\0", NULL, "Inufuto", "Sega Master System",
+	"SwordWork (HB)\0", "YM2413 FM sound chip supported", "Inufuto", "Sega Master System",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_MAZE, 0,
 	SMSGetZipName, sms_swordworkRomInfo, sms_swordworkRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
@@ -25028,6 +25046,24 @@ struct BurnDriver BurnDrvgg_antiairm = {
 	256, 192, 4, 3
 };
 
+// Ascend Mini (HB)
+static struct BurnRomInfo gg_ascendmRomDesc[] = {
+	{ "Ascend Mini (2023)(Inufuto).gg",	16384, 0x0765a5f1, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_ascendm)
+STD_ROM_FN(gg_ascendm)
+
+struct BurnDriver BurnDrvgg_ascendm = {
+	"gg_ascendm", NULL, NULL, NULL, "2023",
+	"Ascend Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_PLATFORM, 0,
+	GGGetZipName, gg_ascendmRomInfo, gg_ascendmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Awass Micro (HB)
 static struct BurnRomInfo gg_awassmRomDesc[] = {
 	{ "Awass Micro (2026)(Inufuto).gg",	16384, 0xeb97874d, BRF_PRG | BRF_ESS },
@@ -25064,6 +25100,24 @@ struct BurnDriver BurnDrvgg_battlemarine = {
 	256, 192, 4, 3
 };
 
+// Battlot Mini (HB)
+static struct BurnRomInfo gg_battlotmRomDesc[] = {
+	{ "Battlot Mini (2023)(Inufuto).gg",	16384, 0x6287b42e, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_battlotm)
+STD_ROM_FN(gg_battlotm)
+
+struct BurnDriver BurnDrvgg_battlotm = {
+	"gg_battlotm", NULL, NULL, NULL, "2023",
+	"Battlot Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_MAZE | GBF_RUNGUN, 0,
+	GGGetZipName, gg_battlotmRomInfo, gg_battlotmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Bishoujo Mahjong Puzzle (HB)
 static struct BurnRomInfo gg_bmpuzzleRomDesc[] = {
 	{ "Bishoujo Mahjong Puzzle (2022)(Habit Soft).gg",	262144, 0x57122381, BRF_PRG | BRF_ESS },
@@ -25078,6 +25132,24 @@ struct BurnDriver BurnDrvgg_bmpuzzle = {
 	L"Bishoujo Mahjong Puzzle (HB)\0\u7f8e\u5c11\u5973 \u9ebb\u96c0 \u30d1\u30ba\u30eb\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_PUZZLE, 0,
 	GGGetZipName, gg_bmpuzzleRomInfo, gg_bmpuzzleRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Bootskell Mini (HB)
+static struct BurnRomInfo gg_bootskellmRomDesc[] = {
+	{ "Bootskell Mini (2023)(Inufuto).gg",	16384, 0x58233b4a, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_bootskellm)
+STD_ROM_FN(gg_bootskellm)
+
+struct BurnDriver BurnDrvgg_bootskellm = {
+	"gg_bootskellm", NULL, NULL, NULL, "2023",
+	"Bootskell Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_MAZE, 0,
+	GGGetZipName, gg_bootskellmRomInfo, gg_bootskellmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };
@@ -25114,6 +25186,42 @@ struct BurnDriver BurnDrvgg_cacormm = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_MAZE, 0,
 	GGGetZipName, gg_cacormmRomInfo, gg_cacormmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Cavit Mini (HB)
+static struct BurnRomInfo gg_cavitmRomDesc[] = {
+	{ "Cavit Mini (2023)(Inufuto).gg",	16384, 0x7ec76ec0, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_cavitm)
+STD_ROM_FN(gg_cavitm)
+
+struct BurnDriver BurnDrvgg_cavitm = {
+	"gg_cavitm", NULL, NULL, NULL, "2023",
+	"Cavit Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION, 0,
+	GGGetZipName, gg_cavitmRomInfo, gg_cavitmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Cracky Mini (HB)
+static struct BurnRomInfo gg_crackymRomDesc[] = {
+	{ "Cracky Mini (2023)(Inufuto).gg",	16368, 0xf76913ed, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_crackym)
+STD_ROM_FN(gg_crackym)
+
+struct BurnDriver BurnDrvgg_crackym = {
+	"gg_crackym", NULL, NULL, NULL, "2023",
+	"Cracky Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_PLATFORM, 0,
+	GGGetZipName, gg_crackymRomInfo, gg_crackymRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };
@@ -25280,6 +25388,24 @@ struct BurnDriver BurnDrvgg_gunstreamcv = {
 	256, 192, 4, 3
 };
 
+// Guntus Mini (HB)
+static struct BurnRomInfo gg_guntusmRomDesc[] = {
+	{ "Guntus Mini (2023)(Inufuto).gg",	16384, 0x518c4c44, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_guntusm)
+STD_ROM_FN(gg_guntusm)
+
+struct BurnDriver BurnDrvgg_guntusm = {
+	"gg_guntusm", NULL, NULL, NULL, "2023",
+	"Guntus Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_VERSHOOT, 0,
+	GGGetZipName, gg_guntusmRomInfo, gg_guntusmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Hopman Mini (HB)
 static struct BurnRomInfo gg_hopmanmRomDesc[] = {
 	{ "Hopman Mini (2023)(Inufuto).gg",	16368, 0x84fd672d, BRF_PRG | BRF_ESS },
@@ -25289,7 +25415,7 @@ STD_ROM_PICK(gg_hopmanm)
 STD_ROM_FN(gg_hopmanm)
 
 struct BurnDriver BurnDrvgg_hopmanm = {
-	"gg_hopmanm", NULL, NULL, NULL, "2025",
+	"gg_hopmanm", NULL, NULL, NULL, "2023",
 	"Hopman Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_PLATFORM, 0,
@@ -25334,6 +25460,24 @@ struct BurnDriver BurnDrvgg_impetuspm = {
 	256, 192, 4, 3
 };
 
+// Lift Mini (HB)
+static struct BurnRomInfo gg_liftmRomDesc[] = {
+	{ "Lift Mini (2023)(Inufuto).gg",	10873, 0xe7b92d77, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_liftm)
+STD_ROM_FN(gg_liftm)
+
+struct BurnDriver BurnDrvgg_liftm = {
+	"gg_liftm", NULL, NULL, NULL, "2023",
+	"Lift Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_PLATFORM, 0,
+	GGGetZipName, gg_liftmRomInfo, gg_liftmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Mai Nurse (HB)
 static struct BurnRomInfo gg_mainurseggRomDesc[] = {
 	{ "Mai Nurse (2024)(lunoka).gg",	131072, 0x36a2da11, BRF_PRG | BRF_ESS },
@@ -25370,6 +25514,24 @@ struct BurnDriver BurnDrvgg_mazym = {
 	256, 192, 4, 3
 };
 
+// Mazy 2 Micro (HB)
+static struct BurnRomInfo gg_mazy2mRomDesc[] = {
+	{ "Mazy 2 Micro (2025)(Inufuto).gg",	16384, 0xaf6e6cbc, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_mazy2m)
+STD_ROM_FN(gg_mazy2m)
+
+struct BurnDriver BurnDrvgg_mazy2m = {
+	"gg_mazy2m", NULL, NULL, NULL, "2025",
+	"Mazy 2 Micro (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_MAZE, 0,
+	GGGetZipName, gg_mazy2mRomInfo, gg_mazy2mRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Mieyen Mini (HB)
 static struct BurnRomInfo gg_mieyenmRomDesc[] = {
 	{ "Mieyen Mini (2025)(Inufuto).gg",	16384, 0xc3eb27e8, BRF_PRG | BRF_ESS },
@@ -25402,6 +25564,42 @@ struct BurnDriver BurnDrvgg_mcmastergg = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_RACING, 0,
 	GGGetZipName, gg_mcmasterggRomInfo, gg_mcmasterggRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Neuras Mini (HB)
+static struct BurnRomInfo gg_neurasmRomDesc[] = {
+	{ "Neuras Mini (2023)(Inufuto).gg",	16384, 0xa2b97db3, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_neurasm)
+STD_ROM_FN(gg_neurasm)
+
+struct BurnDriver BurnDrvgg_neurasm = {
+	"gg_neurasm", NULL, NULL, NULL, "2023",
+	"Neuras Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_MAZE, 0,
+	GGGetZipName, gg_neurasmRomInfo, gg_neurasmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Osotos Mini (HB)
+static struct BurnRomInfo gg_osotosmRomDesc[] = {
+	{ "Osotos Mini (2024)(Inufuto).gg",	16384, 0x3dca13e6, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_osotosm)
+STD_ROM_FN(gg_osotosm)
+
+struct BurnDriver BurnDrvgg_osotosm = {
+	"gg_osotosm", NULL, NULL, NULL, "2024",
+	"Osotos Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_PLATFORM, 0,
+	GGGetZipName, gg_osotosmRomInfo, gg_osotosmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };
@@ -25451,7 +25649,7 @@ STD_ROM_PICK(gg_ruptusm)
 STD_ROM_FN(gg_ruptusm)
 
 struct BurnDriver BurnDrvgg_ruptusm = {
-	"gg_ruptusm", NULL, NULL, NULL, "2025",
+	"gg_ruptusm", NULL, NULL, NULL, "2023",
 	"Ruptus Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_MULTISHOOT, 0,
@@ -25604,6 +25802,23 @@ struct BurnDriver BurnDrvgg_wingwarriors = {
 	256, 192, 4, 3
 };
 
+// Yewdow Mini (HB)
+static struct BurnRomInfo gg_yewdowmRomDesc[] = {
+	{ "Yewdow Mini (2023)(Inufuto).gg",	16384, 0x52cb91df, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_yewdowm)
+STD_ROM_FN(gg_yewdowm)
+
+struct BurnDriver BurnDrvgg_yewdowm = {
+	"gg_yewdowm", NULL, NULL, NULL, "2023",
+	"Yewdow Mini (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_MAZE, 0,
+	GGGetZipName, gg_yewdowmRomInfo, gg_yewdowmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
 
 // ------------------------
 // Translation Hacks GG/SMS

--- a/src/burn/drv/spectrum/d_spectrum.cpp
+++ b/src/burn/drv/spectrum/d_spectrum.cpp
@@ -33578,7 +33578,7 @@ struct BurnDriver BurnSpecAscend = {
 	"spec_ascend", NULL, "spec_spectrum", NULL, "2022",
 	"Ascend (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION | GBF_PLATFORM, 0,
 	SpectrumGetZipName, SpecAscendRomInfo, SpecAscendRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
 	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
@@ -37801,6 +37801,25 @@ struct BurnDriver BurnSpecCrabby2 = {
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION, 0,
 	SpectrumGetZipName, SpecCrabby2RomInfo, SpecCrabby2RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
 	Spec128KInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Cracky (48K) (HB)
+
+static struct BurnRomInfo SpecCrackyRomDesc[] = {
+	{ "Cracky 48K-AY (2023)(Inufuto).tzx", 8623, 0x9c444d38, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecCracky, SpecCracky, Spectrum)
+STD_ROM_FN(SpecCracky)
+
+struct BurnDriver BurnSpecCracky = {
+	"spec_cracky", NULL, "spec_spectrum", NULL, "2023",
+	"Cracky (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION | GBF_PLATFORM, 0,
+	SpectrumGetZipName, SpecCrackyRomInfo, SpecCrackyRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecIntf2DIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
@@ -43409,6 +43428,25 @@ struct BurnDriver BurnSpecGunsngears = {
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
+// Guntus (48K) (HB)
+
+static struct BurnRomInfo SpecGuntusRomDesc[] = {
+	{ "Guntus 48K-AY (2022)(Inufuto).tzx", 12386, 0x9fd62800, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecGuntus, SpecGuntus, Spectrum)
+STD_ROM_FN(SpecGuntus)
+
+struct BurnDriver BurnSpecGuntus = {
+	"spec_guntus", NULL, "spec_spectrum", NULL, "2022",
+	"Guntus (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_VERSHOOT, 0,
+	SpectrumGetZipName, SpecGuntusRomInfo, SpecGuntusRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecIntf2DIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
 // GVolcano (128K) (HB)
 
 static struct BurnRomInfo SpecGvolcanoRomDesc[] = {
@@ -44697,6 +44735,25 @@ struct BurnDriver BurnSpecImpetus = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_VERSHOOT, 0,
 	SpectrumGetZipName, SpecImpetusRomInfo, SpecImpetusRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Impetus+ (48K) (HB)
+
+static struct BurnRomInfo SpecImpetusplusRomDesc[] = {
+	{ "Impetus+ 48K-AY (2025)(Inufuto).tzx", 15492, 0x998812f7, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecImpetusplus, SpecImpetusplus, Spectrum)
+STD_ROM_FN(SpecImpetusplus)
+
+struct BurnDriver BurnSpecImpetusplus = {
+	"spec_impetusplus", NULL, "spec_spectrum", NULL, "2025",
+	"Impetus+ (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_VERSHOOT, 0,
+	SpectrumGetZipName, SpecImpetusplusRomInfo, SpecImpetusplusRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
 	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
@@ -46899,7 +46956,7 @@ struct BurnDriver BurnSpecLift = {
 	"spec_lift", NULL, "spec_spectrum", NULL, "2021",
 	"Lift (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_PLATFORM, 0,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION | GBF_PLATFORM, 0,
 	SpectrumGetZipName, SpecLiftRomInfo, SpecLiftRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
 	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
@@ -51387,6 +51444,25 @@ struct BurnDriver BurnSpecOrvol128es = {
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_PLATFORM, 0,
 	SpectrumGetZipName, SpecOrvol128esRomInfo, SpecOrvol128esRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
 	Spec128KInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Osotos (HB)
+
+static struct BurnRomInfo SpecOsotosRomDesc[] = {
+	{ "Osotos 48K-AY (2024)(Inufuto).tzx", 10250, 0x3269cf11, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecOsotos, SpecOsotos, Spectrum)
+STD_ROM_FN(SpecOsotos)
+
+struct BurnDriver BurnSpecOsotos = {
+	"spec_osotos", NULL, "spec_spectrum", NULL, "2024",
+	"Osotos (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION | GBF_PLATFORM, 0,
+	SpectrumGetZipName, SpecOsotosRomInfo, SpecOsotosRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
@@ -58230,10 +58306,10 @@ struct BurnDriver BurnSpecSwordofianna = {
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
-// Sword Work (48K) (HB)
+// SwordWork (48K) (HB)
 
 static struct BurnRomInfo SpecSwordworkRomDesc[] = {
-	{ "Sword Work 48K-AY (2026)(Inufuto).tzx", 16384, 0x3f805434, BRF_ESS | BRF_PRG },
+	{ "SwordWork 48K-AY (2026)(Inufuto).tzx", 16384, 0x3f805434, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(SpecSwordwork, SpecSwordwork, Spectrum)
@@ -58241,7 +58317,7 @@ STD_ROM_FN(SpecSwordwork)
 
 struct BurnDriver BurnSpecSwordwork = {
 	"spec_swordwork", NULL, "spec_spectrum", NULL, "2026",
-	"Sword Work (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
+	"SwordWork (48K) (HB)\0", "AY Sound supported", "Inufuto", "ZX Spectrum",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_ACTION | GBF_MAZE, 0,
 	SpectrumGetZipName, SpecSwordworkRomInfo, SpecSwordworkRomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecIntf2DIPInfo,
@@ -61217,7 +61293,7 @@ struct BurnDriver BurnSpecyazzie = {
 // Yewdow (48K) (HB)
 
 static struct BurnRomInfo SpecYewdowRomDesc[] = {
-	{ "Yewdow 48K (2023)(Inufuto).tap", 9818, 0xfaf70151, BRF_ESS | BRF_PRG },
+	{ "Yewdow 48K-AY (2023)(Inufuto).tap", 9818, 0xfaf70151, BRF_ESS | BRF_PRG },
 };
 
 STDROMPICKEXT(SpecYewdow, SpecYewdow, Spectrum)


### PR DESCRIPTION
d_coleco.cpp:
"Awass (HB)"
"Impetus+ (HB)"
"Mieyen (HB)"

d_ngp.cpp:
"Aerial Mini (HB)2
"AntiAir Mini (HB)"
"Ascend Mini (HB)"
"Awass Micro (HB)"
"Battlot Mini (HB)"
"Bootskell Mini (HB)"
"Cacorm Mini (HB)"
"Cavit Mini (HB)"
"Cracky Mini (HB)"
"Guntus Mini (HB)"
"Hopman Mini (HB)"
"Impetus Mini (HB)"
"Impetus+ Micro (HB)"
"Lift Mini (HB)"
"Mazy Mini (HB)"
"Mazy 2 Micro (HB)"
"Mieyen Mini (HB)"
"Neuras Mini (HB)"
"Osotos Mini (HB)"
"Ruptus Mini (HB)"
"Svellas Micro (HB)"
"Yewdow Mini (HB)"

d_sg1000.cpp:
"Ascend (HB)"
"Battlot (HB)"
"Bootskell (HB)"
"Lift (HB)"
"Neuras (HB)"
"Osotos (HB)"
"Ruptus (HB)"

d_sms.cpp:
"Ascend Mini (HB)"
"Battlot Mini (HB)"
"Bootskell Mini (HB)"
"Cavit Mini (HB)"
"Cracky Mini (HB)"
"Guntus Mini (HB)"
"Impetus+ (HB)"
"Lift Mini (HB)"
"Mazy 2 Micro (HB)"
"Neuras Mini (HB)"
"Osotos Mini (HB)"
"Yewdow Mini (HB)"

d_spectrum.cpp:
"Cracky (48K) (HB)"
"Guntus (48K) (HB)"
"Impetus+ (48K) (HB)"
"Osotos (48K) (HB)"

Also corrected several typos for the same developer's games