### PR TITLE
d_coleco.cpp, d_msx.cpp, d_sg1000.cpp, d_sms.cpp: various...

### DIFF
--- a/src/burn/drv/coleco/d_coleco.cpp
+++ b/src/burn/drv/coleco/d_coleco.cpp
@@ -5493,6 +5493,24 @@ struct BurnDriver BurnDrvcv_bankbuild = {
     272, 228, 4, 3
 };
 
+// Barbarricade (HB, 5-19-26 Beta)
+static struct BurnRomInfo cv_barbarricadeRomDesc[] = {
+	{ "Barbarricade 5-19-26 Beta (2026)(Jess Creations).rom",	24576, 0x09785a9e, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_barbarricade, cv_barbarricade, cv_coleco)
+STD_ROM_FN(cv_barbarricade)
+
+struct BurnDriver BurnDrvcv_barbarricade = {
+	"cv_barbarricade", NULL, "cv_coleco", NULL, "2026",
+	"Barbarricade (HB, 5-19-26 Beta)\0", NULL, "Jess Creations", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_BREAKOUT, 0,
+	CVGetZipName, cv_barbarricadeRomInfo, cv_barbarricadeRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // BarnBuster (HB)
 static struct BurnRomInfo cv_barnbusterRomDesc[] = {
     { "BarnBuster (2026)(DiRoccoVision).rom",	32768, 0x75a4713d, BRF_PRG | BRF_ESS },
@@ -7217,6 +7235,24 @@ struct BurnDriver BurnDrvcv_exerion = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_COLECO, GBF_SHOOT, 0,
 	CVGetZipName, cv_exerionRomInfo, cv_exerionRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Eye Brawls (HB, 1-31-26)
+static struct BurnRomInfo cv_eyebrawlsRomDesc[] = {
+	{ "Eye Brawls 1-31-26 (2026)(Jess Creations).rom",	32768, 0x7129da45, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_eyebrawls, cv_eyebrawls, cv_coleco)
+STD_ROM_FN(cv_eyebrawls)
+
+struct BurnDriver BurnDrvcv_eyebrawls = {
+	"cv_eyebrawls", NULL, "cv_coleco", NULL, "2026",
+	"Eye Brawls (HB, 1-31-26)\0", NULL, "Jess Creations", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_MAZE, 0,
+	CVGetZipName, cv_eyebrawlsRomInfo, cv_eyebrawlsRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -9383,7 +9419,7 @@ struct BurnDriver BurnDrvcv_mrchin = {
 
 // Mr. Do! Arcade (HB)
 static struct BurnRomInfo cv_mrdoarcadeRomDesc[] = {
-	{ "Mr. Do! Arcade (2026)(Scott Moschella).rom",	32695, 0xa06edcb1, BRF_PRG | BRF_ESS },
+	{ "Mr. Do! Arcade (2026)(Scott Moschella).rom",	32768, 0x09f0d2c7, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(cv_mrdoarcade, cv_mrdoarcade, cv_coleco)
@@ -9395,6 +9431,24 @@ struct BurnDriver BurnDrvcv_mrdoarcade = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_COLECO, GBF_ACTION, 0,
 	CVGetZipName, cv_mrdoarcadeRomInfo, cv_mrdoarcadeRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Mr. Do! Arcade - Red Nose (HB)
+static struct BurnRomInfo cv_mrdoarcadernRomDesc[] = {
+	{ "Mr. Do! Arcade - Red Nose (2026)(Scott Moschella).rom",	32768, 0x99324671, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_mrdoarcadern, cv_mrdoarcadern, cv_coleco)
+STD_ROM_FN(cv_mrdoarcadern)
+
+struct BurnDriver BurnDrvcv_mrdoarcadern = {
+	"cv_mrdoarcadern", "cv_mrdoarcade", "cv_coleco", NULL, "2026",
+	"Mr. Do! Arcade - Red Nose (HB)\0", NULL, "Scott Moschella", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_COLECO, GBF_ACTION, 0,
+	CVGetZipName, cv_mrdoarcadernRomInfo, cv_mrdoarcadernRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -10117,6 +10171,24 @@ struct BurnDriver BurnDrvcv_pyrawbc2 = {
     CVGetZipName, cv_pyrawbc2RomInfo, cv_pyrawbc2RomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
     DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
     272, 228, 4, 3
+};
+
+// Pyrebirds (HB, 01-22-26 Beta)
+static struct BurnRomInfo cv_pyrebirdsRomDesc[] = {
+	{ "Pyrebirds 01-22-26 Beta (2026)(Jess Creations).rom",	32768, 0x6bad1b85, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_pyrebirds, cv_pyrebirds, cv_coleco)
+STD_ROM_FN(cv_pyrebirds)
+
+struct BurnDriver BurnDrvcv_pyrebirds = {
+	"cv_pyrebirds", NULL, "cv_coleco", NULL, "2026",
+	"Pyrebirds (HB, 01-22-26 Beta)\0", NULL, "Jess Creations", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_VERSHOOT, 0,
+	CVGetZipName, cv_pyrebirdsRomInfo, cv_pyrebirdsRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
 };
 
 // qbIqS (SGM) (HB)

--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -30238,9 +30238,9 @@ struct BurnDriver BurnDrvMSX_exoticales = {
 	272, 228, 4, 3
 };
 
-// Eye Brawls (HB, v1.1)
+// Eye Brawls (HB, 5-9-26)
 static struct BurnRomInfo MSX_eyebrawlsRomDesc[] = {
-	{ "Eye Brawls v1.1 (2026)(Jess Creations).rom",	32768, 0x26b6648d, BRF_PRG | BRF_ESS },
+	{ "Eye Brawls 5-9-26 (2026)(Jess Creations).rom",	32768, 0xc1a37604, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(MSX_eyebrawls, MSX_eyebrawls, msx_msx)
@@ -30248,7 +30248,7 @@ STD_ROM_FN(MSX_eyebrawls)
 
 struct BurnDriver BurnDrvMSX_eyebrawls = {
 	"msx_eyebrawls", NULL, "msx_msx", NULL, "2026",
-	"Eye Brawls (HB, v1.1)\0", NULL, "Jess Creations", "MSX",
+	"Eye Brawls (HB, 5-9-26)\0", NULL, "Jess Creations", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION | GBF_MAZE, 0,
 	MSXGetZipName, MSX_eyebrawlsRomInfo, MSX_eyebrawlsRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
@@ -34416,9 +34416,9 @@ struct BurnDriver BurnDrvMSX_soko64p = {
 	272, 228, 4, 3
 };
 
-// Solar Fox II: Space Evaders (HB)
+// Solar Fox II (HB)
 static struct BurnRomInfo MSX_solarfox2RomDesc[] = {
-	{ "Solar Fox II - Space Evaders (2025)(Jess Creations).rom",	32768, 0x7ed32582, BRF_PRG | BRF_ESS },
+	{ "Solar Fox II (2025)(Jess Creations).rom",	32768, 0x7ed32582, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(MSX_solarfox2, MSX_solarfox2, msx_msx)
@@ -34426,7 +34426,7 @@ STD_ROM_FN(MSX_solarfox2)
 
 struct BurnDriver BurnDrvMSX_solarfox2 = {
 	"msx_solarfox2", NULL, "msx_msx", NULL, "2025",
-	"Solar Fox II: Space Evaders (HB)\0", NULL, "Jess Creations", "MSX",
+	"Solar Fox II (HB)\0", NULL, "Jess Creations", "MSX",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_ACTION, 0,
 	MSXGetZipName, MSX_solarfox2RomInfo, MSX_solarfox2RomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,

--- a/src/burn/drv/sg1000/d_sg1000.cpp
+++ b/src/burn/drv/sg1000/d_sg1000.cpp
@@ -4355,9 +4355,9 @@ struct BurnDriver BurnDrvsg1k_crosstrex = {
 	272, 228, 4, 3
 };
 
-// Eye Brawls (HB, v1.2)
+// Eye Brawls (HB, 1-30-26)
 static struct BurnRomInfo sg1k_eyebrawlsRomDesc[] = {
-	{ "Eye Brawls v1.2 (2026)(Jess Creations, ArugulaZ).sg",	32768, 0xe2ce44f0, BRF_PRG | BRF_ESS },
+	{ "Eye Brawls 1-30-26 (2026)(Jess Creations, ArugulaZ).sg",	32768, 0x3ea1da76, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sg1k_eyebrawls)
@@ -4365,7 +4365,7 @@ STD_ROM_FN(sg1k_eyebrawls)
 
 struct BurnDriver BurnDrvsg1k_eyebrawls = {
 	"sg1k_eyebrawls", NULL, NULL, NULL, "2026",
-	"Eye Brawls (HB, v1.2)\0", NULL, "Jess Creations - ArugulaZ", "Sega SG-1000",
+	"Eye Brawls (HB, 1-30-26)\0", NULL, "Jess Creations - ArugulaZ", "Sega SG-1000",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION | GBF_MAZE, 0,
 	SG1KGetZipName, sg1k_eyebrawlsRomInfo, sg1k_eyebrawlsRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
@@ -4770,9 +4770,9 @@ struct BurnDriver BurnDrvsg1k_sgthelmet = {
 	272, 228, 4, 3
 };
 
-// Solar Fox II (HB)
+// Solar Fox II (HB, 21-10-25)
 static struct BurnRomInfo sg1k_solarfoxiiRomDesc[] = {
-	{ "Solar Fox II (2025)(Jess Creations - ArugulaZ).sg",	40960, 0x2ce5cf6f, BRF_PRG | BRF_ESS },
+	{ "Solar Fox II 21-10-25 (2025)(Jess Creations - ArugulaZ).sg",	40960, 0x7886d024, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sg1k_solarfoxii)
@@ -4780,7 +4780,7 @@ STD_ROM_FN(sg1k_solarfoxii)
 
 struct BurnDriver BurnDrvsg1k_solarfoxii = {
 	"sg1k_solarfoxii", NULL, NULL, NULL, "2025",
-	"Solar Fox II (HB)\0", NULL, "Jess Creations - ArugulaZ", "Sega SG-1000",
+	"Solar Fox II (HB, 21-10-25)\0", NULL, "Jess Creations - ArugulaZ", "Sega SG-1000",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_ACTION, 0,
 	SG1KGetZipName, sg1k_solarfoxiiRomInfo, sg1k_solarfoxiiRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,
@@ -4898,7 +4898,7 @@ struct BurnDriver BurnDrvsg1k_vexed = {
 
 // Whack 'Em Smack 'Em Byrons (HB)
 static struct BurnRomInfo sg1k_wsbyronsRomDesc[] = {
-	{ "Whack 'Em Smack 'Em Byrons (2024)(Jess Creations - ArugulaZ).sg",	32706, 0xa444660d, BRF_PRG | BRF_ESS },
+	{ "Whack 'Em Smack 'Em Byrons (2024)(Jess Creations - ArugulaZ).sg",	31770, 0x073dd0e9, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sg1k_wsbyrons)

--- a/src/burn/drv/sms/d_sms.cpp
+++ b/src/burn/drv/sms/d_sms.cpp
@@ -24916,7 +24916,7 @@ struct BurnDriver BurnDrvsms_wekainvaders = {
 
 // Whack 'Em Smack 'Em Byrons Remarked (HB)
 static struct BurnRomInfo sms_wsbyronsrRomDesc[] = {
-	{ "Whack 'Em Smack 'Em Byrons Remarked (2025)(ArugulaZ).sms",	131072, 0xbe34ae87, BRF_PRG | BRF_ESS },
+	{ "Whack 'Em Smack 'Em Byrons Remarked (2025)(Jess Creations - ArugulaZ).sms",	131072, 0xbe34ae87, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sms_wsbyronsr)
@@ -24924,7 +24924,7 @@ STD_ROM_FN(sms_wsbyronsr)
 
 struct BurnDriver BurnDrvsms_wsbyronsr = {
 	"sms_wsbyronsr", NULL, NULL, NULL, "2025",
-	"Whack 'Em Smack 'Em Byrons Remarked (HB)\0", NULL, "ArugulaZ", "Sega Master System",
+	"Whack 'Em Smack 'Em Byrons Remarked (HB)\0", NULL, "Jess Creations - ArugulaZ", "Sega Master System",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_ACTION, 0,
 	SMSGetZipName, sms_wsbyronsrRomInfo, sms_wsbyronsrRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,


### PR DESCRIPTION
d_coleco.cpp: added the support to:
"Barbarricade (HB, 5-19-26 Beta)"
"Eye Brawls (HB, 1-31-26)"
"Mr. Do! Arcade - Red Nose (HB)"
"Pyrebirds (HB, 01-22-26 Beta)"

d_coleco.cpp: updated the support to:
"Mr. Do! Arcade (HB)"

d_msx.cpp: updated the support to:
"Eye Brawls (HB, 5-9-26)"

d_sg1000.cpp: updated the support to:
"Eye Brawls (HB, 1-30-26)"
"Solar Fox II (HB, 21-10-25)"
"Whack 'Em Smack 'Em Byrons (HB)"

d_sms.cpp: fix developer of "Whack 'Em Smack 'Em Byrons Remarked (HB)"