### PR TITLE
d_megadrive.cpp: updated the support to "Ghost Baseball" v1.3

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -39999,10 +39999,10 @@ struct BurnDriver BurnDrvmd_genmtetris = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Ghost Baseball (HB)
+// Ghost Baseball (HB, v1.3)
 // https://infinitestategames.itch.io/ghost-baseball
 static struct BurnRomInfo md_ghbaseballRomDesc[] = {
-	{ "Ghost Baseball (2026)(Infinite State Games).bin", 262144, 0x8171276a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Ghost Baseball v1.3 (2026)(Infinite State Games).bin", 262144, 0x2b95120a, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_ghbaseball)
@@ -40010,7 +40010,7 @@ STD_ROM_FN(md_ghbaseball)
 
 struct BurnDriver BurnDrvmd_ghbaseball = {
 	"md_ghbaseball", NULL, NULL, NULL, "2026",
-	"Ghost Baseball (HB)\0", NULL, "Infinite State Games", "Genesis / Mega Drive",
+	"Ghost Baseball (HB, v1.3)\0", NULL, "Infinite State Games", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 1, HARDWARE_SEGA_MEGADRIVE, GBF_ACTION | GBF_SPORTSMISC, 0,
 	MegadriveGetZipName, md_ghbaseballRomInfo, md_ghbaseballRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,


### PR DESCRIPTION
**Ghost Baseball v1.3 - more score tweaking (people got too good)** 

So basically, people got too good - much better than I could ever do 
in testing - and they broke my score board.
So rather than add an extra zero to the score board, I've divided the
score of everything by 10 :D
Sorry to everyone who has to reburn / reflash their cartridges. It's 
worth it to know it won't crash if you suddenly hit a godlike zone 
focus run.