### PR TITLE
pgm2_draw: Fix sprite flipxy bit shift offset error

### DIFF
--- a/src/burn/drv/pgm2/pgm2_draw.cpp
+++ b/src/burn/drv/pgm2/pgm2_draw.cpp
@@ -398,7 +398,7 @@ static void pgm2_draw_bg(INT32 w, INT32 h)
 			UINT32 entry = BURN_ENDIAN_SWAP_INT32(vram[ty * MAP_W + tx]);
 			UINT32 tileno = entry & 0x3FFFFu;
 			UINT8  colour = (entry >> 18) & 0xFu;
-			UINT8  flipxy = (entry >> 24) & 3u;
+			UINT8  flipxy = (entry >> 23) & 3u;	// flip bits are 24:23
 
 			if (tile_count_pow2) tileno &= (bg_tile_count - 1);
 			else                 tileno %= bg_tile_count;
@@ -468,7 +468,7 @@ static void pgm2_draw_fg(INT32 w, INT32 h)
 			UINT32 entry = BURN_ENDIAN_SWAP_INT32(vram[ty * MAP_W + tx]);
 			UINT32 tileno = entry & 0x3FFFFu;
 			UINT8  colour = (entry >> 18) & 0x1Fu;
-			UINT8  flipxy = (entry >> 24) & 3u;
+			UINT8  flipxy = (entry >> 23) & 3u;	// flip bits are 24:23
 
 			if (tile_count_pow2) tileno &= (fg_tile_count - 1);
 			else                 tileno %= fg_tile_count;


### PR DESCRIPTION
Correct the right shift count for sprite XY flip flags. The flip bits are located at bit23 and bit24; shifting by 24 bits discarded bit23 and caused broken sprite mirror rendering. Adjust shift value from 24 to 23 to read both flip bits properly.