### PR TITLE
taking a shot at making a dark ui mode (still limited)

### DIFF
--- a/src/burner/win32/app.rc
+++ b/src/burner/win32/app.rc
@@ -248,7 +248,7 @@ BEGIN
     CONTROL         BMP_ABOUT,IDC_STATIC,"Static",SS_BITMAP | SS_REALSIZEIMAGE | SS_SUNKEN,3,3,100,50
     CONTROL         "version",IDC_FBA_VER,"Static",SS_OWNERDRAW | WS_GROUP,83,65,269,10
     CONTROL         "specialbuild",IDC_SPECIALSTRING,"Static",SS_OWNERDRAW | WS_GROUP,83,73,269,10
-    LTEXT           "FB Neo contains parts of MAME && Final Burn.\n© 2004-2025, Team FBNeo.",IDC_STATIC,6,88,235,16,WS_DISABLED
+    LTEXT           "FB Neo contains parts of MAME && Final Burn.\nï¿½ 2004-2025, Team FBNeo.",IDC_STATIC,6,88,235,16,WS_DISABLED
     DEFPUSHBUTTON   "OK",IDOK,305,90,50,14
     PUSHBUTTON      "License",IDC_SHOWLICENSE,251,90,50,14
     CONTROL         "",IDC_LICENSE,"RICHEDIT20A",ES_MULTILINE | ES_READONLY | WS_VSCROLL | ES_NOIME,3,109,353,77, WS_EX_STATICEDGE | ES_EX_NOCALLOLEINIT
@@ -1512,6 +1512,8 @@ BEGIN
         	BEGIN
         		MENUITEM "Select skin...",						MENU_SELECTPLACEHOLDER
         		MENUITEM "Set skin to default",					MENU_DISABLEPLACEHOLDER
+                MENUITEM "Select Default Light Mode",           MENU_DEFAULT_LIGHT_MODE
+                MENUITEM "Select Default Dark Mode",            MENU_DEFAULT_DARK_MODE
         	END
        	POPUP    "UI language"
        	BEGIN

--- a/src/burner/win32/burner_win32.h
+++ b/src/burner/win32/burner_win32.h
@@ -380,6 +380,11 @@ extern bool bIconsOnlyParents;
 extern int nIconsSize, nIconsSizeXY, nIconsYDiff;
 extern bool bGameInfoOpen;
 extern bool bIconsByHardwares;
+extern UINT uiBackGroundColor;
+extern UINT uiMenuItemColor;
+extern UINT uiSelectedMenuItemColor;
+extern UINT uiTextFontColor;
+extern UINT nUiColorTheme;
 
 extern HICON* pIconsCache;
 
@@ -648,6 +653,10 @@ int ChooseMonitorCreate();
 // placeholder.cpp
 int SelectPlaceHolder();
 void ResetPlaceHolder();
+
+void UpdateUiColorMode(UINT uiColorMode);
+void ApplyDarkMode();
+void ApplyLightMode();
 
 // Misc
 #define _TtoA(a)	TCHARToANSI(a, NULL, 0)

--- a/src/burner/win32/cona.cpp
+++ b/src/burner/win32/cona.cpp
@@ -984,9 +984,9 @@ int ConfigAppSave()
 	_ftprintf(h, _T("\n// The language index to use for the IPS Patch Manager dialog.\n"));
 	VAR(nIpsSelectedLanguage);
 
-	_ftprintf(h, _T("\n// The reference to determine which ui color mode is to be used 1 - Light Mode and 2 - Dark Mode\n"));
+	_ftprintf(h, _T("\n// The reference to determine which ui color mode is to be used 0 - Light Mode and 1 - Dark Mode\n"));
 	VAR(nUiColorTheme);
-	
+
 	_ftprintf(h, _T("\n// If non-zero, display drivers icons.\n"));
 	VAR(bEnableIcons);
 

--- a/src/burner/win32/cona.cpp
+++ b/src/burner/win32/cona.cpp
@@ -487,6 +487,7 @@ int ConfigAppLoad()
 		VAR(nIpsSelectedLanguage);
 
 		VAR(bEnableIcons);
+		VAR(nUiColorTheme);
 		VAR(bIconsOnlyParents);
 		VAR(nIconsSize);
 		VAR(bIconsByHardwares);
@@ -983,6 +984,9 @@ int ConfigAppSave()
 	_ftprintf(h, _T("\n// The language index to use for the IPS Patch Manager dialog.\n"));
 	VAR(nIpsSelectedLanguage);
 
+	_ftprintf(h, _T("\n// The reference to determine which ui color mode is to be used 1 - Light Mode and 2 - Dark Mode\n"));
+	VAR(nUiColorTheme);
+	
 	_ftprintf(h, _T("\n// If non-zero, display drivers icons.\n"));
 	VAR(bEnableIcons);
 

