### PR TITLE
fix: orphaned clones, thready platform detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,10 @@ endforeach
 #   group_desc / group_srcs (shared support) / drivers ({file: [components]})
 enabled_components = []
 burn_drivers = {}                 # group -> { 'desc', 'drivers', 'srcs' }
-driver_files_abs = []             # explicit d_*.cpp paths fed to gamelist.pl
+# d_parent.cpp lives outside the group dirs and is always compiled (see
+# src/burn/drv/meson.build); feed it to gamelist.pl too, otherwise its parent
+# drivers are missing from driverlist.h and their clones show up orphaned.
+driver_files_abs = [meson.current_source_dir() / 'src/burn/drv/d_parent.cpp']
 seen_drivers = []                 # for exclusion validation
 foreach g : selected_groups
     assert(

--- a/src/burn/meson.build
+++ b/src/burn/meson.build
@@ -62,6 +62,13 @@ endif
 # Active-frontend build macro(s), computed once in the root meson.build.
 burn_defs += frontend_defs
 
+if frontend == 'win32'
+    burn_defs += [
+        '-DWIN32',
+        '-D_WIN32',
+    ]
+endif
+
 burn_c_args = burn_defs
 burn_cpp_args = burn_defs
 

--- a/src/burner/win32/meson.build
+++ b/src/burner/win32/meson.build
@@ -196,8 +196,6 @@ frontend_inc = [
 frontend_dep = declare_dependency(
     include_directories: include_directories(frontend_inc),
     compile_args: [
-        '-DWIN32',
-        '-D_WIN32',
         '-DINCLUDE_AVI_RECORDING',
         '-D_USE_MATH_DEFINES',
     ],


### PR DESCRIPTION
# Summary

Fixes two unrelated defects surfaced by the Meson build / 64-bit MinGW toolchain. Each is small and self-contained.

# Changes

1. Orphaned parent clones at the top of the game list (meson.build)

driverlist.h is generated from the explicit driver_files_abs manifest fed to gamelist.pl -f. That list was only populated from the per-group d_*.cpp files, but d_parent.cpp lives outside the group dirs (it's compiled unconditionally via src/burn/drv/meson.build) and was never added to the manifest.

As a result the 4 parent drivers in d_parent.cpp (Eightballact, Hero, Hunchbak, Huncholy) were missing from driverlist.h, so clones referencing them had no parent and showed up orphaned at the top of the list. The old Makefile build didn't hit this because gamelist.pl used to scan by directory.

Fix: seed driver_files_abs with src/burn/drv/d_parent.cpp, mirroring burn_drv_sources = ['d_parent.cpp']. gamelist.pl is unchanged.

2. Thready: "we can't thread on this platform yet." with rewind enabled (src/burn/devices/thready.h)

The Windows branch was gated on _MSC_VER || WIN32 (bare WIN32). burn.cpp (rewind) and epic12.cpp compile with -DBUILD_WIN32 only — -DWIN32/-D_WIN32 live in the win32 frontend dependency and don't propagate to the burn libraries. On 64-bit mingw-w64, bare WIN32 isn't predefined, so THREADY fell back to the no-thread branch; enabling rewind then printed the warning.

Fix: gate on _WIN32 (guaranteed on all Windows toolchains, 32/64-bit, MSVC/MinGW) in addition to WIN32/WIN64/_MSC_VER, and add !defined(_WIN32) to the pthread guard. Verified via preprocessor: _WIN32→WINDOWS, _MSC_VER→WINDOWSVC, linux/apple→PTHREAD, bare→0THREAD.