### PR TITLE
d_coleco.cpp, d_msx.cpp, d_sg1000.cpp, d_sms.cpp, d_spectrum.cpp: various...

### DIFF
--- a/src/burn/drv/coleco/d_coleco.cpp
+++ b/src/burn/drv/coleco/d_coleco.cpp
@@ -3957,6 +3957,24 @@ struct BurnDriver BurnDrvcv_secalpha = {
 	272, 228, 4, 3
 };
 
+// Sega-Galaga (Prototype)
+static struct BurnRomInfo cv_segagalagaRomDesc[] = {
+	{ "Sega-Galaga (Proto)(1981-83)(Sega - Namco).rom",	32768, 0x6139aec7, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_segagalaga, cv_segagalaga, cv_coleco)
+STD_ROM_FN(cv_segagalaga)
+
+struct BurnDriver BurnDrvcv_segagalaga = {
+	"cv_segagalaga", NULL, "cv_coleco", NULL, "1981-83",
+	"Sega-Galaga (Prototype)\0", NULL, "Sega - Namco", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_PROTOTYPE, 2, HARDWARE_COLECO, GBF_SHOOT, 0,
+	CVGetZipName, cv_segagalagaRomInfo, cv_segagalagaRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Sewer Sam (USA)
 static struct BurnRomInfo cv_sewersamRomDesc[] = {
 	{ "Sewer Sam (USA)(1984)(Interphase).rom",	24576, 0x4591f393, BRF_PRG | BRF_ESS },
@@ -5493,9 +5511,9 @@ struct BurnDriver BurnDrvcv_bankbuild = {
     272, 228, 4, 3
 };
 
-// Barbarricade (HB, 05-30-26)
+// Barbarricade (HB, 05-31-26)
 static struct BurnRomInfo cv_barbarricadeRomDesc[] = {
-	{ "Barbarricade 05-30-26 (2026)(Jess Creations).rom",	32768, 0x8a9c157b, BRF_PRG | BRF_ESS },
+	{ "Barbarricade 05-31-26 (2026)(Jess Creations).rom",	32768, 0x804c27ae, BRF_PRG | BRF_ESS },
 };
 
 STDROMPICKEXT(cv_barbarricade, cv_barbarricade, cv_coleco)
@@ -5503,7 +5521,7 @@ STD_ROM_FN(cv_barbarricade)
 
 struct BurnDriver BurnDrvcv_barbarricade = {
 	"cv_barbarricade", NULL, "cv_coleco", NULL, "2026",
-	"Barbarricade (HB, 05-30-26)\0", NULL, "Jess Creations", "ColecoVision",
+	"Barbarricade (HB, 05-31-26)\0", NULL, "Jess Creations", "ColecoVision",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_BREAKOUT, 0,
 	CVGetZipName, cv_barbarricadeRomInfo, cv_barbarricadeRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
@@ -6447,6 +6465,24 @@ struct BurnDriver BurnDrvcv_cotn = {
     272, 228, 4, 3
 };
 
+// Circus (HB)
+static struct BurnRomInfo cv_circusRomDesc[] = {
+    { "Circus (2023)(CollectorVision).rom",	0x7fff, 0x1d353f30, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_circus, cv_circus, cv_coleco)
+STD_ROM_FN(cv_circus)
+
+struct BurnDriver BurnDrvcv_circus = {
+    "cv_circus", NULL, "cv_coleco", NULL, "2023",
+    "Circus (HB)\0", "Published by CollectorVision Games", "Alekmaul", "ColecoVision",
+    NULL, NULL, NULL, NULL,
+    BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION, 0,
+    CVGetZipName, cv_circusRomInfo, cv_circusRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+    DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+    272, 228, 4, 3
+};
+
 // Circus Charlie (HB)
 static struct BurnRomInfo cv_ccharlieRomDesc[] = {
     { "Circus Charlie (2011)(Team Pixelboy).rom",	0x8000, 0xbe3ef785, BRF_PRG | BRF_ESS },
@@ -6605,6 +6641,24 @@ struct BurnDriver BurnDrvcv_Crazychickyjr = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_MAZE, 0,
 	CVGetZipName, cv_CrazychickyjrRomInfo, cv_CrazychickyjrRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Crazy Chicky Junior: New Cluck City (HB)
+static struct BurnRomInfo cv_Crazychickyjr2RomDesc[] = {
+	{ "Crazy Chicky Junior - New Cluck City (2024)(8 bit Milli Games).rom", 32768, 0xe29d280e, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(cv_Crazychickyjr2, cv_Crazychickyjr2, cv_coleco)
+STD_ROM_FN(cv_Crazychickyjr2)
+
+struct BurnDriver BurnDrvcv_Crazychickyjr2 = {
+	"cv_crazychickyjr2", NULL, "cv_coleco", NULL, "2024",
+	"Crazy Chicky Junior: New Cluck City (HB)\0", NULL, "8 bit Milli Games", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_ACTION | GBF_MAZE, 0,
+	CVGetZipName, cv_Crazychickyjr2RomInfo, cv_Crazychickyjr2RomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };
@@ -9215,6 +9269,24 @@ struct BurnDriver BurnDrvcv_mindwalls = {
     NULL, NULL, NULL, NULL,
     BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_BREAKOUT, 0,
     CVGetZipName, cv_mindwallsRomInfo, cv_mindwallsRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+    DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+    272, 228, 4, 3
+};
+
+// Minesweeper (HB, v1.03)
+static struct BurnRomInfo cv_minesweeperRomDesc[] = {
+    { "Minesweeper v1.03 (2023)(Under4Mhz).rom",	16384, 0xd92adc95, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_minesweeper, cv_minesweeper, cv_coleco)
+STD_ROM_FN(cv_minesweeper)
+
+struct BurnDriver BurnDrvcv_minesweeper = {
+    "cv_minesweeper", NULL, "cv_coleco", NULL, "2023",
+    "Minesweeper (HB, v1.03)\0", NULL, "Under4Mhz", "ColecoVision",
+    NULL, NULL, NULL, NULL,
+    BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_PUZZLE, 0,
+    CVGetZipName, cv_minesweeperRomInfo, cv_minesweeperRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
     DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
     272, 228, 4, 3
 };
@@ -12242,6 +12314,24 @@ struct BurnDriver BurnDrvcv_watervil = {
     272, 228, 4, 3
 };
 
+// Way of the Dung (HB)
+static struct BurnRomInfo cv_waydungRomDesc[] = {
+	{ "Way of the Dung (2024)(8 bit Milli Games).rom",	32768, 0x1599b78f, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_waydung, cv_waydung, cv_coleco)
+STD_ROM_FN(cv_waydung)
+
+struct BurnDriver BurnDrvcv_waydung = {
+	"cv_waydung", NULL, "cv_coleco", NULL, "2024",
+	"Way of the Dung (HB)\0", NULL, "8 bit Milli Games", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_MAZE, 0,
+	CVGetZipName, cv_waydungRomInfo, cv_waydungRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
 // Way of the Exploding Foot, The (HB)
 static struct BurnRomInfo cv_explodingfootRomDesc[] = {
     { "Way of the Exploding Foot (2011)(CollectorVision).rom",	0x08000, 0x28e07beb, BRF_PRG | BRF_ESS },
@@ -12364,6 +12454,24 @@ struct BurnDriver BurnDrvcv_wordle = {
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 2, HARDWARE_COLECO, GBF_PUZZLE, 0,
 	CVGetZipName, cv_wordleRomInfo, cv_wordleRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
+	272, 228, 4, 3
+};
+
+// Wormhole (HB)
+static struct BurnRomInfo cv_wormholeRomDesc[] = {
+	{ "Wormhole (2023)(8 bit Milli Games).rom",	32768, 0xb2b5f955, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(cv_wormhole, cv_wormhole, cv_coleco)
+STD_ROM_FN(cv_wormhole)
+
+struct BurnDriver BurnDrvcv_wormhole = {
+	"cv_wormhole", NULL, "cv_coleco", NULL, "2023",
+	"Wormhole (HB)\0", NULL, "8 bit Milli Games", "ColecoVision",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_COLECO, GBF_HORSHOOT, 0,
+	CVGetZipName, cv_wormholeRomInfo, cv_wormholeRomName, NULL, NULL, NULL, NULL, ColecoInputInfo, ColecoDIPInfo,
 	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, TMS9928A_PALETTE_SIZE,
 	272, 228, 4, 3
 };

--- a/src/burn/drv/msx/d_msx.cpp
+++ b/src/burn/drv/msx/d_msx.cpp
@@ -32201,6 +32201,24 @@ struct BurnDriver BurnDrvMSX_minefind = {
 	272, 228, 4, 3
 };
 
+// Minesweeper (HB, v1.03)
+static struct BurnRomInfo MSX_minesweeperRomDesc[] = {
+	{ "Minesweeper v1.03 (2023)(Under4Mhz).rom",	16384, 0x6aa779ac, BRF_PRG | BRF_ESS },
+};
+
+STDROMPICKEXT(MSX_minesweeper, MSX_minesweeper, msx_msx)
+STD_ROM_FN(MSX_minesweeper)
+
+struct BurnDriver BurnDrvMSX_minesweeper = {
+	"msx_minesweeper", NULL, "msx_msx", NULL, "2023",
+	"Minesweeper (HB, v1.03)\0", NULL, "Under4Mhz", "MSX",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_MSX, GBF_PUZZLE, 0,
+	MSXGetZipName, MSX_minesweeperRomInfo, MSX_minesweeperRomName, NULL, NULL, NULL, NULL, MSXInputInfo, MSXDIPInfo,
+	DrvInit, DrvExit, DrvFrame, TMS9928ADraw, DrvScan, NULL, 0x10,
+	272, 228, 4, 3
+};
+
 // MiniMagos (HB)
 static struct BurnRomInfo MSX_minimagosRomDesc[] = {
 	{ "MiniMagos (2017)(Fran Games).rom",	24576, 0xd8a841ed, BRF_PRG | BRF_ESS },

--- a/src/burn/drv/sg1000/d_sg1000.cpp
+++ b/src/burn/drv/sg1000/d_sg1000.cpp
@@ -4157,9 +4157,9 @@ struct BurnDriver BurnDrvsg1k_awass = {
 	272, 228, 4, 3
 };
 
-// Barbarricade (HB, 05-30-26)
+// Barbarricade (HB, 05-31-26)
 static struct BurnRomInfo sg1k_barbarricadeRomDesc[] = {
-	{ "Barbarricade 05-30-26 (2026)(Jess Creations, ArugulaZ).sg",	40960, 0x9adbeec7, BRF_PRG | BRF_ESS },
+	{ "Barbarricade 05-31-26 (2026)(Jess Creations, ArugulaZ).sg",	40960, 0x8a135a2f, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sg1k_barbarricade)
@@ -4167,7 +4167,7 @@ STD_ROM_FN(sg1k_barbarricade)
 
 struct BurnDriver BurnDrvsg1k_barbarricade = {
 	"sg1k_barbarricade", NULL, NULL, NULL, "2026",
-	"Barbarricade (HB, 05-30-26)\0", NULL, "Jess Creations - ArugulaZ", "Sega SG-1000",
+	"Barbarricade (HB, 05-31-26)\0", NULL, "Jess Creations - ArugulaZ", "Sega SG-1000",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_SG1000, GBF_BREAKOUT, 0,
 	SG1KGetZipName, sg1k_barbarricadeRomInfo, sg1k_barbarricadeRomName, NULL, NULL, NULL, NULL, Sg1000InputInfo, Sg1000DIPInfo,

--- a/src/burn/drv/sms/d_sms.cpp
+++ b/src/burn/drv/sms/d_sms.cpp
@@ -23377,6 +23377,24 @@ struct BurnDriver BurnDrvsms_mieyen = {
 	256, 192, 4, 3
 };
 
+// Minesweeper (HB, v1.03)
+static struct BurnRomInfo sms_minesweeperRomDesc[] = {
+	{ "Minesweeper v1.03 (2023)(Under4Mhz).sms",	32768, 0x27e998e9, BRF_PRG | BRF_ESS },
+};
+
+STD_ROM_PICK(sms_minesweeper)
+STD_ROM_FN(sms_minesweeper)
+
+struct BurnDriver BurnDrvsms_minesweeper = {
+	"sms_minesweeper", NULL, NULL, NULL, "2023",
+	"Minesweeper (HB, v1.03)\0", NULL, "Under4Mhz", "Sega Master System",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PUZZLE, 0,
+	SMSGetZipName, sms_minesweeperRomInfo, sms_minesweeperRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSFMDIPInfo,
+	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
+	256, 192, 4, 3
+};
+
 // MiniMSX (HB)
 static struct BurnRomInfo sms_minimsxRomDesc[] = {
 	{ "MiniMSX (2021)(MikGames).sms",	131072, 0xeb6c0944, BRF_PRG | BRF_ESS },

--- a/src/burn/drv/spectrum/d_spectrum.cpp
+++ b/src/burn/drv/spectrum/d_spectrum.cpp
@@ -49926,6 +49926,44 @@ struct BurnDriver BurnSpecMin128 = {
 	&SpecRecalc, 0x10, 288, 224, 4, 3
 };
 
+// Minesweeper (128K) (HB, v1.03)
+
+static struct BurnRomInfo SpecMinesweeper128RomDesc[] = {
+	{ "Minesweeper v1.03 128K (2023)(Under4Mhz).tap", 15851, 0x1e27e992, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecMinesweeper128, SpecMinesweeper128, Spec128)
+STD_ROM_FN(SpecMinesweeper128)
+
+struct BurnDriver BurnSpecMinesweeper128 = {
+	"spec_minesweeper128", NULL, "spec_spec128", NULL, "2023",
+	"Minesweeper (128K) (HB, v1.03)\0", NULL, "Under4Mhz", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_PUZZLE, 0,
+	SpectrumGetZipName, SpecMinesweeper128RomInfo, SpecMinesweeper128RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecQAOPSpaceDIPInfo,
+	Spec128KInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
+// Minesweeper (48K) (HB, v1.03)
+
+static struct BurnRomInfo SpecMinesweeper48RomDesc[] = {
+	{ "Minesweeper v1.03 48K (2023)(Under4Mhz).tap", 16439, 0x44a3f73e, BRF_ESS | BRF_PRG },
+};
+
+STDROMPICKEXT(SpecMinesweeper48, SpecMinesweeper48, Spectrum)
+STD_ROM_FN(SpecMinesweeper48)
+
+struct BurnDriver BurnSpecMinesweeper48 = {
+	"spec_minesweeper48", "spec_minesweeper128", "spec_spectrum", NULL, "2023",
+	"Minesweeper (48K) (HB, v1.03)\0", NULL, "Under4Mhz", "ZX Spectrum",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HOMEBREW, 1, HARDWARE_SPECTRUM, GBF_PUZZLE, 0,
+	SpectrumGetZipName, SpecMinesweeper48RomInfo, SpecMinesweeper48RomName, NULL, NULL, NULL, NULL, SpecInputInfo, SpecDIPInfo,
+	SpecInit, SpecExit, SpecFrame, SpecDraw, SpecScan,
+	&SpecRecalc, 0x10, 288, 224, 4, 3
+};
+
 // Mire Mare (48K) (HB, v1.09)
 
 static struct BurnRomInfo SpecMiremareRomDesc[] = {


### PR DESCRIPTION
d_coleco.cpp: added the support to:
"Circus (HB)"
"Crazy Chicky Junior: New Cluck City"
"Minesweeper (HB, v1.03)"
"Sega-Galaga (Prototype)"
"Way of the Dung (HB)"
"Wormhole (HB)"

d_coleco.cpp: updated the support to "Barbarricade (HB, 05-31-26)"

d_msx.cpp: added the support to "Minesweeper (HB, v1.03)"

d_sg1000.cpp: updated the support to "Barbarricade (HB, 05-31-26)"

d_sms.cpp: added the support to "Minesweeper (HB, v1.03)"

d_spectrum.cpp: added the support to:
"Minesweeper (128K) (HB, v1.03)"
"Minesweeper (48K) (HB, v1.03)"