--- a/src/burner/win32/menu.cpp
+++ b/src/burner/win32/menu.cpp
@@ -1,6 +1,7 @@
 // Menu handling
 
 #include "burner.h"
+#define TBCDRF_USECDCOLORS      0x00800000 // adding constant so NM_CUSTOMDRAW doesnt get ignored
 
 #ifdef _MSC_VER
 // #include <winable.h>
@@ -50,6 +51,37 @@ static INT32 GetCurrentMonitorHigh() {
 	if (!GetMonitorInfo(hMonitor, &monitorInfo)) return -1;
 
 	return monitorInfo.rcMonitor.bottom;
+}
+
+void ApplyMenuBackground(HMENU hMenu, HBRUSH hbr)
+{
+    MENUINFO mi = { sizeof(MENUINFO) };
+    mi.fMask   = MIM_BACKGROUND;
+    mi.hbrBack = hbr;
+    SetMenuInfo(hMenu, &mi);
+
+    int count = GetMenuItemCount(hMenu);
+    for (int i = 0; i < count; i++) {
+        MENUITEMINFO mii = { sizeof(MENUITEMINFO) };
+        mii.fMask = MIIM_FTYPE | MIIM_DATA;
+        GetMenuItemInfo(hMenu, i, TRUE, &mii); 
+
+        TCHAR szText[256] = { 0 };
+        MENUITEMINFO miiText = { sizeof(MENUITEMINFO) };
+        miiText.fMask = MIIM_STRING;
+        miiText.dwTypeData = szText;
+        miiText.cch = 256;
+        GetMenuItemInfo(hMenu, i, TRUE, &miiText);
+
+        mii.fType    |= MFT_OWNERDRAW;
+        mii.dwItemData = (ULONG_PTR)_tcsdup(szText); 
+        SetMenuItemInfo(hMenu, i, TRUE, &mii);
+
+        HMENU hSub = GetSubMenu(hMenu, i);
+        if (hSub) {
+            ApplyMenuBackground(hSub, hbr);
+        }
+    }
 }
 
 static LRESULT CALLBACK MenuHook(INT32 nCode, WPARAM wParam, LPARAM lParam)
@@ -205,9 +237,18 @@ void DisplayPopupMenu(int nMenu)
 		RECT clientRect;
 		RECT buttonRect;
 
+		COLORREF color = RGB((uiMenuItemColor >> 16) & 0xFF,     // R
+                      		 (uiMenuItemColor >> 8) & 0xFF,      // G
+                      		  uiMenuItemColor & 0xFF);           // B
+		HBRUSH hbrColor = CreateSolidBrush(color);
+
+		ApplyMenuBackground(hPopupMenu, hbrColor);
+
 		nLastMenu         = nMenu;
 		nRecursions       = 0;
 		nCurrentItemFlags = 0;
+
+		SetClassLongPtr(hMenubar, GCLP_HBRBACKGROUND, (LONG_PTR)CreateSolidBrush(RGB(255, 0, 0)));
 
 		GetWindowRect(hMenubar, &clientRect);
 		SendMessage(hMenubar, TB_GETITEMRECT, nMenu, (LPARAM)&buttonRect);
@@ -279,6 +320,20 @@ int OnNotify(HWND, int, NMHDR* lpnmhdr)		// HWND hwnd, int id, NMHDR* lpnmhdr
 				nLastMenu = ((TBNOTIFY*)lpnmhdr)->iItem - MENU_MENU_0;
 			}
 			return TBDDRET_DEFAULT;
+		}
+
+		//adds a custom draw event to change the text font color in the button bar
+		case NM_CUSTOMDRAW: {
+			LPNMTBCUSTOMDRAW lpnmtbcd = (LPNMTBCUSTOMDRAW)lpnmhdr;
+			switch (lpnmtbcd->nmcd.dwDrawStage) {
+				case CDDS_PREPAINT:
+					return CDRF_NOTIFYITEMDRAW;
+
+				case CDDS_ITEMPREPAINT:
+					lpnmtbcd->clrText = (COLORREF) uiTextFontColor; 
+					return TBCDRF_USECDCOLORS;
+			}
+			return CDRF_DODEFAULT;
 		}
 
 		case TBN_HOTITEMCHANGE: {
@@ -1287,6 +1342,8 @@ void MenuUpdate()
 	CheckMenuItem(hMenu, MENU_ASSEMBLYCORE, bBurnUseASMCPUEmulation ? MF_CHECKED : MF_UNCHECKED);
 #endif
 
+	UpdateUiColorMode(nUiColorTheme);
+
 	var = MENU_ICONS_SIZE_16;
 	switch (nIconsSize) {
 		case ICON_16x16: var = MENU_ICONS_SIZE_16;	break;
@@ -1855,4 +1912,3 @@ void MenuEnableItems()
 		EnableMenuItem(hMenu, MENU_AUD_PLUGIN_2,		 MF_ENABLED  | MF_BYCOMMAND);
 	}
 }
