### PR TITLE
SDL2: wait for asynchronous joystick enumeration

### DIFF
--- a/src/intf/input/sdl/inp_sdl2.cpp
+++ b/src/intf/input/sdl/inp_sdl2.cpp
@@ -14,6 +14,7 @@ static SDL_Joystick* JoyList[MAX_JOYSTICKS];
 static SDL_GameController *GCList[MAX_JOYSTICKS];
 static int* JoyPrevAxes = NULL;
 /* static */ int nJoystickCount = 0;						// Number of joysticks connected to this machine
+#define JOYSTICK_DETECT_MS 600								// how long to wait for async pad enumeration (see SDLinpInit)
 int buttons [4][8]= { {-1,-1,-1,-1,-1,-1,-1,-1}, {-1,-1,-1,-1,-1,-1,-1,-1}, {-1,-1,-1,-1,-1,-1,-1,-1}, {-1,-1,-1,-1,-1,-1,-1,-1} }; // 4 joysticks buttons 0 -5 and start / select
 
 void setup_kemaps(void)
@@ -386,11 +387,30 @@ int SDLinpInit()
 		SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
 	}
 
-	// Set up the joysticks
+	// Set up the joysticks.  Device discovery is asynchronous on sdl2-compat/SDL3
+	// (macOS enumerates pads through GameController.framework), so SDL_NumJoysticks()
+	// reads 0 for the first few hundred ms after init.  Pump the queue until a device
+	// shows up, capped so a keyboard-only setup isn't held up for long.
 	nJoystickCount = SDL_NumJoysticks();
+
+	for (int nWait = 0; nJoystickCount == 0 && nWait < JOYSTICK_DETECT_MS; nWait += 20) {
+		SDL_PumpEvents();
+		SDL_Delay(20);
+		nJoystickCount = SDL_NumJoysticks();
+	}
+
 	for (int i = 0; i < nJoystickCount; i++) {
 		SDLinpJoystickInit(i);
 	}
+
+	if (nJoystickCount > 0) {
+		printf("Found %d joystick(s):\n", nJoystickCount);
+		for (int i = 0; i < nJoystickCount; i++) {
+			printf("  Joy %d: %s%s\n", i, SDL_JoystickNameForIndex(i),
+				SDL_IsGameController(i) ? " (game controller)" : "");
+		}
+	}
+
 	SDL_GameControllerEventState(SDL_IGNORE);
 	SDL_JoystickEventState(SDL_IGNORE);
 


### PR DESCRIPTION
Fixes #2669.

`SDLinpInit()` enumerated joysticks once, right after starting the subsystem.
That's fine when SDL enumerates synchronously, but sdl2-compat/SDL3 finds pads
through GameController.framework on macOS, which is asynchronous --
`SDL_NumJoysticks()` reads 0 for roughly the first 300ms. Joystick events are
disabled two lines later and nothing re-enumerates, so no pad was ever detected
and input silently fell back to the keyboard.

Pumps the event queue until a device shows up, capped at 600ms, and prints what
it found.

A couple of comments:

- On real SDL2 with no pad connected, this is up to 600ms of extra startup.
  Happy to shorten the cap or gate it on something narrower.
- It's still startup-only -- plugging a pad in after launch won't register.
  Keeping joystick events on and handling `SDL_JOYDEVICEADDED` would be the
  fuller fix if you'd prefer that instead.

Tested on macOS 15 (arm64), sdl2-compat 2.32.70, Xbox Series X pad over USB.
