### PR TITLE
d_nes.cpp, d_ngp.cpp, d_sms.cpp: various...

### DIFF
--- a/src/burn/drv/nes/d_nes.cpp
+++ b/src/burn/drv/nes/d_nes.cpp
@@ -26471,6 +26471,24 @@ struct BurnDriver BurnDrvnes_veggieinvaders = {
 	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
 };
 
+// Vexed (HB, v1.15)
+static struct BurnRomInfo nes_vexedRomDesc[] = {
+	{ "Vexed v1.15 (2023-24)(Under4Mhz).nes",          32784, 0x7a1f3f2c, BRF_ESS | BRF_PRG },
+};
+
+STD_ROM_PICK(nes_vexed)
+STD_ROM_FN(nes_vexed)
+
+struct BurnDriver BurnDrvnes_vexed = {
+	"nes_vexed", NULL, NULL, NULL, "2023-24",
+	"Vexed (HB, v1.15)\0", NULL, "Under4Mhz", "NES / Famicom",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_NES, GBF_PUZZLE, 0,
+	NESGetZipName, nes_vexedRomInfo, nes_vexedRomName, NULL, NULL, NULL, NULL, NESInputInfo, NESDIPInfo,
+	NESInit, NESExit, NESFrame, NESDraw, NESScan, &NESRecalc, 0x40,
+	SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT
+};
+
 // Vigilante Ninja II (HB)
 static struct BurnRomInfo nes_vigninja2RomDesc[] = {
 	{ "Vigilante Ninja II (2018)(Doug Fraker).nes",          196624, 0xcdd3c07e, BRF_ESS | BRF_PRG },

--- a/src/burn/drv/pst90s/d_ngp.cpp
+++ b/src/burn/drv/pst90s/d_ngp.cpp
@@ -4046,6 +4046,24 @@ struct BurnDriver BurnDrvngpc_svellasm = {
 	160, 152, 4, 3
 };
 
+// SwordWork Micro (HB)
+static struct BurnRomInfo ngpc_swordworkmRomDesc[] = {
+	{ "SwordWork Micro (2026)(Inufuto).ngp", 524288, 0xd7130cdf, 1 | BRF_PRG | BRF_ESS }, // Cartridge
+};
+
+STDROMPICKEXT(ngpc_swordworkm, ngpc_swordworkm, ngpc_ngp)
+STD_ROM_FN(ngpc_swordworkm)
+
+struct BurnDriver BurnDrvngpc_swordworkm = {
+	"ngp_swordworkm", NULL, "ngp_ngp", NULL, "2026",
+	"SwordWork Micro (HB)\0", NULL, "Inufuto", "NeoGeo Pocket Color",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SNK_NGPC, GBF_ACTION | GBF_MAZE, 0,
+	NgpGetZipName, ngpc_swordworkmRomInfo, ngpc_swordworkmRomName, NULL, NULL, NULL, NULL, NgpInputInfo, NgpDIPInfo,
+	DrvInit, DrvExit, DrvFrame, k1geDraw, DrvScan, &BurnRecalc, 0x1000,
+	160, 152, 4, 3
+};
+
 // Thieves (HB)
 static struct BurnRomInfo ngpc_thievesRomDesc[] = {
 	{ "Thieves (2000)(Ivan Mackintosh).ngp", 524288, 0x68242322, 1 | BRF_PRG | BRF_ESS }, // Cartridge

--- a/src/burn/drv/sms/d_sms.cpp
+++ b/src/burn/drv/sms/d_sms.cpp
@@ -21935,6 +21935,24 @@ struct BurnDriver BurnDrvsms_bitlogic = {
 	256, 192, 4, 3
 };
 
+// Black Castle (HB, 20240523)
+static struct BurnRomInfo sms_bcastleRomDesc[] = {
+	{ "Black Castle 20240523 (2023-24)(toxa).sms",	65536, 0xaac28a8d, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sms_bcastle)
+STD_ROM_FN(sms_bcastle)
+
+struct BurnDriver BurnDrvsms_bcastle = {
+	"sms_bcastle", NULL, NULL, NULL, "2023-24",
+	"Black Castle (HB, 20240523)\0", NULL, "toxa", "Sega Master System",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_PLATFORM, 0,
+	SMSGetZipName, sms_bcastleRomInfo, sms_bcastleRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Blast Arena (HB)
 static struct BurnRomInfo sms_blastarenaRomDesc[] = {
 	{ "Blast Arena (2023)(helpcomputer0).sms",	65536, 0xa4233ea3, BRF_PRG | BRF_ESS },
@@ -23395,9 +23413,9 @@ struct BurnDriver BurnDrvsms_moggym100 = {
 	256, 192, 4, 3
 };
 
-// Monaco Master (HB, v2.9.2)
+// Monaco Master (HB, v2.9.3)
 static struct BurnRomInfo sms_mcmasterRomDesc[] = {
-	{ "Monaco Master v2.9.2 (2023)(Louis The SEGA Nerd).sms",	81920, 0x355330b6, BRF_PRG | BRF_ESS },
+	{ "Monaco Master v2.9.3 (2023)(Louis The SEGA Nerd).sms",	81920, 0x694f1fdc, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sms_mcmaster)
@@ -23405,7 +23423,7 @@ STD_ROM_FN(sms_mcmaster)
 
 struct BurnDriver BurnDrvsms_mcmaster = {
 	"sms_mcmaster", NULL, NULL, NULL, "2023",
-	"Monaco Master (HB, v2.9.2)\0", "YM2413 FM sound chip supported", "Louis The SEGA Nerd", "Sega Master System",
+	"Monaco Master (HB, v2.9.3)\0", "YM2413 FM sound chip supported", "Louis The SEGA Nerd", "Sega Master System",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION | GBF_RACING, 0,
 	SMSGetZipName, sms_mcmasterRomInfo, sms_mcmasterRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
@@ -24806,17 +24824,17 @@ struct BurnDriver BurnDrvsms_ultdungesc = {
 	256, 192, 4, 3
 };
 
-// Vexed (HB, v1.08)
+// Vexed (HB, v1.15)
 static struct BurnRomInfo sms_vexedRomDesc[] = {
-	{ "Vexed v1.08 (2023)(Under4Mhz).sms",	32768, 0x834e1138, BRF_PRG | BRF_ESS },
+	{ "Vexed v1.15 (2021-24)(Under4Mhz).sms",	32768, 0x47c39bac, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sms_vexed)
 STD_ROM_FN(sms_vexed)
 
 struct BurnDriver BurnDrvsms_vexed = {
-	"sms_vexed", NULL, NULL, NULL, "2021-23",
-	"Vexed (HB, v1.08)\0", NULL, "Under4Mhz", "Sega Master System",
+	"sms_vexed", NULL, NULL, NULL, "2021-24",
+	"Vexed (HB, v1.15)\0", NULL, "Under4Mhz", "Sega Master System",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PUZZLE, 0,
 	SMSGetZipName, sms_vexedRomInfo, sms_vexedRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
@@ -24982,6 +25000,24 @@ struct BurnDriver BurnDrvsms_wingwarriors = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_VERSHOOT, 0,
 	SMSGetZipName, sms_wingwarriorsRomInfo, sms_wingwarriorsRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Wolfstein (HB, v1.16)
+static struct BurnRomInfo sms_wolfsteinRomDesc[] = {
+	{ "Wolfstein v1.16 (2023)(Under4Mhz).sms",	524288, 0xdd940cdf, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sms_wolfstein)
+STD_ROM_FN(sms_wolfstein)
+
+struct BurnDriver BurnDrvsms_wolfstein = {
+	"sms_wolfstein", NULL, NULL, NULL, "2023",
+	"Wolfstein (HB, v1.16)\0", NULL, "Under4Mhz", "Sega Master System",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_SHOOT, 0,
+	SMSGetZipName, sms_wolfsteinRomInfo, sms_wolfsteinRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };
@@ -25260,6 +25296,24 @@ struct BurnDriver BurnDrvgg_bmpuzzle = {
 	L"Bishoujo Mahjong Puzzle (HB)\0\u7f8e\u5c11\u5973 \u9ebb\u96c0 \u30d1\u30ba\u30eb\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_PUZZLE, 0,
 	GGGetZipName, gg_bmpuzzleRomInfo, gg_bmpuzzleRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Black Castle (HB, 20240523)
+static struct BurnRomInfo gg_bcastleRomDesc[] = {
+	{ "Black Castle 20240523 (2023-24)(toxa).gg",	65536, 0xee80f563, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_bcastle)
+STD_ROM_FN(gg_bcastle)
+
+struct BurnDriver BurnDrvgg_bcastle = {
+	"gg_bcastle", NULL, NULL, NULL, "2023-24",
+	"Black Castle (HB, 20240523)\0", NULL, "toxa", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_PLATFORM, 0,
+	GGGetZipName, gg_bcastleRomInfo, gg_bcastleRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };
@@ -25858,6 +25912,24 @@ struct BurnDriver BurnDrvgg_svellasm = {
 	256, 192, 4, 3
 };
 
+// SwordWork Micro (HB)
+static struct BurnRomInfo gg_swordworkmRomDesc[] = {
+	{ "SwordWork Micro (2026)(Inufuto).gg",	16384, 0xb45207a9, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_swordworkm)
+STD_ROM_FN(gg_swordworkm)
+
+struct BurnDriver BurnDrvgg_swordworkm = {
+	"gg_swordworkm", NULL, NULL, NULL, "2026",
+	"SwordWork Micro (HB)\0", NULL, "Inufuto", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_ACTION | GBF_MAZE, 0,
+	GGGetZipName, gg_swordworkmRomInfo, gg_swordworkmRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // Sword of Stone, The (HB, v2.4)
 static struct BurnRomInfo gg_swordstoneRomDesc[] = {
 	{ "Sword of Stone, The v2.4 (2024-25)(2Minds - Cireza).gg",	524288, 0x3a92a9ed, BRF_PRG | BRF_ESS },
@@ -25894,38 +25966,20 @@ struct BurnDriver BurnDrvgg_tetris4gg = {
 	256, 192, 4, 3
 };
 
-// Vexed (HB, v1.08)
+// Vexed (HB, v1.15)
 static struct BurnRomInfo gg_vexedRomDesc[] = {
-	{ "Vexed v1.08 (2023)(Under4Mhz).gg",	32768, 0x36e8fa84, BRF_PRG | BRF_ESS },
+	{ "Vexed v1.15 (2023-24)(Under4Mhz).gg",	32768, 0x3c456bbf, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(gg_vexed)
 STD_ROM_FN(gg_vexed)
 
 struct BurnDriver BurnDrvgg_vexed = {
-	"gg_vexed", NULL, NULL, NULL, "2023",
-	"Vexed (HB, v1.08)\0", NULL, "Under4Mhz", "Sega Game Gear",
+	"gg_vexed", NULL, NULL, NULL, "2023-24",
+	"Vexed (HB, v1.15)\0", NULL, "Under4Mhz", "Sega Game Gear",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_PUZZLE, 0,
 	GGGetZipName, gg_vexedRomInfo, gg_vexedRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
-	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
-	256, 192, 4, 3
-};
-
-// Yakitori Meijin Torigin (HB)
-static struct BurnRomInfo gg_yakitoriRomDesc[] = {
-	{ "Yakitori Meijin Torigin (2022)(Habit Soft).gg",	65536, 0xbfb52bb3, BRF_PRG | BRF_ESS },
-};
-
-STD_ROM_PICK(gg_yakitori)
-STD_ROM_FN(gg_yakitori)
-
-struct BurnDriver BurnDrvgg_yakitori = {
-	"gg_yakitori", NULL, NULL, NULL, "2022",
-	"Yakitori Meijin Torigin (HB)\0", NULL, "Habit Soft", "Sega Game Gear",
-	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_PUZZLE, 0,
-	GGGetZipName, gg_yakitoriRomInfo, gg_yakitoriRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };
@@ -25944,6 +25998,42 @@ struct BurnDriver BurnDrvgg_wingwarriors = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_VERSHOOT, 0,
 	GGGetZipName, gg_wingwarriorsRomInfo, gg_wingwarriorsRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Wolfstein (HB, v1.16)
+static struct BurnRomInfo gg_wolfsteinRomDesc[] = {
+	{ "Wolfstein v1.16 (2023)(Under4Mhz).gg",	524288, 0xc2760884, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_wolfstein)
+STD_ROM_FN(gg_wolfstein)
+
+struct BurnDriver BurnDrvgg_wolfstein = {
+	"gg_wolfstein", NULL, NULL, NULL, "2023",
+	"Wolfstein (HB, v1.16)\0", NULL, "Under4Mhz", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_SHOOT, 0,
+	GGGetZipName, gg_wolfsteinRomInfo, gg_wolfsteinRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
+// Yakitori Meijin Torigin (HB)
+static struct BurnRomInfo gg_yakitoriRomDesc[] = {
+	{ "Yakitori Meijin Torigin (2022)(Habit Soft).gg",	65536, 0xbfb52bb3, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(gg_yakitori)
+STD_ROM_FN(gg_yakitori)
+
+struct BurnDriver BurnDrvgg_yakitori = {
+	"gg_yakitori", NULL, NULL, NULL, "2022",
+	"Yakitori Meijin Torigin (HB)\0", NULL, "Habit Soft", "Sega Game Gear",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_GAME_GEAR, GBF_PUZZLE, 0,
+	GGGetZipName, gg_yakitoriRomInfo, gg_yakitoriRomName, NULL, NULL, NULL, NULL, SMSInputInfo, GGDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3
 };


### PR DESCRIPTION
d_nes.cpp: added the support to:
"Vexed (HB, v1.15)"

d_ngp.cpp: added the support to:
"SwordWork Micro (HB)"

d_sms.cpp: added the support to
"Black Castle (HB, 20240523)" (GG)
"Black Castle (HB, 20240523)" (SMS)
"SwordWork Micro (HB)" (GG)
"Wolfstein (HB, v1.16)" (GG)
"Wolfstein (HB, v1.16)" (SMS)

d_sms.cpp: updated the support to
"Monaco Master (HB, v2.9.3)" (SMS)
"Vexed (HB, v1.15)" (GG)
"Vexed (HB, v1.15)" (SMS)