-

--- a/src/burner/win32/placeholder.cpp
+++ b/src/burner/win32/placeholder.cpp
@@ -1,5 +1,12 @@
 #include "burner.h"
 
+UINT uiBackGroundColor = 0xFFFFFF;
+UINT uiMenuItemColor   = 0xf4f4f4;
+UINT uiSelectedMenuItemColor = 0x9fc5e8;
+UINT uiTextFontColor = 0x000000;
+UINT nUiColorTheme = 0;
+
+
 static void MakeOfn()
 {
 	memset(&ofn, 0, sizeof(ofn));
@@ -40,4 +47,31 @@ int SelectPlaceHolder()
 void ResetPlaceHolder()
 {
 	szPlaceHolder[0] = _T('\0');
+}
+
+
+void UpdateUiColorMode(UINT uiColorMode)
+{
+	if(uiColorMode == 0)
+	{
+		ApplyLightMode();
+	}
+	else
+	{
+		ApplyDarkMode();
+	}
+}
+
+void ApplyLightMode()
+{
+	uiBackGroundColor = 0xFFFFFF;
+	uiMenuItemColor   = 0xf4f4f4;
+	uiTextFontColor = 0x000000;
+}
+
+void ApplyDarkMode()
+{
+	uiBackGroundColor = 0x262626;
+	uiMenuItemColor   = 0x1a1a1a;
+	uiTextFontColor   = 0xFFFFFF;
 }

--- a/src/burner/win32/resource.h
+++ b/src/burner/win32/resource.h
@@ -1109,6 +1109,8 @@
 #define GAMESEL_MENU_VIEWEMMA				11902
 #define GAMESEL_MENU_FAVORITE				11903
 #define GAMESEL_MENU_ROMDATA				11904
+#define MENU_DEFAULT_DARK_MODE              11905
+#define MENU_DEFAULT_LIGHT_MODE             11906
 
 // Next default values for new objects
 //

--- a/src/burner/win32/scrn.cpp
+++ b/src/burner/win32/scrn.cpp
@@ -59,6 +59,7 @@ void DisplayPopupMenu(int nMenu);
 // Double-clicking the titlebar, or clicking the Maximize button on titlebar
 // can also be problematic, sometimes creating a window that is too wide.
 
+typedef HRESULT (WINAPI *SetWindowThemeFn)(HWND, LPCWSTR, LPCWSTR);
 static HBITMAP hBezelBitmap = NULL;
 static int nBezelCacheX = 0;
 static int nBezelCacheY = 0;
@@ -604,6 +605,54 @@ static LRESULT CALLBACK ScrnProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lPar
 				bBackFromHibernation = 1;
 			}
 			break;
+		}
+
+		case WM_MEASUREITEM:
+		{
+			LPMEASUREITEMSTRUCT pmis = (LPMEASUREITEMSTRUCT)lParam;
+			if (pmis->CtlType == ODT_MENU) {
+				pmis->itemWidth  = 150; 
+				pmis->itemHeight = 20;  
+			}
+			return TRUE;
+		}
+		
+		// doing a drawItem case to control the shading of the selected item
+		case WM_DRAWITEM:
+		{
+			LPDRAWITEMSTRUCT pdis = (LPDRAWITEMSTRUCT)lParam;
+			if (pdis->CtlType == ODT_MENU) {
+				BOOL bSelected = (pdis->itemState & ODS_SELECTED) != 0;
+				BOOL bChecked  = (pdis->itemState & ODS_CHECKED)  != 0;
+
+				COLORREF clr;
+				if (bSelected)
+					clr = RGB((uiSelectedMenuItemColor >> 16) & 0xFF,   // R
+                      		  (uiSelectedMenuItemColor >> 8) & 0xFF,    // G
+                      		   uiSelectedMenuItemColor & 0xFF);         // B
+				else if (bChecked)
+					clr = RGB((uiSelectedMenuItemColor >> 16) & 0xFF,   // R
+                      		  (uiSelectedMenuItemColor >> 8) & 0xFF,    // G
+                      		   uiSelectedMenuItemColor & 0xFF);         // B
+				else
+					clr = RGB((uiMenuItemColor >> 16) & 0xFF,   // R
+                      		  (uiMenuItemColor >> 8) & 0xFF,    // G
+                      		   uiMenuItemColor & 0xFF);         // B
+
+				HBRUSH hbr = CreateSolidBrush(clr);
+				FillRect(pdis->hDC, &pdis->rcItem, hbr);
+				DeleteObject(hbr);
+
+				SetBkMode(pdis->hDC, TRANSPARENT);
+				SetTextColor(pdis->hDC, (COLORREF) uiTextFontColor);          
+
+				TCHAR* pszText = (TCHAR*)pdis->itemData;
+				if (pszText) {
+					DrawText(pdis->hDC, pszText, -1, &pdis->rcItem,
+							DT_SINGLELINE | DT_VCENTER | DT_LEFT);
+				}
+			}
+			return TRUE;
 		}
 		// - dink - end
 		HANDLE_MSG(hWnd, WM_SIZE,			OnSize);
