### PR TITLE
d_neogeo: samsho2pe

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -21633,14 +21633,14 @@ struct BurnDriver BurnDrvSamsh2jq = {
 };
 
 
-// Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.5, Hack)
+// Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.6, Hack)
 // Modified by Bear
-// 20260104
+// 20260516
 
 static struct BurnRomInfo samsho2peRomDesc[] = {
-	{ "063-p1pe.p1",	0x100000, 0xe4dd1c44, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "063-p2pe.sp2",	0x100000, 0x68ef2a4a, 1 | BRF_ESS | BRF_PRG }, //  1
-	{ "063-p3pe.p3",	0x020000, 0x2c311c74, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
+	{ "063-p1pe.p1",	0x100000, 0x9fd23e79, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "063-p2pe.sp2",	0x100000, 0x77c880b3, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "063-p3pe.p3",	0x020000, 0x0d1408be, 1 | BRF_ESS | BRF_PRG }, //  2 Extra ROM
 
 	SAMSHO2_COMPONENTS
 };
@@ -21650,8 +21650,8 @@ STD_ROM_FN(samsho2pe)
 
 struct BurnDriver BurnDrvSamsho2pe = {
 	"samsho2pe", "samsho2", "neogeo", NULL, "2023-26",
-	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.5, Hack)\0", NULL, "Bear", "Neo Geo MVS",
-	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.5, Hack)\0", NULL, NULL, NULL,
+	"Samurai Shodown II / Shin Samurai Spirits - Haohmaru Jigokuhen (Perfect V. 2.6, Hack)\0", NULL, "Bear", "Neo Geo MVS",
+	L"Samurai Shodown II\0\u771F Samurai Spirits - \u8987\u738B\u4E38\u5730\u7344\u5909 (Perfect V. 2.6, Hack)\0", NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_VSFIGHT, FBF_SAMSHO,
 	NULL, samsho2peRomInfo, samsho2peRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neoForceMVSDIPInfo,
 	samsh2spInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,


### PR DESCRIPTION
updated to versioon 2.6


Update patch notes:

[Nerf]  Shikihadori has been removed from the following characters: Galford, Hanzo, Nakoruru,Genan,Nicotine, Cham Cham, Earthquake Reason:
Characters with many special moves while unarmed have lost access to Shikihadori. The move is now intended to be more exclusive to characters with fewer unarmed special options, improving combat balance and character identity.

[System Update] Weapon Timer Saved Between Rounds
New weapon break system update implemented.
Before:
When a weapon was broken, an internal timer controlled when the weapon would return to the player. If the round ended before the timer reached zero, the system would reset normally in the next round. Now:
The weapon recovery timer is saved between rounds. Example:
If a player still has remaining recovery time when the round ends, the next round will start with that player still disarmed until the timer finishes. The timer continues exactly where it stopped in the previous round. Purpose:
To make weapon breaking more meaningful and preserve the advantage earned by the opponent during combat.

[Versus Mode Update] Stage System Changes
The automatic random stage system in VS mode has been removed. To restore character identity and allow players to fight on their own stages with their own music themes.

[New Feature] Optional Stage Randomizer
Players with WIN status can now manually randomize stages.

How it works:
After selecting your character, keep holding any input button: A / B / C / D or any button combination.
Do not release the button after character selection. Continue holding the input until the VS presentation screen appears, where the announcer introduces both fighters. The input must remain held continuously for exactly 5 seconds during the transition and VS presentation screen. If successful, the stage will randomize automatically before the fight begins. This method prevents timing issues caused by the opponent selecting their character too quickly or too slowly. This system allows players to choose between:
classic stage rotation or optional random stages.

[Buffs]

Wanfu - Create New Move for "Armed Version" -  Pillar Front Lock (Block Sword)  Wanfu - Create New Move for "Unnarmed Version" - Spirit Whirlwind Wham Fist Ukyo  - Create New Move for "Unnarmed Version" - Ghostly Dashing Punch Ukyo  - Create New Move for "Unnarmed Version" - Ghostly Dashing Kick Genjuro - Create New Move for "Unnarmed Version" - Lightning Fist Jubei - Create New Move for "Unnarmed Version" - Tsunami Punch