### PR TITLE
d_megadrive.cpp, d_pce.cpp: Barbarian time!

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -38255,17 +38255,17 @@ struct BurnDriver BurnDrvmd_baileybrave = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Barbarian - Amiga (HB)
+// Barbarian: The Ultimate Warrior - Amiga (HB)
 static struct BurnRomInfo md_barbarianamiRomDesc[] = {
-	{ "Barbarian AMIGA (2017)(F.L).bin", 1031574, 0x4fc515f5, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Barbarian - The Ultimate Warrior - Amiga (2015)(F.L).bin", 1031574, 0x4fc515f5, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_barbarianami)
 STD_ROM_FN(md_barbarianami)
 
 struct BurnDriver BurnDrvmd_barbarianami = {
-	"md_barbarianami", NULL, NULL, NULL, "2017",
-	"Barbarian the Ultimate Warrior - Amiga (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	"md_barbarianami", NULL, NULL, NULL, "2015	",
+	"Barbarian: The Ultimate Warrior - Amiga (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_barbarianamiRomInfo, md_barbarianamiRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -38273,63 +38273,9 @@ struct BurnDriver BurnDrvmd_barbarianami = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
-// Barbarian - Atari ST (HB)
-static struct BurnRomInfo md_barbarianstRomDesc[] = {
-	{ "Barbarian Atari ST (2014)(F.L).bin", 2487416, 0xfec97705, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_barbarianst)
-STD_ROM_FN(md_barbarianst)
-
-struct BurnDriver BurnDrvmd_barbarianst = {
-	"md_barbarianst", "md_barbarianami", NULL, NULL, "2014",
-	"Barbarian the Ultimate Warrior - Atari ST (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
-	MegadriveGetZipName, md_barbarianstRomInfo, md_barbarianstRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
-// Barbarian - C64 (HB)
-static struct BurnRomInfo md_barbarianc64RomDesc[] = {
-	{ "Barbarian C64 (2014)(F.L).bin", 3028428, 0xd37f9af0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_barbarianc64)
-STD_ROM_FN(md_barbarianc64)
-
-struct BurnDriver BurnDrvmd_barbarianc64 = {
-	"md_barbarianc64", "md_barbarianami", NULL, NULL, "2014",
-	"Barbarian the Ultimate Warrior - C64 (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
-	MegadriveGetZipName, md_barbarianc64RomInfo, md_barbarianc64RomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
-// Barbarian - ZX Spectrum (HB)
-static struct BurnRomInfo md_barbarianzxsRomDesc[] = {
-	{ "Barbarian ZX Spectrum (2015)(F.L).bin", 1432448, 0x5360129d, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
-};
-
-STD_ROM_PICK(md_barbarianzxs)
-STD_ROM_FN(md_barbarianzxs)
-
-struct BurnDriver BurnDrvmd_barbarianzxs = {
-	"md_barbarianzxs", "md_barbarianami", NULL, NULL, "2015",
-	"Barbarian the Ultimate Warrior - ZX Spectrum (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
-	MegadriveGetZipName, md_barbarianzxsRomInfo, md_barbarianzxsRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
-	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
-	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
-};
-
-// Barbarian - Amstrad CPC (HB)
+// Barbarian: The Ultimate Warrior - Amstrad CPC (HB)
 static struct BurnRomInfo md_barbariancpcRomDesc[] = {
-	{ "Barbarian Amstrad CPC (2014)(F.L).bin", 2296122, 0xd63f8446, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Barbarian - The Ultimate Warrior - Amstrad CPC (2014)(F.L).bin", 2296122, 0xd63f8446, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_barbariancpc)
@@ -38337,7 +38283,7 @@ STD_ROM_FN(md_barbariancpc)
 
 struct BurnDriver BurnDrvmd_barbariancpc = {
 	"md_barbariancpc", "md_barbarianami", NULL, NULL, "2014",
-	"Barbarian the Ultimate Warrior - Amstrad CPC (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	"Barbarian: The Ultimate Warrior - Amstrad CPC (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_barbariancpcRomInfo, md_barbariancpcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -38345,9 +38291,63 @@ struct BurnDriver BurnDrvmd_barbariancpc = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Barbarian: The Ultimate Warrior - Atari ST (HB)
+static struct BurnRomInfo md_barbarianstRomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - Atari ST (2014)(F.L).bin", 2487416, 0xfec97705, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_barbarianst)
+STD_ROM_FN(md_barbarianst)
+
+struct BurnDriver BurnDrvmd_barbarianst = {
+	"md_barbarianst", "md_barbarianami", NULL, NULL, "2014",
+	"Barbarian: The Ultimate Warrior - Atari ST (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_barbarianstRomInfo, md_barbarianstRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Barbarian: The Ultimate Warrior - C64 (HB)
+static struct BurnRomInfo md_barbarianc64RomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - C64 (2014)(F.L).bin", 3028428, 0xd37f9af0, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_barbarianc64)
+STD_ROM_FN(md_barbarianc64)
+
+struct BurnDriver BurnDrvmd_barbarianc64 = {
+	"md_barbarianc64", "md_barbarianami", NULL, NULL, "2014",
+	"Barbarian: The Ultimate Warrior - C64 (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_barbarianc64RomInfo, md_barbarianc64RomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
+// Barbarian: The Ultimate Warrior - ZX Spectrum (HB)
+static struct BurnRomInfo md_barbarianzxsRomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - ZX Spectrum (2015)(F.L).bin", 1432448, 0x5360129d, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_barbarianzxs)
+STD_ROM_FN(md_barbarianzxs)
+
+struct BurnDriver BurnDrvmd_barbarianzxs = {
+	"md_barbarianzxs", "md_barbarianami", NULL, NULL, "2015",
+	"Barbarian: The Ultimate Warrior - ZX Spectrum (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	MegadriveGetZipName, md_barbarianzxsRomInfo, md_barbarianzxsRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Death Sword - Apple II (HB)
 static struct BurnRomInfo md_barbarianap2RomDesc[] = {
-	{ "Death Sword Apple II (2014)(F.L).bin", 425616, 0x12a01f70, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Death Sword - Apple II (2014)(F.L).bin", 425616, 0x12a01f70, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_barbarianap2)
@@ -38355,7 +38355,7 @@ STD_ROM_FN(md_barbarianap2)
 
 struct BurnDriver BurnDrvmd_barbarianap2 = {
 	"md_barbarianap2", "md_barbarianami", NULL, NULL, "2014",
-	"Death Sword - Apple II (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	"Death Sword - Apple II (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_barbarianap2RomInfo, md_barbarianap2RomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
@@ -38365,7 +38365,7 @@ struct BurnDriver BurnDrvmd_barbarianap2 = {
 
 // Death Sword - PC CGA (HB)
 static struct BurnRomInfo md_barbarianpcRomDesc[] = {
-	{ "Death Sword PC CGA (2014)(F.L).bin", 446380, 0xaaeaeb87, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Death Sword - PC CGA (2014)(F.L).bin", 446380, 0xaaeaeb87, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_barbarianpc)
@@ -38373,7 +38373,7 @@ STD_ROM_FN(md_barbarianpc)
 
 struct BurnDriver BurnDrvmd_barbarianpc = {
 	"md_barbarianpc", "md_barbarianami", NULL, NULL, "2014",
-	"Death Sword - PC CGA (HB)\0", "raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
+	"Death Sword - PC CGA (HB)\0", "Raw conversion - no improvements", "F.L", "Genesis / Mega Drive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_barbarianpcRomInfo, md_barbarianpcRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/pce/d_pce.cpp
+++ b/src/burn/drv/pce/d_pce.cpp
@@ -9199,21 +9199,135 @@ struct BurnDriver BurnDrvpce_atlantean = {
 	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
 };
 
-// Barbarian (HB)
+// Barbarian: The Ultimate Warrior - Amiga (HB)
 
-static struct BurnRomInfo pce_barbarianRomDesc[] = {
-	{ "Barbarian (2017)(F.L).pce", 0x0b8200, 0x42d3c3f9, BRF_PRG | BRF_ESS },
+static struct BurnRomInfo pce_barbarianamiRomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - Amiga (2017)(F.L).pce", 0x0b8200, 0x42d3c3f9, BRF_PRG | BRF_ESS },
 };
 
-STD_ROM_PICK(pce_barbarian)
-STD_ROM_FN(pce_barbarian)
+STD_ROM_PICK(pce_barbarianami)
+STD_ROM_FN(pce_barbarianami)
 
-struct BurnDriver BurnDrvpce_barbarian = {
-	"pce_barbarian", NULL, NULL, NULL, "2017",
-	"Barbarian (HB)\0", NULL, "F.L", "PC Engine",
+struct BurnDriver BurnDrvpce_barbarianami = {
+	"pce_barbarianami", NULL, NULL, NULL, "2017",
+	"Barbarian: The Ultimate Warrior - Amiga (HB)\0", NULL, "F.L", "PC Engine",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_ACTION, 0,
-	PceGetZipName, pce_barbarianRomInfo, pce_barbarianRomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbarianamiRomInfo, pce_barbarianamiRomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
+	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
+};
+
+// Barbarian: The Ultimate Warrior - Amstrad CPC (HB)
+
+static struct BurnRomInfo pce_barbariancpcRomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - Amstrad CPC (2017)(F.L).pce", 0x0b2200, 0x7e8670d1, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(pce_barbariancpc)
+STD_ROM_FN(pce_barbariancpc)
+
+struct BurnDriver BurnDrvpce_barbariancpc = {
+	"pce_barbariancpc", "pce_barbarianami", NULL, NULL, "2017",
+	"Barbarian: The Ultimate Warrior - Amstrad CPC (HB)\0", NULL, "F.L", "PC Engine",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbariancpcRomInfo, pce_barbariancpcRomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
+	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
+};
+
+// Barbarian: The Ultimate Warrior - Atari ST (HB)
+
+static struct BurnRomInfo pce_barbarianstRomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - Atari ST (2017)(F.L).pce", 0x0b2200, 0xb9424bb0, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(pce_barbarianst)
+STD_ROM_FN(pce_barbarianst)
+
+struct BurnDriver BurnDrvpce_barbarianst = {
+	"pce_barbarianst", "pce_barbarianami", NULL, NULL, "2017",
+	"Barbarian: The Ultimate Warrior - Atari ST (HB)\0", NULL, "F.L", "PC Engine",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbarianstRomInfo, pce_barbarianstRomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
+	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
+};
+
+// Barbarian: The Ultimate Warrior - C64 (HB)
+
+static struct BurnRomInfo pce_barbarianc64RomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - C64 (2017)(F.L).pce", 0x0b2200, 0xc6c6f05b, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(pce_barbarianc64)
+STD_ROM_FN(pce_barbarianc64)
+
+struct BurnDriver BurnDrvpce_barbarianc64 = {
+	"pce_barbarianc64", "pce_barbarianami", NULL, NULL, "2017",
+	"Barbarian: The Ultimate Warrior - C64 (HB)\0", NULL, "F.L", "PC Engine",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbarianc64RomInfo, pce_barbarianc64RomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
+	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
+};
+
+// Barbarian: The Ultimate Warrior - ZX Spectrum (HB)
+
+static struct BurnRomInfo pce_barbarianzxsRomDesc[] = {
+	{ "Barbarian - The Ultimate Warrior - ZX Spectrum (2017)(F.L).pce", 0x0da200, 0xaffadae5, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(pce_barbarianzxs)
+STD_ROM_FN(pce_barbarianzxs)
+
+struct BurnDriver BurnDrvpce_barbarianzxs = {
+	"pce_barbarianzxs", "pce_barbarianami", NULL, NULL, "2017",
+	"Barbarian: The Ultimate Warrior - ZX Spectrum (HB)\0", NULL, "F.L", "PC Engine",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbarianzxsRomInfo, pce_barbarianzxsRomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
+	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
+};
+
+// Death Sword - Apple II (HB)
+
+static struct BurnRomInfo pce_barbarianap2RomDesc[] = {
+	{ "Death Sword - Apple II (2017)(F.L).pce", 0x0c4200, 0x221793a6, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(pce_barbarianap2)
+STD_ROM_FN(pce_barbarianap2)
+
+struct BurnDriver BurnDrvpce_barbarianap2 = {
+	"pce_barbarianap2", "pce_barbarianami", NULL, NULL, "2017",
+	"Death Sword - Apple II (HB)\0", NULL, "F.L", "PC Engine",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbarianap2RomInfo, pce_barbarianap2RomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
+	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
+	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
+};
+
+// Death Sword - PC CGA (HB)
+
+static struct BurnRomInfo pce_barbarianpcRomDesc[] = {
+	{ "Death Sword - PC CGA (2017)(F.L).pce", 0x0c4200, 0xaae0a16e, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(pce_barbarianpc)
+STD_ROM_FN(pce_barbarianpc)
+
+struct BurnDriver BurnDrvpce_barbarianpc = {
+	"pce_barbarianpc", "pce_barbarianami", NULL, NULL, "2017",
+	"Death Sword - PC CGA (HB)\0", NULL, "F.L", "PC Engine",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_PCENGINE_PCENGINE, GBF_VSFIGHT, 0,
+	PceGetZipName, pce_barbarianpcRomInfo, pce_barbarianpcRomName, NULL, NULL, NULL, NULL, pceInputInfo, pceDIPInfo,
 	PCEInit, PCEExit, PCEFrame, PCEDraw, PCEScan,
 	&PCEPaletteRecalc, 0x400, 1024, 240, 4, 3
 };


### PR DESCRIPTION
d_megadrive.cpp: some changes to "Barbarian: The Ultimate Warrior" definition.

d_pce.cpp: Added the support to:
"Barbarian: The Ultimate Warrior - Amstrad CPC (HB)"
"Barbarian: The Ultimate Warrior - Atari ST (HB)"
"Barbarian: The Ultimate Warrior - C64 (HB)"
"Barbarian: The Ultimate Warrior - ZX Spectrum (HB)"
"Death Sword - Apple II (HB)"
"Death Sword - PC CGA (HB)"
...as clones of previous existent "Barbarian: The Ultimate Warrior - Amiga (HB)"