@@ -2778,6 +2827,18 @@ static void OnCommand(HWND /*hDlg*/, int id, HWND /*hwndCtl*/, UINT codeNotify)
 			ResetPlaceHolder();
 			POST_INITIALISE_MESSAGE;
 			break;
+		
+		case MENU_DEFAULT_LIGHT_MODE:
+ 			nUiColorTheme = 0;
+			UpdateUiColorMode(nUiColorTheme);
+			POST_INITIALISE_MESSAGE;
+			break;
+
+		case MENU_DEFAULT_DARK_MODE:
+			nUiColorTheme = 1;
+			UpdateUiColorMode(nUiColorTheme);
+			POST_INITIALISE_MESSAGE;
+			break;	
 
 		case MENU_LANGUAGE_SELECT:
 			if (UseDialogs()) {
@@ -4304,6 +4365,7 @@ int ScrnTitle()
 // Init the screen window (create it)
 int ScrnInit()
 {
+
 	REBARINFO rebarInfo;
 	REBARBANDINFO rebarBandInfo;
 	RECT rect;
@@ -4333,6 +4395,7 @@ int ScrnInit()
 		0, 0, 0, 0,									   			// size of window
 		NULL, NULL, hAppInst, NULL);
 
+
 	if (hScrnWnd == NULL) {
 		ScrnExit();
 		return 1;
@@ -4353,22 +4416,36 @@ int ScrnInit()
 				0, 0, 0, 0,
 				hScrnWnd, NULL, hAppInst, NULL);
 
+			HMODULE hUxTheme = LoadLibrary(L"uxtheme.dll");
+			if (hUxTheme) {
+				SetWindowThemeFn pSetWindowTheme = 
+					(SetWindowThemeFn)GetProcAddress(hUxTheme, "SetWindowTheme");
+				if (pSetWindowTheme) {
+					pSetWindowTheme(hRebar, L"", L"");
+				}
+				FreeLibrary(hUxTheme);
+			}
+
+
 			rebarInfo.cbSize = sizeof(REBARINFO);
 			rebarInfo.fMask = 0;
 			rebarInfo.himl = NULL;
 
 			SendMessage(hRebar, RB_SETBARINFO, 0, (LPARAM)&rebarInfo);
 
-			// Add the menu toolbar to the rebar
+			//SendMessage(hRebar, RB_SETBKCOLOR, 0, (LPARAM)RGB(0, 255, 0));
+
+			//Add the menu toolbar to the rebar
 			GetWindowRect(hMenubar, &rect);
 
 			rebarBandInfo.cbSize		= sizeof(REBARBANDINFO);
-			rebarBandInfo.fMask			= RBBIM_CHILD | RBBIM_CHILDSIZE | RBBIM_SIZE | RBBIM_STYLE;// | RBBIM_BACKGROUND;
+			rebarBandInfo.fMask			= RBBIM_CHILD | RBBIM_CHILDSIZE | RBBIM_SIZE | RBBIM_STYLE | RBBIM_COLORS;// | RBBIM_BACKGROUND;
 			rebarBandInfo.fStyle		= 0;//RBBS_GRIPPERALWAYS;// | RBBS_FIXEDBMP;
 			rebarBandInfo.hwndChild		= hMenubar;
 			rebarBandInfo.cxMinChild	= 100;
 			rebarBandInfo.cyMinChild	= ((SendMessage(hMenubar, TB_GETBUTTONSIZE, 0, 0)) >> 16) + 1;
 			rebarBandInfo.cx			= rect.right - rect.left;
+    		rebarBandInfo.clrBack    = uiBackGroundColor;
 
 			SendMessage(hRebar, RB_INSERTBAND, (WPARAM)-1, (LPARAM)&rebarBandInfo);
 


### PR DESCRIPTION
i while ago i saw an issue was opened where someone was requesting a dark mode, i decided to give it a shot. maybe it  could be cool to figure out a way to change the main fbneo image so it goes from a dark gray to a black fade also it would still be necessary to track other windows not children of hScrnWnd and change their colors 

dark mode

<img width="1208" height="948" alt="image" src="https://github.com/user-attachments/assets/c9513c20-624b-4131-a8c8-041128a32f3f" />

light mode

<img width="1199" height="952" alt="image" src="https://github.com/user-attachments/assets/d5f04c0c-7a1e-4b08-85aa-762f5f9b964c" />

